### PR TITLE
Make tavern gambling and drinking real risk/reward choices

### DIFF
--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -12,6 +12,18 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 
 
+# Dice has 6 equally likely faces, so a correct guess pays 5x the bet to make
+# the wager roughly fair (EV ~= 0) instead of the old even-money payout, which
+# made gambling a guaranteed long-run loss no rational player would take.
+DICE_WIN_MULTIPLIER = 5
+
+# Chances applied while drunk, in order: lose a chunk of money, or instead pick
+# up a lucrative rumor. Giving drinking an upside (not just a downside) makes it
+# a real risk/reward choice rather than a pure money sink.
+DRUNK_LOSS_CHANCE = 0.3
+DRUNK_TIP_CHANCE = 0.3
+
+
 # @author Daniel McCoy Stephenson
 class Tavern:
     def __init__(
@@ -115,8 +127,10 @@ class Tavern:
 
         self.stats.timesGottenDrunk += 1
 
-        # Random chance of losing additional money while drunk
-        if random.random() < 0.3:  # 30% chance
+        # A night of drinking is a gamble: you might lose money in a drunken
+        # stupor, or you might overhear a lucrative rumor and come out ahead.
+        roll = random.random()
+        if roll < DRUNK_LOSS_CHANCE:
             if self.player.money > 0:
                 # Lose between 10% and 50% of remaining money
                 loss_percentage = random.uniform(0.1, 0.5)
@@ -129,6 +143,14 @@ class Tavern:
                     self.currentPrompt.text = "You have a headache."
             else:
                 self.currentPrompt.text = "You have a headache."
+        elif roll < DRUNK_LOSS_CHANCE + DRUNK_TIP_CHANCE:
+            # Pick up a profitable rumor at the bar.
+            tip = random.randint(15, 30)
+            self.player.money += tip
+            self.stats.totalMoneyMade += tip
+            self.currentPrompt.text = (
+                f"You have a headache, but a regular tipped you off to a hot catch — you earned ${tip}!"
+            )
         else:
             self.currentPrompt.text = "You have a headache."
 
@@ -139,7 +161,9 @@ class Tavern:
             li = ["1", "2", "3", "4", "5", "6", "Change Bet", "Back"]
             input = int(
                 self.userInterface.showOptions(
-                    "Once you place your bet, the burly man in front of you will throw the dice.",
+                    "Once you place your bet, the burly man in front of you will throw the dice. "
+                    "Guess the number right and he pays out %dx your bet."
+                    % DICE_WIN_MULTIPLIER,
                     li,
                 )
             )
@@ -148,9 +172,9 @@ class Tavern:
                 self.diceThrow = random.randint(1, 6)
 
                 if input == self.diceThrow:
-                    winAmount = self.currentBet
-                    self.player.money += self.currentBet
-                    self.stats.totalMoneyMade += self.currentBet
+                    winAmount = self.currentBet * DICE_WIN_MULTIPLIER
+                    self.player.money += winAmount
+                    self.stats.totalMoneyMade += winAmount
                     self.currentBet = 0
                     self.currentPrompt.text = (
                         "The dice rolled a %d! You won $%d! Care to try again? Current Bet: $%d"

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -329,3 +329,48 @@ def test_getDrunk_updates_stats():
     assert tavernInstance.player.money == 10  # Lost $10
     assert tavernInstance.stats.timesGottenDrunk == 1
     assert tavernInstance.currentPrompt.text == "You have a headache."
+
+
+def test_getDrunk_can_earn_a_tip():
+    # prepare
+    tavernInstance = createTavern()
+    tavernInstance.userInterface.lotsOfSpace = MagicMock()
+    tavernInstance.userInterface.divider = MagicMock()
+    tavernInstance.player.money = 20
+    tavernInstance.stats.totalMoneyMade = 0
+    tavern.print = MagicMock()
+    tavern.sys.stdout.flush = MagicMock()
+    tavern.time.sleep = MagicMock()
+    tavernInstance.timeService.increaseDay = MagicMock()
+
+    # call - land in the "tip" outcome (>= loss chance, < loss + tip) and fix
+    # the tip amount deterministically.
+    with patch("src.location.tavern.random.random", return_value=0.5), patch(
+        "src.location.tavern.random.randint", return_value=25
+    ):
+        tavernInstance.getDrunk()
+
+    # check - $10 drink cost, then +$25 tip => net +$15, and it counts as earnings
+    assert tavernInstance.player.money == 35
+    assert tavernInstance.stats.totalMoneyMade == 25
+    assert "earned $25" in tavernInstance.currentPrompt.text
+
+
+def test_gamble_win_pays_multiple_of_bet():
+    # prepare - drive the real gamble() loop: guess 3, dice rolls 3, then go back
+    from src.location.tavern import DICE_WIN_MULTIPLIER
+
+    tavernInstance = createTavern()
+    tavernInstance.player.money = 100
+    tavernInstance.currentBet = 50
+    tavernInstance.userInterface.showOptions = MagicMock(side_effect=["3", "8"])
+
+    # call
+    with patch("src.location.tavern.random.randint", return_value=3):
+        tavernInstance.gamble()
+
+    # check - a correct guess pays DICE_WIN_MULTIPLIER x the bet (not even money)
+    expectedWin = 50 * DICE_WIN_MULTIPLIER
+    assert tavernInstance.player.money == 100 + expectedWin
+    assert tavernInstance.stats.totalMoneyMade == expectedWin
+    assert tavernInstance.currentBet == 0


### PR DESCRIPTION
## Summary
- **Dice gambling** (`src/location/tavern.py`): a correct guess now pays `DICE_WIN_MULTIPLIER` (5×) the bet instead of even money. With six equally likely faces this makes the wager roughly fair (EV ≈ 0) rather than a guaranteed long-run loss. The payout multiplier is shown in the betting prompt.
- **Getting drunk**: now has an upside as well as the existing downside — a ~30% chance to lose money *and* a ~30% chance to overhear a lucrative rumor and earn a cash tip (constants `DRUNK_LOSS_CHANCE` / `DRUNK_TIP_CHANCE`), so the $10 + lost day buys a real gamble instead of being pure loss.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — all passing
- [x] Added `test_gamble_win_pays_multiple_of_bet` (drives the real `gamble()` loop; asserts 5× payout — would fail under the old even-money logic) and `test_getDrunk_can_earn_a_tip` (tip outcome adds money). Existing `getDrunk` tests still pass (they pin `random.random` to the no-event branch).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_