### PR TITLE
Add a distinct rod upgrade path alongside bait

### DIFF
--- a/schemas/player.json
+++ b/schemas/player.json
@@ -25,6 +25,10 @@
             "type": "integer",
             "minimum": 0,
             "maximum": 100
+        },
+        "rodLevel": {
+            "type": "integer",
+            "minimum": 1
         }
     },
     "required": [

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -11,6 +11,13 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 
 
+# The catch reaction window widens with the player's rod level, so a better rod
+# (bought at the shop) makes the timing minigame more forgiving. Level 1 keeps
+# the original 2.0s window.
+REACTION_BASE_WINDOW = 2.0
+ROD_WINDOW_STEP = 0.5
+
+
 # @author Daniel McCoy Stephenson
 class Docks:
     def __init__(
@@ -149,7 +156,10 @@ class Docks:
 
         successfulCatches = 0
         totalAttempts = 0
-        
+
+        # A better rod widens the timing window, making catches more forgiving.
+        reactionWindow = REACTION_BASE_WINDOW + (self.player.rodLevel - 1) * ROD_WINDOW_STEP
+
         for i in range(hours):
             print("><> ")
             sys.stdout.flush()
@@ -164,8 +174,8 @@ class Docks:
                 input()
                 reactionTime = time.time() - startTime
                 
-                # Success if pressed within 2 seconds
-                if reactionTime <= 2.0:
+                # Success if pressed within the (rod-dependent) reaction window
+                if reactionTime <= reactionWindow:
                     successfulCatches += 1
                     print("Got it! ")
                 else:

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -12,6 +12,17 @@ from npc.npc import NPC
 # climb: past this point "Buy Better Bait" is refused with a message.
 MAX_FISH_MULTIPLIER = 10
 
+# Rod upgrades are a second, distinct progression axis from bait: bait raises
+# yield (fishMultiplier), the rod widens the catch reaction window (see Docks).
+# The cost to reach the next level scales with the current level, so only the
+# level needs to be stored.
+ROD_BASE_PRICE = 75
+MAX_ROD_LEVEL = 10
+
+
+def rodUpgradeCost(rodLevel):
+    return ROD_BASE_PRICE * rodLevel
+
 
 # @author Daniel McCoy Stephenson
 class Shop:
@@ -77,6 +88,7 @@ class Shop:
         li = [
             "Sell Fish",
             "Buy Better Bait ( $%.2f )" % self.player.priceForBait,
+            "Buy Better Rod ( $%.2f )" % rodUpgradeCost(self.player.rodLevel),
             "Talk to %s" % self.npc.name,
             "Go to Docks",
         ]
@@ -92,9 +104,12 @@ class Shop:
             self.buyBetterBait()
             return LocationType.SHOP
         elif input == "3":
-            self.talkToNPC()
+            self.buyBetterRod()
             return LocationType.SHOP
         elif input == "4":
+            self.talkToNPC()
+            return LocationType.SHOP
+        elif input == "5":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
 
@@ -117,6 +132,17 @@ class Shop:
 
             self.player.priceForBait = self.player.priceForBait * 1.25
             self.currentPrompt.text = "You bought some better bait!"
+
+    def buyBetterRod(self):
+        cost = rodUpgradeCost(self.player.rodLevel)
+        if self.player.rodLevel >= MAX_ROD_LEVEL:
+            self.currentPrompt.text = "Your rod is already the finest in the village!"
+        elif self.player.money < cost:
+            self.currentPrompt.text = "You don't have enough money!"
+        else:
+            self.player.rodLevel += 1
+            self.player.money -= cost
+            self.currentPrompt.text = "You bought a better fishing rod!"
 
     def talkToNPC(self):
         self.userInterface.showInteractiveDialogue(self.npc)

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -7,3 +7,4 @@ class Player:
         self.fishMultiplier = 1
         self.priceForBait = 50
         self.energy = 100
+        self.rodLevel = 1

--- a/src/player/playerJsonReaderWriter.py
+++ b/src/player/playerJsonReaderWriter.py
@@ -11,6 +11,7 @@ class PlayerJsonReaderWriter:
             "moneyInBank": player.moneyInBank,
             "priceForBait": player.priceForBait,
             "energy": player.energy,
+            "rodLevel": player.rodLevel,
         }
 
     def createPlayerFromJson(self, playerJson):
@@ -24,6 +25,7 @@ class PlayerJsonReaderWriter:
         player.moneyInBank = playerJson.get("moneyInBank", player.moneyInBank)
         player.priceForBait = playerJson.get("priceForBait", player.priceForBait)
         player.energy = playerJson.get("energy", player.energy)
+        player.rodLevel = playerJson.get("rodLevel", player.rodLevel)
         return player
 
     def writePlayerToFile(self, player, jsonFile):

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -340,3 +340,38 @@ def test_fish_applies_time_of_day_modifier():
 
     # check - the midday penalty yields fewer fish than the dawn bonus
     assert results["midday"] < results["dawn"]
+
+
+def test_fish_higher_rod_widens_reaction_window():
+    # prepare - a 2.5s reaction is "too slow" at rod level 1 (2.0s window) but
+    # within the window at a high rod level, so it should catch more fish.
+    def make_docks_with_rod(rodLevel):
+        d = createDocks()
+        d.userInterface.lotsOfSpace = MagicMock()
+        d.userInterface.divider = MagicMock()
+        d.player.rodLevel = rodLevel
+        return d
+
+    def time_side_effect():
+        while True:
+            yield 0
+            yield 2.5  # reaction of 2.5s
+
+    results = {}
+    for label, rod in (("lowRod", 1), ("highRod", 5)):
+        docksInstance = make_docks_with_rod(rod)
+        with patch("src.location.docks.print"), patch(
+            "src.location.docks.sys.stdout.flush"
+        ), patch("src.location.docks.time.sleep"), patch(
+            "src.location.docks.time.time", side_effect=time_side_effect()
+        ), patch(
+            "src.location.docks.input", return_value=""
+        ), patch(
+            "src.location.docks.random.randint", side_effect=[5, 10]
+        ):
+            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.fish()
+        results[label] = docksInstance.player.fishCount
+
+    # check - the wider window of the better rod lands more catches
+    assert results["highRod"] > results["lowRod"]

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -59,10 +59,24 @@ def test_run_buy_better_bait_action():
     shopInstance.buyBetterBait.assert_called_once()
 
 
+def test_run_buy_better_rod_action():
+    # prepare
+    shopInstance = createShop()
+    shopInstance.userInterface.showOptions = MagicMock(return_value="3")
+    shopInstance.buyBetterRod = MagicMock()
+
+    # call
+    nextLocation = shopInstance.run()
+
+    # check
+    assert nextLocation == LocationType.SHOP
+    shopInstance.buyBetterRod.assert_called_once()
+
+
 def test_run_go_to_docks_action():
     # prepare
     shopInstance = createShop()
-    shopInstance.userInterface.showOptions = MagicMock(return_value="4")
+    shopInstance.userInterface.showOptions = MagicMock(return_value="5")
 
     # call
     nextLocation = shopInstance.run()
@@ -74,7 +88,7 @@ def test_run_go_to_docks_action():
 def test_run_talk_to_npc_action():
     # prepare
     shopInstance = createShop()
-    shopInstance.userInterface.showOptions = MagicMock(return_value="3")
+    shopInstance.userInterface.showOptions = MagicMock(return_value="4")
     shopInstance.talkToNPC = MagicMock()
 
     # call
@@ -146,3 +160,54 @@ def test_buyBetterBait_refused_at_cap():
     assert shopInstance.player.money == 10000
     assert shopInstance.player.priceForBait == priceBefore
     assert shopInstance.currentPrompt.text == "Your bait is already the best money can buy!"
+
+
+def test_buyBetterRod():
+    # prepare
+    from src.location.shop import rodUpgradeCost
+
+    shopInstance = createShop()
+    shopInstance.player.rodLevel = 1
+    cost = rodUpgradeCost(1)
+    shopInstance.player.money = cost + 100
+
+    # call
+    shopInstance.buyBetterRod()
+
+    # check - rod level up and money reduced by the level-scaled cost
+    assert shopInstance.player.rodLevel == 2
+    assert shopInstance.player.money == 100
+    assert shopInstance.currentPrompt.text == "You bought a better fishing rod!"
+
+
+def test_buyBetterRod_refused_when_too_poor():
+    # prepare
+    from src.location.shop import rodUpgradeCost
+
+    shopInstance = createShop()
+    shopInstance.player.rodLevel = 1
+    shopInstance.player.money = rodUpgradeCost(1) - 1
+
+    # call
+    shopInstance.buyBetterRod()
+
+    # check - no change
+    assert shopInstance.player.rodLevel == 1
+    assert shopInstance.currentPrompt.text == "You don't have enough money!"
+
+
+def test_buyBetterRod_refused_at_cap():
+    # prepare
+    from src.location.shop import MAX_ROD_LEVEL
+
+    shopInstance = createShop()
+    shopInstance.player.rodLevel = MAX_ROD_LEVEL
+    shopInstance.player.money = 1000000
+
+    # call
+    shopInstance.buyBetterRod()
+
+    # check - no purchase past the cap
+    assert shopInstance.player.rodLevel == MAX_ROD_LEVEL
+    assert shopInstance.player.money == 1000000
+    assert shopInstance.currentPrompt.text == "Your rod is already the finest in the village!"

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -15,3 +15,4 @@ def test_initialization():
     assert player.moneyInBank == 0.01
     assert player.fishMultiplier == 1
     assert player.energy == 100
+    assert player.rodLevel == 1

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -156,3 +156,38 @@ def test_createPlayerFromJson_missingAllFields_usesDefaults():
     assert player.moneyInBank == defaults.moneyInBank
     assert player.priceForBait == defaults.priceForBait
     assert player.energy == defaults.energy
+    assert player.rodLevel == defaults.rodLevel
+
+
+def test_rodLevel_round_trips():
+    # prepare
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    player = Player()
+    player.rodLevel = 4
+
+    # call - serialize then deserialize
+    playerJson = playerJsonReaderWriter.createJsonFromPlayer(player)
+    restored = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check - rodLevel persists, and is present in the JSON
+    assert playerJson["rodLevel"] == 4
+    assert restored.rodLevel == 4
+
+
+def test_createPlayerFromJson_missingRodLevel_defaultsToOne():
+    # prepare - an older save with no rodLevel field
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    playerJson = {
+        "fishCount": 5,
+        "fishMultiplier": 2,
+        "money": 100,
+        "moneyInBank": 50,
+        "priceForBait": 75,
+        "energy": 80,
+    }
+
+    # call
+    player = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check - backward compatible default
+    assert player.rodLevel == 1


### PR DESCRIPTION
## Summary
A second upgrade axis distinct from bait:
- `src/player/player.py` + `schemas/player.json` + `playerJsonReaderWriter.py`: new persisted `rodLevel` (default 1; optional in schema with a backward-compatible `.get` default).
- `src/location/shop.py`: "Buy Better Rod" option (cost = `ROD_BASE_PRICE * rodLevel`, so only the level is stored), capped at `MAX_ROD_LEVEL`. Menu options renumbered (rod inserted at 3; talk→4, docks→5).
- `src/location/docks.py`: the catch reaction window now widens with `rodLevel` (`REACTION_BASE_WINDOW + (rodLevel-1)*ROD_WINDOW_STEP`); level 1 = the original 2.0s, so start-of-game behavior is unchanged.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 161 passed
- [x] New tests: rod purchase/cap/too-poor; rodLevel default + round-trip + missing-field backward compat; rod widens the window (a 2.5s reaction fails at level 1 but catches at level 5); shop run() menu renumbering updated.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_