### PR TITLE
Refactor the UI layer behind a single front-end interface

### DIFF
--- a/src/fishE.py
+++ b/src/fishE.py
@@ -9,7 +9,8 @@ from stats.statsJsonReaderWriter import StatsJsonReaderWriter
 from world.timeServiceJsonReaderWriter import TimeServiceJsonReaderWriter
 from world.timeService import TimeService
 from stats.stats import Stats
-from ui.userInterface import UserInterface
+from ui.userInterfaceFactory import UserInterfaceFactory
+from ui.enum.uiType import UIType
 from saveFileManager import SaveFileManager
 from achievements import achievements
 
@@ -18,6 +19,10 @@ from achievements import achievements
 # a one-time victory message; the game then continues until the player retires.
 GOAL_AMOUNT = 10000
 GOAL_MILESTONE_NAME = "Reached Goal"
+
+# Which front-end the game runs. Swap to UIType.PYGAME (or a future web type)
+# here to change the interface — the rest of the game is front-end agnostic.
+INTERFACE_TYPE = UIType.CONSOLE
 
 
 # @author Daniel McCoy Stephenson
@@ -59,7 +64,9 @@ class FishE:
 
         self.prompt = Prompt("What would you like to do?")
 
-        self.userInterface = UserInterface(self.prompt, self.timeService, self.player)
+        self.userInterface = UserInterfaceFactory.create_user_interface(
+            INTERFACE_TYPE, self.prompt, self.timeService, self.player
+        )
 
         self.locations = {
             LocationType.BANK: bank.Bank(

--- a/src/ui/baseUserInterface.py
+++ b/src/ui/baseUserInterface.py
@@ -6,8 +6,13 @@ from world.timeService import TimeService
 
 # @author Daniel McCoy Stephenson
 class BaseUserInterface(ABC):
-    """Abstract base class for user interfaces"""
-    
+    """Abstract contract every front-end (text/console, pygame, web, ...) implements.
+
+    Concrete subclasses must implement the rendering/input primitives below.
+    Shared state and the higher-level interactive-dialogue flow live here so all
+    front-ends behave consistently and only the primitives differ.
+    """
+
     def __init__(self, currentPrompt: Prompt, timeService: TimeService, player: Player):
         self.currentPrompt = currentPrompt
         self.timeService = timeService
@@ -15,6 +20,9 @@ class BaseUserInterface(ABC):
 
         self.prompt = "Make your choice!"
         self.optionList = []
+        # Header fields the game loop sets before each render; empty hides the line.
+        self.currentLocationName = ""
+        self.goalProgress = ""
 
         self.times = {
             0: "12:00 AM",
@@ -45,20 +53,53 @@ class BaseUserInterface(ABC):
 
     @abstractmethod
     def lotsOfSpace(self):
-        """Clear or add space to the display"""
+        """Clear or add space to the display."""
         pass
 
     @abstractmethod
     def divider(self):
-        """Display a divider line"""
+        """Display a divider between sections."""
         pass
 
     @abstractmethod
     def showOptions(self, descriptor, optionList):
-        """Show options to the user and return their choice"""
+        """Show numbered options and return the chosen option's number as a string."""
         pass
-    
+
+    @abstractmethod
+    def showDialogue(self, text):
+        """Show a block of text and wait for the player to acknowledge it."""
+        pass
+
     @abstractmethod
     def cleanup(self):
-        """Clean up any resources used by the UI"""
+        """Release any resources held by the front-end."""
         pass
+
+    def showInteractiveDialogue(self, npc):
+        """Default interactive NPC conversation built on the primitives above.
+
+        Front-ends inherit this for free; one (the console) overrides it with a
+        richer layout. Picks a question via showOptions and shows the response
+        via showDialogue until the player chooses to go back."""
+        while True:
+            dialogueOptions = npc.get_dialogue_options()
+            if not dialogueOptions:
+                self.showDialogue(npc.introduce())
+                self.currentPrompt.text = "What would you like to do?"
+                return
+
+            questions = [
+                option.get("question", "Option %d" % (index + 1))
+                for index, option in enumerate(dialogueOptions)
+            ]
+            questions.append("[Back]")
+
+            choice = int(self.showOptions("Talking with %s" % npc.name, questions))
+            if choice == len(questions):
+                self.currentPrompt.text = "What would you like to do?"
+                return
+
+            self.showDialogue(
+                "%s: %s" % (npc.name, npc.get_dialogue_response(choice - 1))
+            )

--- a/src/ui/consoleUserInterface.py
+++ b/src/ui/consoleUserInterface.py
@@ -1,50 +1,13 @@
-from ui.baseUserInterface import BaseUserInterface
-from prompt.prompt import Prompt
-from player.player import Player
-from world.timeService import TimeService
+from ui.userInterface import UserInterface
 
 
 # @author Daniel McCoy Stephenson
-class ConsoleUserInterface(BaseUserInterface):
-    """Console-based user interface implementation"""
-    
-    def __init__(self, currentPrompt: Prompt, timeService: TimeService, player: Player):
-        super().__init__(currentPrompt, timeService, player)
+class ConsoleUserInterface(UserInterface):
+    """Explicitly-named console/text front-end used by the UI factory.
 
-    def lotsOfSpace(self):
-        print("\n" * 20)
+    The console rendering lives in UserInterface (FishE's default front-end);
+    this subclass exists so the factory and callers can refer to the console
+    interface by an unambiguous name alongside PygameUserInterface and any
+    future web front-end."""
 
-    def divider(self):
-        print("\n")
-        print("-" * 75)
-        print("\n")
-
-    def showOptions(self, descriptor, optionList):
-        while True:
-            self.lotsOfSpace()
-            self.divider()
-            print(" " + descriptor)
-            self.divider()
-            print(" Day %d" % self.timeService.day)
-            print(" | " + self.times[self.timeService.time])
-            print(" | Money: $%d" % self.player.money)
-            print(" | Fish: %d" % self.player.fishCount)
-            print("\n " + self.currentPrompt.text)
-            self.divider()
-            self.n = 1
-            self.listOfN = []
-            for option in optionList:
-                print(" [%d] %s" % (self.n, option))
-                self.listOfN.append("%d" % self.n)
-                self.n += 1
-
-            choice = input("\n> ")
-            for i in self.listOfN:
-                if choice == i:
-                    return choice
-
-            self.currentPrompt.text = "Try again!"
-    
-    def cleanup(self):
-        # Console UI doesn't need cleanup
-        pass
+    pass

--- a/src/ui/pygameUserInterface.py
+++ b/src/ui/pygameUserInterface.py
@@ -212,6 +212,35 @@ class PygameUserInterface(BaseUserInterface):
             self.screen.blit(inst_surface, inst_rect)
             y_offset += instruction_spacing
 
+    def showDialogue(self, text):
+        """Render a block of text and wait for the player to press a key."""
+        waiting = True
+        while waiting:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.cleanup()
+                    sys.exit()
+                elif event.type == pygame.VIDEORESIZE:
+                    self._handle_resize(event.w, event.h)
+                elif event.type == pygame.KEYDOWN:
+                    waiting = False
+
+            self.screen.fill(self.BLACK)
+            margin_x = self.width * 0.06
+            text_surface = self.font_medium.render(text, True, self.WHITE)
+            self.screen.blit(text_surface, (margin_x, self.height * 0.2))
+            prompt_surface = self.font_small.render(
+                "Press any key to continue", True, self.GRAY
+            )
+            prompt_rect = prompt_surface.get_rect(
+                center=(self.width // 2, self.height - self.height * 0.1)
+            )
+            self.screen.blit(prompt_surface, prompt_rect)
+            pygame.display.flip()
+            pygame.time.Clock().tick(60)
+
+        self.currentPrompt.text = "What would you like to do?"
+
     def cleanup(self):
         """Clean up pygame resources"""
         pygame.quit()

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -1,50 +1,19 @@
+from ui.baseUserInterface import BaseUserInterface
 from prompt.prompt import Prompt
 from player.player import Player
 from world.timeService import TimeService
 
 
 # @author Daniel McCoy Stephenson
-class UserInterface:
+class UserInterface(BaseUserInterface):
+    """The text/console front-end — FishE's default user interface.
+
+    Shared state (prompt, times, header fields) comes from BaseUserInterface;
+    this class implements the console rendering/input primitives and a richer
+    interactive-dialogue layout."""
+
     def __init__(self, currentPrompt: Prompt, timeService: TimeService, player: Player):
-        self.currentPrompt = currentPrompt
-        self.timeService = timeService
-        self.player = player
-
-        self.prompt = "Make your choice!"
-        self.optionList = []
-        # Display name of the player's current location, shown in the header.
-        # Set by the game loop before each render; empty hides the line.
-        self.currentLocationName = ""
-        # Progress toward the wealth goal (e.g. "$1200 / $10000"), shown in the
-        # header. Set by the game loop before each render; empty hides the line.
-        self.goalProgress = ""
-
-        self.times = {
-            0: "12:00 AM",
-            1: "1:00 AM",
-            2: "2:00 AM",
-            3: "3:00 AM",
-            4: "4:00 AM",
-            5: "5:00 AM",
-            6: "6:00 AM",
-            7: "7:00 AM",
-            8: "8:00 AM",
-            9: "9:00 AM",
-            10: "10:00 AM",
-            11: "11:00 AM",
-            12: "12:00 PM",
-            13: "1:00 PM",
-            14: "2:00 PM",
-            15: "3:00 PM",
-            16: "4:00 PM",
-            17: "5:00 PM",
-            18: "6:00 PM",
-            19: "7:00 PM",
-            20: "8:00 PM",
-            21: "9:00 PM",
-            22: "10:00 PM",
-            23: "11:00 PM",
-        }
+        super().__init__(currentPrompt, timeService, player)
 
     def lotsOfSpace(self):
         print("\n" * 20)
@@ -145,3 +114,7 @@ class UserInterface:
             else:
                 print(" Invalid choice. Try again!")
                 input(" [ CONTINUE ]")
+
+    def cleanup(self):
+        # The console front-end holds no resources to release.
+        pass

--- a/src/ui/userInterfaceFactory.py
+++ b/src/ui/userInterfaceFactory.py
@@ -1,6 +1,5 @@
 from ui.enum.uiType import UIType
 from ui.consoleUserInterface import ConsoleUserInterface
-from ui.pygameUserInterface import PygameUserInterface
 from prompt.prompt import Prompt
 from player.player import Player
 from world.timeService import TimeService
@@ -8,14 +7,27 @@ from world.timeService import TimeService
 
 # @author Daniel McCoy Stephenson
 class UserInterfaceFactory:
-    """Factory class to create user interfaces based on type"""
-    
+    """Creates the requested front-end behind the BaseUserInterface contract.
+
+    To add a new front-end (e.g. a web interface): implement BaseUserInterface,
+    add a UIType value, and add a branch here. Heavy/optional front-ends (like
+    pygame) are imported lazily inside their branch so the default text mode has
+    no extra dependencies."""
+
     @staticmethod
-    def create_user_interface(ui_type: UIType, currentPrompt: Prompt, timeService: TimeService, player: Player):
-        """Create a user interface of the specified type"""
+    def create_user_interface(
+        ui_type: UIType,
+        currentPrompt: Prompt,
+        timeService: TimeService,
+        player: Player,
+    ):
+        """Create a user interface of the specified type."""
         if ui_type == UIType.CONSOLE:
             return ConsoleUserInterface(currentPrompt, timeService, player)
         elif ui_type == UIType.PYGAME:
+            # Imported lazily so text mode does not require pygame.
+            from ui.pygameUserInterface import PygameUserInterface
+
             return PygameUserInterface(currentPrompt, timeService, player)
         else:
             raise ValueError(f"Unsupported UI type: {ui_type}")

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -18,7 +18,7 @@ def createFishE():
     fishE.Stats = MagicMock()
     fishE.TimeService = MagicMock()
     fishE.Prompt = MagicMock()
-    fishE.UserInterface = MagicMock()
+    fishE.UserInterfaceFactory = MagicMock()
     fishE.bank.Bank = MagicMock()
     fishE.shop.Shop = MagicMock()
     fishE.home.Home = MagicMock()
@@ -64,7 +64,7 @@ def test_initialization():
         or fishEInstance.statsJsonReaderWriter.readStatsFromFile.call_count == 1
     )
     fishE.Prompt.assert_called_once()
-    fishE.UserInterface.assert_called_once()
+    fishE.UserInterfaceFactory.create_user_interface.assert_called_once()
     fishE.bank.Bank.assert_called_once()
     fishE.shop.Shop.assert_called_once()
     fishE.home.Home.assert_called_once()

--- a/tests/ui/test_baseUserInterface.py
+++ b/tests/ui/test_baseUserInterface.py
@@ -1,0 +1,89 @@
+import sys
+import os
+
+# Match the import style production code uses (bare `ui.*`/`player.*`), so class
+# identities line up with the runtime MRO. pytest.ini exposes both `.` and `src`,
+# and the project's modules import each other without the `src.` prefix.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+import pytest
+
+from ui.baseUserInterface import BaseUserInterface
+from ui.userInterface import UserInterface
+from ui.consoleUserInterface import ConsoleUserInterface
+from player.player import Player
+from prompt.prompt import Prompt
+from stats.stats import Stats
+from world.timeService import TimeService
+
+
+def makeArgs():
+    prompt = Prompt("What would you like to do?")
+    player = Player()
+    stats = Stats()
+    timeService = TimeService(player, stats)
+    return prompt, timeService, player
+
+
+def test_base_user_interface_is_abstract():
+    # check - the contract cannot be instantiated directly
+    prompt, timeService, player = makeArgs()
+    with pytest.raises(TypeError):
+        BaseUserInterface(prompt, timeService, player)
+
+
+def test_front_ends_implement_the_interface():
+    # check - the text front-ends are BaseUserInterface implementations
+    assert issubclass(UserInterface, BaseUserInterface)
+    assert issubclass(ConsoleUserInterface, BaseUserInterface)
+
+
+class RecordingUserInterface(BaseUserInterface):
+    """Minimal front-end that records primitive calls and replays scripted
+    showOptions choices — used to exercise the inherited dialogue flow."""
+
+    def __init__(self, prompt, timeService, player, choices):
+        super().__init__(prompt, timeService, player)
+        self.choices = list(choices)
+        self.shownDialogues = []
+
+    def lotsOfSpace(self):
+        pass
+
+    def divider(self):
+        pass
+
+    def showOptions(self, descriptor, optionList):
+        return self.choices.pop(0)
+
+    def showDialogue(self, text):
+        self.shownDialogues.append(text)
+
+    def cleanup(self):
+        pass
+
+
+class FakeNPC:
+    name = "Tester"
+
+    def get_dialogue_options(self):
+        return [{"question": "Q1", "response": "R1"}]
+
+    def get_dialogue_response(self, index):
+        return "R1"
+
+    def introduce(self):
+        return "Hello"
+
+
+def test_inherited_interactive_dialogue_uses_primitives():
+    # prepare - pick the first question, then choose [Back]
+    prompt, timeService, player = makeArgs()
+    ui = RecordingUserInterface(prompt, timeService, player, choices=["1", "2"])
+
+    # call - the dialogue flow is inherited from BaseUserInterface
+    ui.showInteractiveDialogue(FakeNPC())
+
+    # check - the response was shown via the showDialogue primitive, then it exited
+    assert ui.shownDialogues == ["Tester: R1"]
+    assert ui.currentPrompt.text == "What would you like to do?"


### PR DESCRIPTION
## Why
The UI layer had drifted into four overlapping pieces: `UserInterface` (the complete, active console UI, implementing no interface), a stale duplicate `ConsoleUserInterface`, an incomplete `BaseUserInterface` ABC, a `PygameUserInterface` missing `showInteractiveDialogue` (which locations call, so it was never usable), and a factory the game bypassed entirely. This makes it hard to add a pygame or web front-end cleanly.

## What changed
- **`BaseUserInterface` = the single contract.** Holds shared state (one `times` dict, `currentLocationName`/`goalProgress`) and the primitives (`lotsOfSpace`, `divider`, `showOptions`, `showDialogue`, `cleanup`). Adds a concrete `showInteractiveDialogue` *template* built on the primitives, so every front-end inherits the NPC conversation flow.
- **`UserInterface`** (the text/console front-end, unchanged behavior) now extends `BaseUserInterface`, drops its duplicated `times`/state via `super().__init__`, and gains `cleanup()`.
- **`ConsoleUserInterface`** is now a thin, correctly-named subclass of the console UI for the factory — the stale duplicate implementation is deleted.
- **`PygameUserInterface`** implements `showDialogue` and inherits the dialogue flow, so it satisfies the full interface.
- **`UserInterfaceFactory`** imports pygame **lazily** (text mode no longer requires pygame) and documents the web extension point.
- **`FishE`** constructs its UI through the factory via a single `INTERFACE_TYPE` constant — front-end is now swappable in one place; the rest of the game is UI-agnostic.

Adding a web front-end is now: implement `BaseUserInterface`, add a `UIType`, add one factory branch.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 182 passed
- [x] New `tests/ui/test_baseUserInterface.py`: interface is abstract (can't instantiate), front-ends are implementations, and the inherited `showInteractiveDialogue` drives the `showOptions`/`showDialogue` primitives.
- [x] Verified text mode does **not** import pygame (lazy factory import).
- [x] `test_fishE` updated to mock the factory (the only test affected by the construction change). All existing console/location/UI tests pass unchanged — behavior is preserved.

Behavior-preserving refactor; no save-file or schema changes. Related to (but does not close) #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_