### PR TITLE
Add save/load round-trip coverage for FishE

### DIFF
--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -1,5 +1,15 @@
+import json
+import os
+import tempfile
 from unittest.mock import MagicMock, patch
 from src import fishE
+from src.player.player import Player
+from src.stats.stats import Stats
+from src.world.timeService import TimeService
+from src.player.playerJsonReaderWriter import PlayerJsonReaderWriter
+from src.stats.statsJsonReaderWriter import StatsJsonReaderWriter
+from src.world.timeServiceJsonReaderWriter import TimeServiceJsonReaderWriter
+from src.saveFileManager import SaveFileManager
 
 
 def createFishE():
@@ -63,3 +73,87 @@ def test_initialization():
     fishE.TimeServiceJsonReaderWriter.assert_called_once()
     fishE.StatsJsonReaderWriter.assert_called_once()
     fishE.SaveFileManager.assert_called_once()
+
+
+def createGameForPersistence(data_directory):
+    # Build a FishE without running __init__ (which drives stdin); attach real
+    # collaborators and a temp-dir-backed save manager so save()/load*() exercise
+    # real serialization against a real (temporary) save slot.
+    game = fishE.FishE.__new__(fishE.FishE)
+    game.playerJsonReaderWriter = PlayerJsonReaderWriter()
+    game.statsJsonReaderWriter = StatsJsonReaderWriter()
+    game.timeServiceJsonReaderWriter = TimeServiceJsonReaderWriter()
+    saveFileManager = SaveFileManager(data_directory=data_directory)
+    saveFileManager.select_save_slot(1)
+    game.saveFileManager = saveFileManager
+    return game
+
+
+def test_save_then_load_roundtrip():
+    # restore real classes in case an earlier test mocked the module globals
+    fishE.Player = Player
+    fishE.Stats = Stats
+    fishE.TimeService = TimeService
+
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - a game holding non-default state
+        game = createGameForPersistence(data_directory)
+        game.player = Player()
+        game.player.fishCount = 42
+        game.player.money = 123
+        game.stats = Stats()
+        game.stats.totalFishCaught = 7
+        game.timeService = TimeService(game.player, game.stats)
+        game.timeService.day = 9
+        game.timeService.time = 15
+
+        # call - persist, then load into a fresh game on the same slot
+        game.save()
+        loaded = createGameForPersistence(data_directory)
+        loaded.loadPlayer()
+        loaded.loadStats()
+        loaded.loadTimeService()
+
+        # check - state round-trips through disk
+        assert loaded.player.fishCount == 42
+        assert loaded.player.money == 123
+        assert loaded.stats.totalFishCaught == 7
+        assert loaded.timeService.day == 9
+        assert loaded.timeService.time == 15
+
+
+def test_save_writes_all_three_files():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare
+        game = createGameForPersistence(data_directory)
+        game.player = Player()
+        game.stats = Stats()
+        game.timeService = TimeService(game.player, game.stats)
+
+        # call
+        game.save()
+
+        # check - all three save files are written into the selected slot
+        slot = os.path.join(data_directory, "slot_1")
+        assert os.path.exists(os.path.join(slot, "player.json"))
+        assert os.path.exists(os.path.join(slot, "stats.json"))
+        assert os.path.exists(os.path.join(slot, "timeService.json"))
+
+
+def test_loadPlayer_recovers_from_corrupt_file():
+    # restore the real Player so the except-path fallback builds a real player
+    fishE.Player = Player
+
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - a player save file containing invalid JSON
+        game = createGameForPersistence(data_directory)
+        path = game.saveFileManager.get_save_path("player.json")
+        with open(path, "w") as f:
+            f.write("{ not valid json")
+
+        # call - must not raise; falls back to a fresh player
+        game.loadPlayer()
+
+        # check
+        assert isinstance(game.player, Player)
+        assert game.player.fishCount == Player().fishCount


### PR DESCRIPTION
## Summary
`fishE.py`'s persistence methods previously had no behavior coverage (only `test_initialization`). This adds:
- `test_save_then_load_roundtrip` — non-default player/stats/timeService state is saved and read back identically through a temporary save slot.
- `test_save_writes_all_three_files` — `save()` writes `player.json`, `stats.json`, `timeService.json` into the selected slot.
- `test_loadPlayer_recovers_from_corrupt_file` — invalid-JSON save falls back to a fresh `Player` without raising.

These are characterization tests (assert current behavior); no production code changed. They build `FishE` via `__new__` with real reader/writers and a `tempfile` `SaveFileManager`, bypassing the stdin-driven `__init__`.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 151 passed (3 new)
- [x] `tests/test_fishE.py` passes in isolation (order-independent)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_