### PR TITLE
Rework fishing minigame into a single quality-tiered catch

### DIFF
--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -154,67 +154,46 @@ class Docks:
                 self.currentPrompt.text = "You're too tired to fish! Go home and sleep."
                 return
 
-        successfulCatches = 0
-        totalAttempts = 0
-
         # A better rod widens the timing window, making catches more forgiving.
         reactionWindow = REACTION_BASE_WINDOW + (self.player.rodLevel - 1) * ROD_WINDOW_STEP
 
+        # One timing challenge per cast (not a pass/fail repeated every hour):
+        # how quickly you set the hook maps to a catch-quality tier.
+        print("Cast your line... press Enter the moment you feel a bite! ")
+        sys.stdout.flush()
+        startTime = time.time()
+        try:
+            input()
+            reactionTime = time.time() - startTime
+        except (KeyboardInterrupt, EOFError):
+            reactionTime = reactionWindow + 1.0  # an aborted input counts as a miss
+
+        if reactionTime <= reactionWindow / 2:
+            quality, qualityLabel = 1.0, "A perfect hook!"
+        elif reactionTime <= reactionWindow:
+            quality, qualityLabel = 0.6, "A solid hook."
+        else:
+            quality, qualityLabel = 0.25, "The fish nearly got away."
+
+        # Spend the fishing hours: time passes and energy is consumed.
         for i in range(hours):
-            print("><> ")
-            sys.stdout.flush()
-            time.sleep(0.5)
-            
-            # Interactive minigame: player must press Enter at the right moment
-            print("A fish is biting! Press Enter quickly! ")
-            sys.stdout.flush()
-            
-            startTime = time.time()
-            try:
-                input()
-                reactionTime = time.time() - startTime
-                
-                # Success if pressed within the (rod-dependent) reaction window
-                if reactionTime <= reactionWindow:
-                    successfulCatches += 1
-                    print("Got it! ")
-                else:
-                    print("Too slow... ")
-            except (KeyboardInterrupt, EOFError):
-                print("Missed! ")
-            
-            sys.stdout.flush()
-            totalAttempts += 1
-            
             self.stats.hoursSpentFishing += 1
             self.timeService.increaseTime()
             self.player.energy -= 10  # Consume 10 energy per hour
 
-        # Calculate fish caught based on success rate
         baseFish = random.randint(1, 10)
-        if totalAttempts > 0:
-            successRate = successfulCatches / totalAttempts
-            fishToAdd = int(
-                baseFish * successRate * self.player.fishMultiplier * timeFactor
-            )
-        else:
-            fishToAdd = 0
-
-        # Ensure at least 1 fish if player attempted
-        if fishToAdd == 0 and totalAttempts > 0:
-            fishToAdd = 1
+        fishToAdd = int(baseFish * quality * self.player.fishMultiplier * timeFactor)
+        if fishToAdd == 0:
+            fishToAdd = 1  # always land at least one fish for the effort
 
         self.player.fishCount += fishToAdd
         self.stats.totalFishCaught += fishToAdd
 
-        if fishToAdd == 1:
-            self.currentPrompt.text = "Nice catch!"
-        else:
-            self.currentPrompt.text = "You caught %d fish! It only took %d hours! Success rate: %d%%" % (
-                fishToAdd,
-                hours,
-                int((successfulCatches / totalAttempts * 100) if totalAttempts > 0 else 0)
-            )
+        self.currentPrompt.text = "You caught %d fish over %d hours! %s" % (
+            fishToAdd,
+            hours,
+            qualityLabel,
+        )
 
         if timeLabel:
             self.currentPrompt.text += " " + timeLabel

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -263,33 +263,42 @@ def test_fish_interactive_success():
         assert docksInstance.stats.totalFishCaught >= 3
 
 
-def test_fish_interactive_failure():
-    # Test that slow reactions result in fewer catches
-    docksInstance = createDocks()
-    docksInstance.userInterface.lotsOfSpace = MagicMock()
-    docksInstance.userInterface.divider = MagicMock()
-    
-    # Create a side effect that alternates between 0 and 3.0 indefinitely (slow reactions)
-    def time_side_effect():
-        while True:
-            yield 0
-            yield 3.0
-    
-    with patch('src.location.docks.print'), \
-         patch('src.location.docks.sys.stdout.flush'), \
-         patch('src.location.docks.time.sleep'), \
-         patch('src.location.docks.time.time', side_effect=time_side_effect()), \
-         patch('src.location.docks.input', return_value=""), \
-         patch('src.location.docks.random.randint', side_effect=[3, 10]):
-        
-        docksInstance.timeService.increaseTime = MagicMock()
+def test_fish_slow_reaction_yields_fewer_than_fast():
+    # A slow reaction lands the lowest-quality tier; a fast one lands the best.
+    # With identical rolls, slow should yield fewer fish (but still at least 1).
+    def make_docks():
+        d = createDocks()
+        d.userInterface.lotsOfSpace = MagicMock()
+        d.userInterface.divider = MagicMock()
+        return d
 
-        # call
-        docksInstance.fish()
+    def fish_with_reaction(reactionTime):
+        docksInstance = make_docks()
 
-        # check - with 0% success rate, should still get at least 1 fish minimum
-        assert docksInstance.player.fishCount == 1  # Minimum 1 fish even with failures
-        assert docksInstance.stats.totalFishCaught == 1
+        def time_side_effect():
+            while True:
+                yield 0
+                yield reactionTime
+
+        with patch("src.location.docks.print"), patch(
+            "src.location.docks.sys.stdout.flush"
+        ), patch("src.location.docks.time.sleep"), patch(
+            "src.location.docks.time.time", side_effect=time_side_effect()
+        ), patch(
+            "src.location.docks.input", return_value=""
+        ), patch(
+            "src.location.docks.random.randint", side_effect=[3, 10]
+        ):
+            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.fish()
+        return docksInstance.player.fishCount
+
+    slow = fish_with_reaction(3.0)  # beyond the 2.0s window => poorest tier
+    fast = fish_with_reaction(0.5)  # within half the window => perfect tier
+
+    # check - a poor reaction still lands at least one fish, but fewer than a perfect one
+    assert slow >= 1
+    assert slow < fast
 
 
 def test_getTimeOfDayModifier_windows():


### PR DESCRIPTION
## Summary
`src/location/docks.py` `fish()`:
- **One timing challenge per cast** instead of a pass/fail repeated every in-game hour (previously up to 10 timed `input()` prompts with `time.sleep` between each).
- Reaction speed maps to a **catch-quality tier** — perfect (≤ half the window), solid (≤ window), or poor (miss/over) — which scales the yield, rather than binary success counting.
- The window is the rod-derived `reactionWindow` from #73, so the hardcoded 2.0s is gone and a better rod genuinely helps.
- Hours still pass and consume energy (10/hour) in a now-silent loop.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 161 passed
- [x] Replaced the old binary `test_fish_interactive_failure` (which asserted exactly 1 fish on a miss — no longer the model) with `test_fish_slow_reaction_yields_fewer_than_fast` (slow ≥ 1 but < fast, identical rolls). Existing energy/time/limited-energy and rod-window tests still hold.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_