### PR TITLE
Add a wealth goal and one-time victory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This game allows you to explore a fishing village and perform actions in it.
 
 ## Features
 
+### Your Goal
+Build a fortune of **$10,000** in total wealth (cash on hand plus savings in the bank). Your progress toward the goal is shown in the status header, and reaching it earns a one-time victory — after which you're free to keep fishing or retire from the Home menu.
+
 ### Multiple Save Files
 FishE supports multiple save files, allowing you to maintain different game progressions simultaneously. When you start the game, you'll see a save file manager that displays:
 

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -14,6 +14,12 @@ from saveFileManager import SaveFileManager
 from achievements import achievements
 
 
+# Total wealth (cash + bank) the player is working toward. Reaching it triggers
+# a one-time victory message; the game then continues until the player retires.
+GOAL_AMOUNT = 10000
+GOAL_MILESTONE_NAME = "Reached Goal"
+
+
 # @author Daniel McCoy Stephenson
 class FishE:
     def __init__(self):
@@ -193,8 +199,12 @@ class FishE:
 
     def play(self):
         while self.running:
-            # show the current location in the UI header
+            # show the current location and goal progress in the UI header
             self.userInterface.currentLocationName = self.currentLocation.capitalize()
+            self.userInterface.goalProgress = "$%d / $%d" % (
+                self.getTotalWealth(),
+                GOAL_AMOUNT,
+            )
 
             # change location
             nextLocation = self.locations[self.currentLocation].run()
@@ -210,9 +220,33 @@ class FishE:
             for milestone in newlyEarned:
                 self.prompt.text += "  [Milestone unlocked: %s!]" % milestone["name"]
 
+            # announce reaching the wealth goal once (the run continues)
+            self.announceGoalIfReached()
+
             # increase time & save
             self.timeService.increaseTime()
             self.save()
+
+    def getTotalWealth(self):
+        return self.player.money + self.player.moneyInBank
+
+    def announceGoalIfReached(self):
+        """Announce the wealth goal the first time it is reached.
+
+        The persisted earnedMilestones list doubles as the "already announced"
+        flag, so the victory is shown once and not repeated on later actions or
+        after a reload. Returns True only on the announcing call."""
+        if (
+            self.getTotalWealth() >= GOAL_AMOUNT
+            and GOAL_MILESTONE_NAME not in self.stats.earnedMilestones
+        ):
+            self.stats.earnedMilestones.append(GOAL_MILESTONE_NAME)
+            self.prompt.text += (
+                "  [GOAL REACHED! You've built your fortune of $%d! "
+                "Keep fishing, or retire from the Home menu.]" % GOAL_AMOUNT
+            )
+            return True
+        return False
 
     def save(self):
         # create data directory - use SaveFileManager's directory

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -15,6 +15,9 @@ class UserInterface:
         # Display name of the player's current location, shown in the header.
         # Set by the game loop before each render; empty hides the line.
         self.currentLocationName = ""
+        # Progress toward the wealth goal (e.g. "$1200 / $10000"), shown in the
+        # header. Set by the game loop before each render; empty hides the line.
+        self.goalProgress = ""
 
         self.times = {
             0: "12:00 AM",
@@ -68,6 +71,8 @@ class UserInterface:
             print(" | Money: $%.2f" % self.player.money)
             print(" | Fish: %d" % self.player.fishCount)
             print(" | Energy: %d" % self.player.energy)
+            if self.goalProgress:
+                print(" | Goal: " + self.goalProgress)
             print("\n " + self.currentPrompt.text)
             self.divider()
             self.n = 1

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from src import fishE
 from src.player.player import Player
 from src.stats.stats import Stats
+from src.prompt.prompt import Prompt
 from src.world.timeService import TimeService
 from src.player.playerJsonReaderWriter import PlayerJsonReaderWriter
 from src.stats.statsJsonReaderWriter import StatsJsonReaderWriter
@@ -138,6 +139,51 @@ def test_save_writes_all_three_files():
         assert os.path.exists(os.path.join(slot, "player.json"))
         assert os.path.exists(os.path.join(slot, "stats.json"))
         assert os.path.exists(os.path.join(slot, "timeService.json"))
+
+
+def test_getTotalWealth_sums_cash_and_bank():
+    # prepare
+    game = fishE.FishE.__new__(fishE.FishE)
+    game.player = Player()
+    game.player.money = 30
+    game.player.moneyInBank = 70
+
+    # check
+    assert game.getTotalWealth() == 100
+
+
+def test_announceGoalIfReached_fires_once():
+    # prepare - wealth at/above the goal
+    game = fishE.FishE.__new__(fishE.FishE)
+    game.player = Player()
+    game.player.money = fishE.GOAL_AMOUNT
+    game.player.moneyInBank = 0
+    game.stats = Stats()
+    game.prompt = Prompt("hi")
+
+    # call - first time announces and records the flag
+    assert game.announceGoalIfReached() is True
+    assert fishE.GOAL_MILESTONE_NAME in game.stats.earnedMilestones
+    assert "GOAL REACHED" in game.prompt.text
+
+    # call again - already recorded, so it does not re-announce
+    game.prompt.text = "fresh"
+    assert game.announceGoalIfReached() is False
+    assert "GOAL REACHED" not in game.prompt.text
+
+
+def test_announceGoalIfReached_not_before_goal():
+    # prepare - wealth below the goal
+    game = fishE.FishE.__new__(fishE.FishE)
+    game.player = Player()
+    game.player.money = fishE.GOAL_AMOUNT - 1
+    game.player.moneyInBank = 0
+    game.stats = Stats()
+    game.prompt = Prompt("hi")
+
+    # call
+    assert game.announceGoalIfReached() is False
+    assert fishE.GOAL_MILESTONE_NAME not in game.stats.earnedMilestones
 
 
 def test_loadPlayer_recovers_from_corrupt_file():

--- a/tests/ui/test_userInterface.py
+++ b/tests/ui/test_userInterface.py
@@ -86,6 +86,23 @@ def test_showOptions_includes_location_when_set():
     assert " | Location: Docks" in printedLines
 
 
+def test_showOptions_includes_goal_progress_when_set():
+    # setup
+    userInterfaceInstance = createUserInterface()
+    userInterfaceInstance.goalProgress = "$1200 / $10000"
+    userInterface.print = MagicMock()
+    userInterface.input = MagicMock(return_value="1")
+    userInterfaceInstance.lotsOfSpace = MagicMock()
+    userInterfaceInstance.divider = MagicMock()
+
+    # call
+    userInterfaceInstance.showOptions("descriptor", ["option1"])
+
+    # check
+    printedLines = [call.args[0] for call in userInterface.print.call_args_list]
+    assert " | Goal: $1200 / $10000" in printedLines
+
+
 def test_showOptions_omits_location_when_unset():
     # setup
     userInterfaceInstance = createUserInterface()  # currentLocationName defaults to ""


### PR DESCRIPTION
## Summary
Gives the previously goal-less sandbox an objective:
- `src/fishE.py`: `GOAL_AMOUNT` ($10,000) of total wealth (cash + bank). `getTotalWealth()` and `announceGoalIfReached()` (extracted for testability) announce a one-time victory when the goal is crossed; the run continues. The persisted `earnedMilestones` list is reused as the "already announced" flag, so there's **no new save-schema field**.
- `src/ui/userInterface.py`: a `goalProgress` header line ("Goal: $X / $10000"), set by the play loop each render (same pattern as the location line).
- `README.md`: documents the goal under Features.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 179 passed
- [x] New tests: `getTotalWealth` sum; `announceGoalIfReached` fires once / not before goal; header shows goal progress. Existing `showOptions` tests unaffected (goalProgress defaults to "").

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_