### PR TITLE
Add fish species and rarity

### DIFF
--- a/schemas/player.json
+++ b/schemas/player.json
@@ -29,6 +29,13 @@
         "rodLevel": {
             "type": "integer",
             "minimum": 1
+        },
+        "fishByType": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+            }
         }
     },
     "required": [

--- a/src/fish/fish.py
+++ b/src/fish/fish.py
@@ -1,0 +1,40 @@
+import random
+
+# @author Daniel McCoy Stephenson
+#
+# Catalogue of fish species. Each has a rarity weight (used to pick which
+# species is hooked on a trip) and a value range (used when selling). Rarer
+# fish are worth more, so what you catch — not just how many — now matters.
+
+FISH_TYPES = [
+    {"name": "Minnow", "weight": 60, "minValue": 2, "maxValue": 4},
+    {"name": "Bass", "weight": 30, "minValue": 5, "maxValue": 9},
+    {"name": "Marlin", "weight": 9, "minValue": 15, "maxValue": 25},
+    {"name": "Golden Koi", "weight": 1, "minValue": 50, "maxValue": 80},
+]
+
+
+def getFishType(name):
+    """Return the catalogue entry for a species name, or None if unknown."""
+    for fishType in FISH_TYPES:
+        if fishType["name"] == name:
+            return fishType
+    return None
+
+
+def rollFishType():
+    """Pick a species weighted by rarity and return its name."""
+    weights = [fishType["weight"] for fishType in FISH_TYPES]
+    return random.choices(FISH_TYPES, weights=weights)[0]["name"]
+
+
+def fishValue(name):
+    """Return a per-fish sale price for the given species.
+
+    Falls back to the original flat $3-5 range for an unknown species so that
+    legacy saves (which tracked only an undifferentiated fish count) still sell.
+    """
+    fishType = getFishType(name)
+    if fishType is None:
+        return random.randint(3, 5)
+    return random.randint(fishType["minValue"], fishType["maxValue"])

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -9,6 +9,7 @@ from world.timeService import TimeService
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
+from fish import fish
 
 
 # The catch reaction window widens with the player's rod level, so a better rod
@@ -186,11 +187,14 @@ class Docks:
         if fishToAdd == 0:
             fishToAdd = 1  # always land at least one fish for the effort
 
-        self.player.fishCount += fishToAdd
+        # Which species you hooked this trip, weighted by rarity.
+        fishTypeName = fish.rollFishType()
+        self.player.addFish(fishTypeName, fishToAdd)
         self.stats.totalFishCaught += fishToAdd
 
-        self.currentPrompt.text = "You caught %d fish over %d hours! %s" % (
+        self.currentPrompt.text = "You caught %d %s over %d hours! %s" % (
             fishToAdd,
+            fishTypeName,
             hours,
             qualityLabel,
         )

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -6,6 +6,7 @@ from world.timeService import TimeService
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
+from fish import fish
 
 
 # Upper bound on fishMultiplier so bait upgrades stop being an infinite power
@@ -114,10 +115,18 @@ class Shop:
             return LocationType.DOCKS
 
     def sellFish(self):
-        moneyToAdd = self.player.fishCount * random.randint(3, 5)
+        if self.player.fishByType:
+            # Price each species individually (rarer fish are worth more).
+            moneyToAdd = 0
+            for fishTypeName, count in self.player.fishByType.items():
+                moneyToAdd += count * fish.fishValue(fishTypeName)
+        else:
+            # Legacy save with only an aggregate count: flat $3-5 per fish.
+            moneyToAdd = self.player.fishCount * random.randint(3, 5)
+
         self.player.money += moneyToAdd
         self.stats.totalMoneyMade += moneyToAdd
-        self.player.fishCount = 0
+        self.player.clearFish()
 
         self.currentPrompt.text = "You sold all of your fish!"
 

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -8,3 +8,14 @@ class Player:
         self.priceForBait = 50
         self.energy = 100
         self.rodLevel = 1
+        # Per-species breakdown of the fish currently held. fishCount remains the
+        # aggregate total; addFish/clearFish keep the two in sync.
+        self.fishByType = {}
+
+    def addFish(self, fishTypeName, amount):
+        self.fishByType[fishTypeName] = self.fishByType.get(fishTypeName, 0) + amount
+        self.fishCount += amount
+
+    def clearFish(self):
+        self.fishByType = {}
+        self.fishCount = 0

--- a/src/player/playerJsonReaderWriter.py
+++ b/src/player/playerJsonReaderWriter.py
@@ -12,6 +12,7 @@ class PlayerJsonReaderWriter:
             "priceForBait": player.priceForBait,
             "energy": player.energy,
             "rodLevel": player.rodLevel,
+            "fishByType": player.fishByType,
         }
 
     def createPlayerFromJson(self, playerJson):
@@ -26,6 +27,7 @@ class PlayerJsonReaderWriter:
         player.priceForBait = playerJson.get("priceForBait", player.priceForBait)
         player.energy = playerJson.get("energy", player.energy)
         player.rodLevel = playerJson.get("rodLevel", player.rodLevel)
+        player.fishByType = playerJson.get("fishByType", player.fishByType)
         return player
 
     def writePlayerToFile(self, player, jsonFile):

--- a/tests/fish/test_fish.py
+++ b/tests/fish/test_fish.py
@@ -1,0 +1,31 @@
+from src.fish import fish
+
+
+def test_rollFishType_returns_known_species():
+    # call repeatedly; every result must be a catalogued species
+    names = {fishType["name"] for fishType in fish.FISH_TYPES}
+    for _ in range(50):
+        assert fish.rollFishType() in names
+
+
+def test_fishValue_within_species_range():
+    # prepare
+    marlin = fish.getFishType("Marlin")
+
+    # check - many rolls all fall within the species' value range
+    for _ in range(50):
+        value = fish.fishValue("Marlin")
+        assert marlin["minValue"] <= value <= marlin["maxValue"]
+
+
+def test_fishValue_unknown_species_falls_back():
+    # check - an unknown species (e.g. a legacy/aggregate sale) uses $3-5
+    for _ in range(50):
+        assert 3 <= fish.fishValue("NotARealFish") <= 5
+
+
+def test_rarer_fish_are_worth_more():
+    # check - the catalogue is ordered so rarer fish carry higher value floors
+    minnow = fish.getFishType("Minnow")
+    marlin = fish.getFishType("Marlin")
+    assert marlin["minValue"] > minnow["maxValue"]

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -128,6 +128,24 @@ def test_sellFish():
     assert shopInstance.stats.totalMoneyMade > 0
 
 
+def test_sellFish_prices_by_species():
+    # prepare - hold two marlin (a high-value species)
+    from src.fish import fish
+
+    shopInstance = createShop()
+    shopInstance.player.money = 0
+    shopInstance.player.addFish("Marlin", 2)
+    marlin = fish.getFishType("Marlin")
+
+    # call
+    shopInstance.sellFish()
+
+    # check - sale is within 2x the species value range; inventory cleared
+    assert 2 * marlin["minValue"] <= shopInstance.player.money <= 2 * marlin["maxValue"]
+    assert shopInstance.player.fishByType == {}
+    assert shopInstance.player.fishCount == 0
+
+
 def test_buyBetterBait():
     # prepare
     shopInstance = createShop()

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -16,3 +16,23 @@ def test_initialization():
     assert player.fishMultiplier == 1
     assert player.energy == 100
     assert player.rodLevel == 1
+    assert player.fishByType == {}
+
+
+def test_addFish_and_clearFish_keep_count_in_sync():
+    # prepare
+    player = createPlayer()
+
+    # call - add two species
+    player.addFish("Bass", 3)
+    player.addFish("Bass", 2)
+    player.addFish("Marlin", 1)
+
+    # check - per-type breakdown and aggregate count agree
+    assert player.fishByType == {"Bass": 5, "Marlin": 1}
+    assert player.fishCount == 6
+
+    # call - clearing resets both
+    player.clearFish()
+    assert player.fishByType == {}
+    assert player.fishCount == 0

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -174,6 +174,40 @@ def test_rodLevel_round_trips():
     assert restored.rodLevel == 4
 
 
+def test_fishByType_round_trips():
+    # prepare
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    player = Player()
+    player.fishByType = {"Bass": 3, "Marlin": 1}
+
+    # call
+    playerJson = playerJsonReaderWriter.createJsonFromPlayer(player)
+    restored = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check
+    assert playerJson["fishByType"] == {"Bass": 3, "Marlin": 1}
+    assert restored.fishByType == {"Bass": 3, "Marlin": 1}
+
+
+def test_createPlayerFromJson_missingFishByType_defaultsToEmpty():
+    # prepare - an older save with no fishByType field
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    playerJson = {
+        "fishCount": 5,
+        "fishMultiplier": 2,
+        "money": 100,
+        "moneyInBank": 50,
+        "priceForBait": 75,
+        "energy": 80,
+    }
+
+    # call
+    player = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check
+    assert player.fishByType == {}
+
+
 def test_createPlayerFromJson_missingRodLevel_defaultsToOne():
     # prepare - an older save with no rodLevel field
     playerJsonReaderWriter = createPlayerJsonReaderWriter()


### PR DESCRIPTION
## Summary
- New `src/fish/fish.py`: a `FISH_TYPES` catalogue (Minnow → Golden Koi) with rarity weights and per-species value ranges, plus `rollFishType()` (weighted) and `fishValue(name)` (per-species price, falling back to flat $3–5 for unknown/legacy).
- `src/player/player.py`: per-species `fishByType` plus `addFish`/`clearFish` that keep it in sync with the aggregate `fishCount` (kept for the HUD + backward compat).
- `src/location/docks.py`: a trip rolls the species hooked and reports it ("You caught 4 Bass…").
- `src/location/shop.py`: `sellFish()` prices each species individually; legacy aggregate-only inventories use the old flat price.
- `schemas/player.json` + `playerJsonReaderWriter.py`: `fishByType` persisted (optional, `.get` default `{}`).

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 175 passed
- [x] New tests: fish catalogue (roll/value/fallback/ordering), `addFish`/`clearFish` sync, sell-by-species, `fishByType` round-trip + missing-field default. Existing aggregate-count tests still hold via the flat-price fallback.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_