### PR TITLE
Make time of day affect fishing yield

### DIFF
--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -112,6 +112,19 @@ class Docks:
             )
             return LocationType.BANK
 
+    def getTimeOfDayModifier(self, hour):
+        """Return (yield factor, flavour label) for fishing at the given hour.
+
+        Fish feed most actively around dawn and dusk and go quiet under the
+        midday sun, so the time of day now meaningfully affects the catch."""
+        if 5 <= hour <= 8:
+            return 1.5, "The dawn bite is on!"
+        if 17 <= hour <= 20:
+            return 1.5, "The fish are feeding at dusk!"
+        if 11 <= hour <= 14:
+            return 0.6, "The midday sun keeps the fish deep."
+        return 1.0, ""
+
     def fish(self):
         self.userInterface.lotsOfSpace()
         self.userInterface.divider()
@@ -119,6 +132,9 @@ class Docks:
         print("Fishing... "),
         sys.stdout.flush()
         time.sleep(1)
+
+        # Capture the time of day at the start of the trip (the loop advances it).
+        timeFactor, timeLabel = self.getTimeOfDayModifier(self.timeService.time)
 
         hours = random.randint(1, 10)
 
@@ -168,14 +184,16 @@ class Docks:
         baseFish = random.randint(1, 10)
         if totalAttempts > 0:
             successRate = successfulCatches / totalAttempts
-            fishToAdd = int(baseFish * successRate * self.player.fishMultiplier)
+            fishToAdd = int(
+                baseFish * successRate * self.player.fishMultiplier * timeFactor
+            )
         else:
             fishToAdd = 0
-            
+
         # Ensure at least 1 fish if player attempted
         if fishToAdd == 0 and totalAttempts > 0:
             fishToAdd = 1
-            
+
         self.player.fishCount += fishToAdd
         self.stats.totalFishCaught += fishToAdd
 
@@ -187,6 +205,9 @@ class Docks:
                 hours,
                 int((successfulCatches / totalAttempts * 100) if totalAttempts > 0 else 0)
             )
+
+        if timeLabel:
+            self.currentPrompt.text += " " + timeLabel
 
     def talkToNPC(self):
         self.userInterface.showInteractiveDialogue(self.npc)

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -290,3 +290,53 @@ def test_fish_interactive_failure():
         # check - with 0% success rate, should still get at least 1 fish minimum
         assert docksInstance.player.fishCount == 1  # Minimum 1 fish even with failures
         assert docksInstance.stats.totalFishCaught == 1
+
+
+def test_getTimeOfDayModifier_windows():
+    # prepare
+    docksInstance = createDocks()
+
+    # check - dawn and dusk boost the catch, midday suppresses it, else neutral
+    dawnFactor, dawnLabel = docksInstance.getTimeOfDayModifier(6)
+    duskFactor, duskLabel = docksInstance.getTimeOfDayModifier(18)
+    middayFactor, middayLabel = docksInstance.getTimeOfDayModifier(12)
+    nightFactor, nightLabel = docksInstance.getTimeOfDayModifier(2)
+
+    assert dawnFactor > 1.0 and dawnLabel
+    assert duskFactor > 1.0 and duskLabel
+    assert middayFactor < 1.0 and middayLabel
+    assert nightFactor == 1.0 and nightLabel == ""
+
+
+def test_fish_applies_time_of_day_modifier():
+    # prepare - fish at midday (penalty) vs dawn (bonus) with identical rolls
+    def make_docks_at(hour):
+        d = createDocks()
+        d.userInterface.lotsOfSpace = MagicMock()
+        d.userInterface.divider = MagicMock()
+        d.timeService.time = hour
+        return d
+
+    def time_side_effect():
+        while True:
+            yield 0
+            yield 0.5  # quick reaction => 100% success
+
+    results = {}
+    for label, hour in (("midday", 12), ("dawn", 6)):
+        docksInstance = make_docks_at(hour)
+        with patch("src.location.docks.print"), patch(
+            "src.location.docks.sys.stdout.flush"
+        ), patch("src.location.docks.time.sleep"), patch(
+            "src.location.docks.time.time", side_effect=time_side_effect()
+        ), patch(
+            "src.location.docks.input", return_value=""
+        ), patch(
+            "src.location.docks.random.randint", side_effect=[5, 10]
+        ):  # 5 hours, baseFish 10
+            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.fish()
+        results[label] = docksInstance.player.fishCount
+
+    # check - the midday penalty yields fewer fish than the dawn bonus
+    assert results["midday"] < results["dawn"]


### PR DESCRIPTION
## Summary
- `src/location/docks.py`: new `getTimeOfDayModifier(hour)` returns a yield factor + flavour label; `fish()` captures the start-of-trip hour and multiplies the catch by it. Dawn (5–8) and dusk (17–20) give a 1.5× bonus, midday (11–14) a 0.6× penalty, other hours neutral. A flavour line is appended to the catch prompt.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 154 passed
- [x] Added `test_getTimeOfDayModifier_windows` and `test_fish_applies_time_of_day_modifier` (midday < dawn with identical rolls). Existing `fish()` tests run at the default hour 8 and use `>=`/floored assertions, so they still hold.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_