### PR TITLE
Add milestones/achievements built on the existing stats

### DIFF
--- a/schemas/stats.json
+++ b/schemas/stats.json
@@ -28,6 +28,13 @@
         "moneyLostWhileDrunk": {
             "type": "number",
             "description": "The total amount of money lost while drunk by the player."
+        },
+        "earnedMilestones": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Names of milestones the player has already been awarded."
         }
     }
 }

--- a/src/achievements/achievements.py
+++ b/src/achievements/achievements.py
@@ -1,0 +1,70 @@
+# @author Daniel McCoy Stephenson
+#
+# Milestones are short-term goals derived entirely from the player's lifetime
+# Stats. They are data-driven: add a row to MILESTONES and it is automatically
+# tracked, displayed, and announced. A milestone is "earned" once its stat
+# reaches its threshold; the set of already-announced milestone names lives on
+# Stats (stats.earnedMilestones) so each is announced only once across saves.
+
+MILESTONES = [
+    {
+        "name": "First Catch",
+        "stat": "totalFishCaught",
+        "threshold": 1,
+        "description": "Catch your first fish",
+    },
+    {
+        "name": "Seasoned Angler",
+        "stat": "totalFishCaught",
+        "threshold": 100,
+        "description": "Catch 100 fish",
+    },
+    {
+        "name": "Master Fisher",
+        "stat": "totalFishCaught",
+        "threshold": 1000,
+        "description": "Catch 1,000 fish",
+    },
+    {
+        "name": "Pocket Money",
+        "stat": "totalMoneyMade",
+        "threshold": 100,
+        "description": "Earn $100 total",
+    },
+    {
+        "name": "Big Earner",
+        "stat": "totalMoneyMade",
+        "threshold": 1000,
+        "description": "Earn $1,000 total",
+    },
+    {
+        "name": "Old Salt",
+        "stat": "hoursSpentFishing",
+        "threshold": 50,
+        "description": "Spend 50 hours fishing",
+    },
+]
+
+
+def isEarned(milestone, stats):
+    """True if the milestone's stat has reached its threshold."""
+    return getattr(stats, milestone["stat"], 0) >= milestone["threshold"]
+
+
+def getMilestoneStatuses(stats):
+    """Return a list of (milestone, earned) for every milestone, in order."""
+    return [(milestone, isEarned(milestone, stats)) for milestone in MILESTONES]
+
+
+def getNewlyEarned(stats):
+    """Return milestones newly earned since the last call and record them.
+
+    Records each newly-earned milestone's name on stats.earnedMilestones so it
+    is not announced again (including across reloads, since that list is saved).
+    """
+    newly = []
+    for milestone in MILESTONES:
+        if isEarned(milestone, stats) and milestone["name"] not in stats.earnedMilestones:
+            stats.earnedMilestones.append(milestone["name"])
+            newly.append(milestone)
+    return newly

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -11,6 +11,7 @@ from world.timeService import TimeService
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from saveFileManager import SaveFileManager
+from achievements import achievements
 
 
 # @author Daniel McCoy Stephenson
@@ -202,6 +203,12 @@ class FishE:
                 self.running = False
 
             self.currentLocation = nextLocation
+
+            # announce any milestones just crossed (appended so the action's own
+            # message is preserved on the next screen)
+            newlyEarned = achievements.getNewlyEarned(self.stats)
+            for milestone in newlyEarned:
+                self.prompt.text += "  [Milestone unlocked: %s!]" % milestone["name"]
 
             # increase time & save
             self.timeService.increaseTime()

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -4,6 +4,7 @@ from prompt.prompt import Prompt
 from world.timeService import TimeService
 from stats.stats import Stats
 from ui.userInterface import UserInterface
+from achievements import achievements
 
 
 # @author Daniel McCoy Stephenson
@@ -56,5 +57,10 @@ class Home:
         print("Money Made From Interest: %d" % self.stats.moneyMadeFromInterest)
         print("Times Gotten Drunk: %d" % self.stats.timesGottenDrunk)
         print("Money Lost Gambling: %d" % self.stats.moneyLostFromGambling)
+        print("")
+        print("Milestones:")
+        for milestone, earned in achievements.getMilestoneStatuses(self.stats):
+            mark = "x" if earned else " "
+            print(" [%s] %s - %s" % (mark, milestone["name"], milestone["description"]))
         print("")
         input(" [ CONTINUE ]")

--- a/src/stats/stats.py
+++ b/src/stats/stats.py
@@ -8,3 +8,4 @@ class Stats:
         self.timesGottenDrunk = 0
         self.moneyLostFromGambling = 0
         self.moneyLostWhileDrunk = 0
+        self.earnedMilestones = []

--- a/src/stats/statsJsonReaderWriter.py
+++ b/src/stats/statsJsonReaderWriter.py
@@ -12,6 +12,7 @@ class StatsJsonReaderWriter:
             "timesGottenDrunk": stats.timesGottenDrunk,
             "moneyLostFromGambling": stats.moneyLostFromGambling,
             "moneyLostWhileDrunk": stats.moneyLostWhileDrunk,
+            "earnedMilestones": stats.earnedMilestones,
         }
 
     def createStatsFromJson(self, statsJson):
@@ -35,6 +36,9 @@ class StatsJsonReaderWriter:
         )
         stats.moneyLostWhileDrunk = statsJson.get(
             "moneyLostWhileDrunk", stats.moneyLostWhileDrunk
+        )
+        stats.earnedMilestones = statsJson.get(
+            "earnedMilestones", stats.earnedMilestones
         )
         return stats
 

--- a/tests/achievements/test_achievements.py
+++ b/tests/achievements/test_achievements.py
@@ -1,0 +1,51 @@
+from src.achievements import achievements
+from src.stats.stats import Stats
+
+
+def createStats():
+    return Stats()
+
+
+def test_isEarned_threshold():
+    # prepare
+    stats = createStats()
+    milestone = {"name": "X", "stat": "totalFishCaught", "threshold": 5}
+
+    # check - below threshold not earned, at/above earned
+    stats.totalFishCaught = 4
+    assert achievements.isEarned(milestone, stats) is False
+    stats.totalFishCaught = 5
+    assert achievements.isEarned(milestone, stats) is True
+
+
+def test_getMilestoneStatuses_covers_all():
+    # prepare
+    stats = createStats()
+
+    # call
+    statuses = achievements.getMilestoneStatuses(stats)
+
+    # check - one entry per defined milestone, none earned on a fresh game
+    assert len(statuses) == len(achievements.MILESTONES)
+    assert all(earned is False for _, earned in statuses)
+
+
+def test_getNewlyEarned_records_and_does_not_repeat():
+    # prepare - enough fish to clear the "First Catch" (1) milestone
+    stats = createStats()
+    stats.totalFishCaught = 1
+
+    # call - first pass returns it and records it
+    firstPass = achievements.getNewlyEarned(stats)
+    names = [m["name"] for m in firstPass]
+    assert "First Catch" in names
+    assert "First Catch" in stats.earnedMilestones
+
+    # call again - already recorded, so not returned a second time
+    secondPass = achievements.getNewlyEarned(stats)
+    assert all(m["name"] != "First Catch" for m in secondPass)
+
+
+def test_stats_default_earnedMilestones_is_empty():
+    # check
+    assert createStats().earnedMilestones == []

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -5,6 +5,7 @@ from src.prompt.prompt import Prompt
 from src.stats.stats import Stats
 from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
+from src.achievements import achievements
 from unittest.mock import MagicMock
 
 
@@ -122,7 +123,7 @@ def test_displayStats():
     # call
     homeInstance.displayStats()
 
-    # check
+    # check - 6 stat lines + blank, then "Milestones:" + one line per milestone + blank
     assert homeInstance.userInterface.lotsOfSpace.call_count == 1
-    assert home.print.call_count == 7
+    assert home.print.call_count == 9 + len(achievements.MILESTONES)
     assert home.input.call_count == 1

--- a/tests/stats/test_statsJsonReaderWriter.py
+++ b/tests/stats/test_statsJsonReaderWriter.py
@@ -61,6 +61,41 @@ def test_createStatsFromJson():
     assert statsFromJson.moneyLostWhileDrunk == 2
 
 
+def test_earnedMilestones_round_trips():
+    # prepare
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    stats = createStats()
+    stats.earnedMilestones = ["First Catch", "Big Earner"]
+
+    # call - serialize then deserialize
+    statsJson = statsJsonReaderWriter.createJsonFromStats(stats)
+    restored = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check
+    assert statsJson["earnedMilestones"] == ["First Catch", "Big Earner"]
+    assert restored.earnedMilestones == ["First Catch", "Big Earner"]
+
+
+def test_createStatsFromJson_missingEarnedMilestones_defaultsToEmpty():
+    # prepare - an older save with no earnedMilestones field
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    statsJson = {
+        "totalFishCaught": 1,
+        "totalMoneyMade": 1,
+        "hoursSpentFishing": 1,
+        "moneyMadeFromInterest": 1,
+        "timesGottenDrunk": 1,
+        "moneyLostFromGambling": 1,
+        "moneyLostWhileDrunk": 1,
+    }
+
+    # call
+    stats = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check - backward compatible default
+    assert stats.earnedMilestones == []
+
+
 def test_writeStatsToFile():
     # prepare
     import tempfile


### PR DESCRIPTION
## Summary
- New `src/achievements/achievements.py`: a data-driven `MILESTONES` table plus `isEarned`, `getMilestoneStatuses`, and `getNewlyEarned` (which records earned names so each announces once).
- `src/stats/stats.py` + `schemas/stats.json` + `statsJsonReaderWriter.py`: new persisted `earnedMilestones` list (optional in schema, backward-compatible `.get` default `[]`).
- `src/location/home.py`: the stats screen now lists each milestone as `[x]`/`[ ]` with its description.
- `src/fishE.py`: the play loop announces newly-crossed milestones by appending to the current prompt (so the action's own message is preserved).

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 167 passed
- [x] New `tests/achievements/test_achievements.py` (threshold, statuses, record-once); stats `earnedMilestones` round-trip + missing-field backward-compat; `test_displayStats` print count updated to track `len(MILESTONES)`.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_