### PR TITLE
Show the current location in the status header

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -8,6 +8,5 @@ GOALS
 - FISH LOADING BAIT PRICE BUG
 
 Maybes
-- Maybe include something that tells you where you are
 - Maybe make the fishMultiplier a chance thing
 - Aesthetic upgrades?

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -192,6 +192,9 @@ class FishE:
 
     def play(self):
         while self.running:
+            # show the current location in the UI header
+            self.userInterface.currentLocationName = self.currentLocation.capitalize()
+
             # change location
             nextLocation = self.locations[self.currentLocation].run()
 

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -12,6 +12,9 @@ class UserInterface:
 
         self.prompt = "Make your choice!"
         self.optionList = []
+        # Display name of the player's current location, shown in the header.
+        # Set by the game loop before each render; empty hides the line.
+        self.currentLocationName = ""
 
         self.times = {
             0: "12:00 AM",
@@ -59,6 +62,8 @@ class UserInterface:
             print(" " + descriptor)
             self.divider()
             print(" Day %d" % self.timeService.day)
+            if self.currentLocationName:
+                print(" | Location: " + self.currentLocationName)
             print(" | " + self.times[self.timeService.time])
             print(" | Money: $%.2f" % self.player.money)
             print(" | Fish: %d" % self.player.fishCount)

--- a/tests/ui/test_userInterface.py
+++ b/tests/ui/test_userInterface.py
@@ -69,6 +69,39 @@ def test_showOptions():
     userInterface.input.assert_called_with("\n> ")
 
 
+def test_showOptions_includes_location_when_set():
+    # setup
+    userInterfaceInstance = createUserInterface()
+    userInterfaceInstance.currentLocationName = "Docks"
+    userInterface.print = MagicMock()
+    userInterface.input = MagicMock(return_value="1")
+    userInterfaceInstance.lotsOfSpace = MagicMock()
+    userInterfaceInstance.divider = MagicMock()
+
+    # call
+    userInterfaceInstance.showOptions("descriptor", ["option1"])
+
+    # check - the header shows the current location
+    printedLines = [call.args[0] for call in userInterface.print.call_args_list]
+    assert " | Location: Docks" in printedLines
+
+
+def test_showOptions_omits_location_when_unset():
+    # setup
+    userInterfaceInstance = createUserInterface()  # currentLocationName defaults to ""
+    userInterface.print = MagicMock()
+    userInterface.input = MagicMock(return_value="1")
+    userInterfaceInstance.lotsOfSpace = MagicMock()
+    userInterfaceInstance.divider = MagicMock()
+
+    # call
+    userInterfaceInstance.showOptions("descriptor", ["option1"])
+
+    # check - no Location line is printed when none is set
+    printedLines = [call.args[0] for call in userInterface.print.call_args_list]
+    assert not any(line.startswith(" | Location:") for line in printedLines)
+
+
 def test_showDialogue():
     # setup
     userInterfaceInstance = createUserInterface()


### PR DESCRIPTION
## Summary
- `src/ui/userInterface.py`: added a `currentLocationName` field (default `""`) and a `Location: <name>` header line, rendered only when set.
- `src/fishE.py`: the game loop sets `userInterface.currentLocationName` from the current `LocationType` (`.capitalize()`) before each render.
- `PLANNING.md`: removed the now-implemented "tells you where you are" idea.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 152 passed
- [x] Added `test_showOptions_includes_location_when_set` and `test_showOptions_omits_location_when_unset`; existing `test_showOptions` (empty location) still asserts 9 prints.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_