### PR TITLE
Adopt main-based branching workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Unit Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ FishE supports multiple save files, allowing you to maintain different game prog
 - **Quick Load**: Load any existing save file to continue your adventure
 
 Each save file is stored in its own slot (slot_1, slot_2, etc.) in the `data/` directory, ensuring your saves never conflict with each other.
+
+## Contributing
+
+This project uses a simple, trunk-based branching model:
+
+- `main` is the single long-lived branch and the source of truth.
+- Branch off `main` for any change (e.g. `feature/...`, `fix/...`, `chore/...`).
+- Open a pull request back into `main`. CI runs the test suite on every PR.
+- Once CI is green and the change is reviewed, merge into `main` and delete the feature branch.
+
+There is no `develop` branch — work flows directly off of and back into `main`.


### PR DESCRIPTION
Switches the repository to a trunk-based branching model: branch off `main`, PR back into `main`. The `develop` branch is being retired (it has already been fast-forward merged into `main`, so no work is lost).

## Changes
- **CI** (`.github/workflows/test.yml`): trigger on push/PR to `main` only (was `main` + `develop`).
- **README**: document the branching convention under a new *Contributing* section.

## Follow-up
- The `develop` branch will be deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_