### PR TITLE
Load save fields with defaults so incomplete saves don't crash

### DIFF
--- a/src/player/playerJsonReaderWriter.py
+++ b/src/player/playerJsonReaderWriter.py
@@ -14,15 +14,16 @@ class PlayerJsonReaderWriter:
         }
 
     def createPlayerFromJson(self, playerJson):
+        # Read each field with a fallback to the freshly-constructed Player's
+        # default, so a save file missing any field loads gracefully instead of
+        # raising KeyError (backwards compatibility for older/partial saves).
         player = Player()
-        player.fishCount = playerJson["fishCount"]
-        player.fishMultiplier = playerJson["fishMultiplier"]
-        player.money = playerJson["money"]
-        player.moneyInBank = playerJson["moneyInBank"]
-        player.priceForBait = playerJson["priceForBait"]
-        player.energy = playerJson.get(
-            "energy", 100
-        )  # Default to 100 for backwards compatibility
+        player.fishCount = playerJson.get("fishCount", player.fishCount)
+        player.fishMultiplier = playerJson.get("fishMultiplier", player.fishMultiplier)
+        player.money = playerJson.get("money", player.money)
+        player.moneyInBank = playerJson.get("moneyInBank", player.moneyInBank)
+        player.priceForBait = playerJson.get("priceForBait", player.priceForBait)
+        player.energy = playerJson.get("energy", player.energy)
         return player
 
     def writePlayerToFile(self, player, jsonFile):

--- a/src/stats/statsJsonReaderWriter.py
+++ b/src/stats/statsJsonReaderWriter.py
@@ -15,15 +15,27 @@ class StatsJsonReaderWriter:
         }
 
     def createStatsFromJson(self, statsJson):
+        # Read each field with a fallback to the freshly-constructed Stats'
+        # default, so a save file missing any field loads gracefully instead of
+        # raising KeyError (backwards compatibility for older/partial saves).
         stats = Stats()
-        stats.totalFishCaught = statsJson["totalFishCaught"]
-        stats.totalMoneyMade = statsJson["totalMoneyMade"]
-        stats.hoursSpentFishing = statsJson["hoursSpentFishing"]
-        stats.moneyMadeFromInterest = statsJson["moneyMadeFromInterest"]
-        stats.timesGottenDrunk = statsJson["timesGottenDrunk"]
-        stats.moneyLostFromGambling = statsJson["moneyLostFromGambling"]
-        # Handle backward compatibility for existing save files
-        stats.moneyLostWhileDrunk = statsJson.get("moneyLostWhileDrunk", 0)
+        stats.totalFishCaught = statsJson.get("totalFishCaught", stats.totalFishCaught)
+        stats.totalMoneyMade = statsJson.get("totalMoneyMade", stats.totalMoneyMade)
+        stats.hoursSpentFishing = statsJson.get(
+            "hoursSpentFishing", stats.hoursSpentFishing
+        )
+        stats.moneyMadeFromInterest = statsJson.get(
+            "moneyMadeFromInterest", stats.moneyMadeFromInterest
+        )
+        stats.timesGottenDrunk = statsJson.get(
+            "timesGottenDrunk", stats.timesGottenDrunk
+        )
+        stats.moneyLostFromGambling = statsJson.get(
+            "moneyLostFromGambling", stats.moneyLostFromGambling
+        )
+        stats.moneyLostWhileDrunk = statsJson.get(
+            "moneyLostWhileDrunk", stats.moneyLostWhileDrunk
+        )
         return stats
 
     def readStatsFromFile(self, statsJsonFile):

--- a/src/world/timeServiceJsonReaderWriter.py
+++ b/src/world/timeServiceJsonReaderWriter.py
@@ -7,9 +7,12 @@ class TimeServiceJsonReaderWriter:
         return {"time": timeService.time, "day": timeService.day}
 
     def createTimeServiceFromJson(self, timeServiceJson, player, stats):
+        # Read each field with a fallback to the freshly-constructed
+        # TimeService's default, so a save file missing any field loads
+        # gracefully instead of raising KeyError (backwards compatibility).
         timeService = TimeService(player, stats)
-        timeService.time = timeServiceJson["time"]
-        timeService.day = timeServiceJson["day"]
+        timeService.time = timeServiceJson.get("time", timeService.time)
+        timeService.day = timeServiceJson.get("day", timeService.day)
         return timeService
 
     def writeTimeServiceToFile(self, timeService, jsonFile):

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -138,3 +138,21 @@ def test_readPlayerFromFile():
     import os
 
     os.remove(temp_file_path)
+
+
+def test_createPlayerFromJson_missingAllFields_usesDefaults():
+    # prepare - a corrupt/partial save with no recognizable fields
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    playerJson = {}
+
+    # call - must not raise KeyError
+    player = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check - every field falls back to the Player() default
+    defaults = Player()
+    assert player.fishCount == defaults.fishCount
+    assert player.fishMultiplier == defaults.fishMultiplier
+    assert player.money == defaults.money
+    assert player.moneyInBank == defaults.moneyInBank
+    assert player.priceForBait == defaults.priceForBait
+    assert player.energy == defaults.energy

--- a/tests/stats/test_statsJsonReaderWriter.py
+++ b/tests/stats/test_statsJsonReaderWriter.py
@@ -125,3 +125,22 @@ def test_readStatsFromFile():
     import os
 
     os.remove(temp_file_path)
+
+
+def test_createStatsFromJson_missingAllFields_usesDefaults():
+    # prepare - a corrupt/partial save with no recognizable fields
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    statsJson = {}
+
+    # call - must not raise KeyError
+    stats = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check - every field falls back to the Stats() default
+    defaults = Stats()
+    assert stats.totalFishCaught == defaults.totalFishCaught
+    assert stats.totalMoneyMade == defaults.totalMoneyMade
+    assert stats.hoursSpentFishing == defaults.hoursSpentFishing
+    assert stats.moneyMadeFromInterest == defaults.moneyMadeFromInterest
+    assert stats.timesGottenDrunk == defaults.timesGottenDrunk
+    assert stats.moneyLostFromGambling == defaults.moneyLostFromGambling
+    assert stats.moneyLostWhileDrunk == defaults.moneyLostWhileDrunk

--- a/tests/world/test_timeServiceJsonReaderWriter.py
+++ b/tests/world/test_timeServiceJsonReaderWriter.py
@@ -111,3 +111,21 @@ def test_readTimeServiceFromFile():
     import os
 
     os.remove(temp_file_path)
+
+
+def test_createTimeServiceFromJson_missingAllFields_usesDefaults():
+    # prepare - a corrupt/partial save with no recognizable fields
+    timeServiceJsonReaderWriter = createTimeServiceJsonReaderWriter()
+    player = Player()
+    stats = Stats()
+    timeServiceJson = {}
+
+    # call - must not raise KeyError
+    timeService = timeServiceJsonReaderWriter.createTimeServiceFromJson(
+        timeServiceJson, player, stats
+    )
+
+    # check - both fields fall back to the TimeService() default
+    defaults = TimeService(player, stats)
+    assert timeService.time == defaults.time
+    assert timeService.day == defaults.day


### PR DESCRIPTION
## Summary
- `createPlayerFromJson`, `createStatsFromJson`, and `createTimeServiceFromJson` now read every persisted field with `dict.get(key, <default>)`, where the default is the value the freshly-constructed model already holds. A save missing any field loads gracefully instead of raising an uncaught `KeyError`.
- This generalizes the backward-compat pattern that previously covered only `energy` and `moneyLostWhileDrunk`, so the fallback default can never drift from the model default.
- No schema changes; persisted shape is unchanged. Older/partial saves now load.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 148 passed (3 new)
- [x] New regression tests: each reader/writer loads `{}` and asserts all fields equal the model defaults (would `KeyError` before this change).

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_