### PR TITLE
Balance bank interest so it can't bypass the core loop

### DIFF
--- a/src/world/timeService.py
+++ b/src/world/timeService.py
@@ -1,6 +1,14 @@
 import math
 
 
+# Daily bank interest is deliberately modest and capped so that saving is a
+# minor convenience rather than a way to bypass fishing entirely: sleeping is
+# free and unlimited, so any large/uncapped compounding rate lets the player
+# ignore the core loop and grow money exponentially by repeatedly sleeping.
+INTEREST_RATE = 0.02
+MAX_INTEREST_PER_DAY = 50
+
+
 # @author Daniel McCoy Stephenson
 class TimeService:
     def __init__(self, player, stats):
@@ -23,7 +31,8 @@ class TimeService:
         self.time = 8
         self.day += 1
 
-        moneyToAdd = int(math.ceil(self.player.moneyInBank * 0.10))
+        moneyToAdd = int(math.ceil(self.player.moneyInBank * INTEREST_RATE))
+        moneyToAdd = min(moneyToAdd, MAX_INTEREST_PER_DAY)
         self.player.moneyInBank += moneyToAdd
         self.stats.moneyMadeFromInterest += moneyToAdd
         self.stats.totalMoneyMade += moneyToAdd

--- a/tests/world/test_timeService.py
+++ b/tests/world/test_timeService.py
@@ -59,11 +59,29 @@ def test_increaseDay():
     # call
     timeService.increaseDay()
 
-    # check
+    # check - interest is 2% of 100 = 2 (well under the per-day cap)
     expected_day = 2
     expected_time = 8
     assert timeService.day == expected_day
     assert timeService.time == expected_time
-    assert timeService.player.moneyInBank == 110
-    assert timeService.stats.moneyMadeFromInterest == 10
-    assert timeService.stats.totalMoneyMade == 110
+    assert timeService.player.moneyInBank == 102
+    assert timeService.stats.moneyMadeFromInterest == 2
+    assert timeService.stats.totalMoneyMade == 102
+
+
+def test_increaseDay_interest_is_capped():
+    # prepare - a large balance whose 2% would exceed the per-day cap
+    from src.world.timeService import MAX_INTEREST_PER_DAY
+
+    timeService = createTimeService()
+    timeService.player.moneyInBank = 1000000
+    timeService.stats.moneyMadeFromInterest = 0
+    timeService.stats.totalMoneyMade = 0
+
+    # call
+    timeService.increaseDay()
+
+    # check - interest is clamped to the cap, not 2% of the balance
+    assert timeService.stats.moneyMadeFromInterest == MAX_INTEREST_PER_DAY
+    assert timeService.player.moneyInBank == 1000000 + MAX_INTEREST_PER_DAY
+    assert timeService.stats.totalMoneyMade == MAX_INTEREST_PER_DAY


### PR DESCRIPTION
## Summary
- `src/world/timeService.py`: daily interest reduced from 10% to 2% and capped at a per-day maximum (new `INTEREST_RATE` / `MAX_INTEREST_PER_DAY` constants). Previously interest was uncapped and compounding, and since sleeping is free/unlimited the optimal play was to bank everything and spam Sleep for exponential money — bypassing fishing entirely.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 147 passed
- [x] Updated `test_increaseDay` for the 2% rate; added `test_increaseDay_interest_is_capped` (large balance clamps to the cap — would fail under the old uncapped 10%).

Closes #66

### Triage skip notes
- #67/#68 (balance), #69–#75 (features/QoL): scheduled for later cycles this run.
- #42 (pygame input): too large for one cycle. #20 (shop money recharge): needs a shop-money feature that does not yet exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_