### PR TITLE
Fix install.sh to clone from Stephenson-Software

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@ mkdir /usr/games
 
 apt-get update
 apt-get install git
-cd /usr/games && git clone https://www.github.com/Preponderous-Software/FishE
+cd /usr/games && git clone https://github.com/Stephenson-Software/FishE
 
 echo "cd /usr/games/FishE && ./run.sh" > /bin/fishe
 chmod +x /usr/games/FishE/run.sh


### PR DESCRIPTION
## Summary
- `install.sh:5` cloned from the project's former owner `Preponderous-Software`; updated to the current home `https://github.com/Stephenson-Software/FishE` (and dropped the `www.` host prefix).

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 145 passed
- N/A for automated regression: `install.sh` is a shell installer with no pytest surface; verified by inspection that the new URL is the canonical repo.

Closes #56

### Triage skip notes (issues not picked this cycle)
- #57, #58, #59, #60 — scheduled for subsequent cycles in this run.
- #42 (pygame input) — too large for a single coherent cycle.
- #20 (shop money recharge) — blocked: the shop has no money attribute/feature in the live game (see #58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_