### PR TITLE
Cap fishMultiplier so bait upgrades aren't an infinite power climb

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -5,7 +5,6 @@ You are a fisherman living in a home by the docks. There’s a store nearby that
 GOALS
 - Make it possible to open a fishing business
 - Make hiring workers a thing
-- make a limit on fishMultiplier
 - FISH LOADING BAIT PRICE BUG
 
 Maybes

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -8,6 +8,11 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 
 
+# Upper bound on fishMultiplier so bait upgrades stop being an infinite power
+# climb: past this point "Buy Better Bait" is refused with a message.
+MAX_FISH_MULTIPLIER = 10
+
+
 # @author Daniel McCoy Stephenson
 class Shop:
     def __init__(
@@ -102,7 +107,9 @@ class Shop:
         self.currentPrompt.text = "You sold all of your fish!"
 
     def buyBetterBait(self):
-        if self.player.money < self.player.priceForBait:
+        if self.player.fishMultiplier >= MAX_FISH_MULTIPLIER:
+            self.currentPrompt.text = "Your bait is already the best money can buy!"
+        elif self.player.money < self.player.priceForBait:
             self.currentPrompt.text = "You don't have enough money!"
         else:
             self.player.fishMultiplier += 1

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -127,3 +127,22 @@ def test_buyBetterBait():
     assert shopInstance.player.money == 50
     assert shopInstance.player.fishMultiplier == 2
     assert shopInstance.player.priceForBait > 0
+
+
+def test_buyBetterBait_refused_at_cap():
+    # prepare - multiplier already at the cap, with plenty of money
+    from src.location.shop import MAX_FISH_MULTIPLIER
+
+    shopInstance = createShop()
+    shopInstance.player.money = 10000
+    shopInstance.player.fishMultiplier = MAX_FISH_MULTIPLIER
+    priceBefore = shopInstance.player.priceForBait
+
+    # call
+    shopInstance.buyBetterBait()
+
+    # check - no purchase: multiplier, money, and price are unchanged
+    assert shopInstance.player.fishMultiplier == MAX_FISH_MULTIPLIER
+    assert shopInstance.player.money == 10000
+    assert shopInstance.player.priceForBait == priceBefore
+    assert shopInstance.currentPrompt.text == "Your bait is already the best money can buy!"


### PR DESCRIPTION
## Summary
- `src/location/shop.py`: `buyBetterBait()` now refuses to upgrade once `fishMultiplier` reaches `MAX_FISH_MULTIPLIER` (10), with the message "Your bait is already the best money can buy!" and no change to money or bait price. Implements the `PLANNING.md` goal "make a limit on fishMultiplier".

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — all passing
- [x] Added `test_buyBetterBait_refused_at_cap` (at cap: multiplier/money/price unchanged); existing `test_buyBetterBait` still covers the normal purchase.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_