### PR TITLE
ux: usability pass — 10 web-client fixes (Nielsen heuristics + Don't Make Me Think)

### DIFF
--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -22,7 +22,8 @@ HTML_PAGE = """<!DOCTYPE html>
   body { font-family: monospace; background: #0b1d2a; color: #e0f0ff;
          max-width: 680px; margin: 2rem auto; padding: 0 1rem; }
   .header { color: #7fb0d0; border-bottom: 1px solid #2a4a5a;
-            padding-bottom: .5rem; margin-bottom: 1rem; }
+            padding-bottom: .5rem; margin-bottom: 1rem;
+            display: flex; flex-wrap: wrap; gap: .15rem 1.1rem; }
   .descriptor { margin: 1rem 0; font-size: 1.1rem; }
   .prompt { color: #9fd0ff; margin: 1rem 0; }
   .dialogue { white-space: pre-wrap; margin: 1rem 0; line-height: 1.5; }
@@ -94,9 +95,10 @@ function render(screen) {
   if (screen.header) {
     const h = screen.header;
     const header = el("div", { className: "header" });
-    const addPart = (node) => {
-      if (header.childNodes.length) header.append("  |  ");
-      header.append(node);
+    // Each stat is its own chip; the flex-wrap row spaces them with whitespace
+    // and wraps cleanly on narrow screens instead of running off one long line.
+    const addPart = (content) => {
+      header.append(content instanceof Node ? content : el("span", { textContent: content }));
     };
     addPart(`Day ${h.day}`);
     addPart(h.time);

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -34,6 +34,8 @@ HTML_PAGE = """<!DOCTYPE html>
   button:hover { background: #1f4a63; }
   button.danger { background: #4a1620; border-color: #7a2a35; }
   button.danger:hover { background: #63202c; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  button:disabled:hover { background: #163345; }
   input { width: 100%; padding: .6rem; font-family: monospace; font-size: 1rem;
           background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
           border-radius: 4px; }
@@ -135,9 +137,17 @@ function render(screen) {
   } else if (screen.type === "prompt") {
     app.append(el("div", { className: "descriptor", textContent: screen.text }));
     const inp = el("input", { type: "text" });
-    const submit = () => send(inp.value);
-    inp.onkeydown = (e) => { if (e.key === "Enter") submit(); };
     const b = el("button", { textContent: "Submit" });
+    const valid = () => !screen.numeric ||
+      (inp.value.trim() !== "" && !isNaN(Number(inp.value)));
+    const submit = () => { if (valid()) send(inp.value); };
+    if (screen.numeric) {
+      inp.inputMode = "decimal";
+      inp.placeholder = "Enter a number";
+      inp.oninput = () => { b.disabled = !valid(); };
+      b.disabled = true;  // nothing valid typed yet
+    }
+    inp.onkeydown = (e) => { if (e.key === "Enter") submit(); };
     b.onclick = submit;
     app.append(inp); app.append(b); inp.focus();
   } else if (screen.type === "timed") {

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -37,11 +37,14 @@ HTML_PAGE = """<!DOCTYPE html>
           background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
           border-radius: 4px; }
   .tagline { font-size: .8rem; font-weight: normal; color: #7fb0d0; }
+  .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
+              margin-top: 1.5rem; padding-top: .5rem; }
 </style>
 </head>
 <body>
 <h2>FishE <span class="tagline">— fish a seaside village and build a fortune of $10,000</span></h2>
 <div id="app">Connecting&hellip;</div>
+<p class="controls">Tip: click an option or press its number key (1-9). Enter or Space continues.</p>
 <script>
 let version = -1;
 let currentScreen = null;

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -109,6 +109,7 @@ function render(screen) {
     if (h.location) addPart(h.location);
     if (h.goal) addPart(`Goal: ${h.goal}`);
     app.append(header);
+    document.title = `FishE — Day ${h.day}, $${h.money.toFixed(2)}`;
   }
   if (screen.descriptor) app.append(el("div", { className: "descriptor", textContent: screen.descriptor }));
   if (screen.prompt) app.append(el("div", { className: "prompt", textContent: screen.prompt }));

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -36,6 +36,9 @@ HTML_PAGE = """<!DOCTYPE html>
   button.danger:hover { background: #63202c; }
   button:disabled { opacity: .45; cursor: not-allowed; }
   button:disabled:hover { background: #163345; }
+  button.action { width: auto; text-align: center; padding: .6rem 1.4rem;
+                  background: #1d5a7a; border-color: #2f7ba0; }
+  button.action:hover { background: #246a90; }
   input { width: 100%; padding: .6rem; font-family: monospace; font-size: 1rem;
           background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
           border-radius: 4px; }
@@ -131,13 +134,13 @@ function render(screen) {
     });
   } else if (screen.type === "dialogue") {
     app.append(el("div", { className: "dialogue", textContent: screen.text }));
-    const b = el("button", { textContent: "Continue" });
+    const b = el("button", { textContent: "Continue", className: "action" });
     b.onclick = () => send("");
     app.append(b);
   } else if (screen.type === "prompt") {
     app.append(el("div", { className: "descriptor", textContent: screen.text }));
     const inp = el("input", { type: "text" });
-    const b = el("button", { textContent: "Submit" });
+    const b = el("button", { textContent: "Submit", className: "action" });
     const valid = () => !screen.numeric ||
       (inp.value.trim() !== "" && !isNaN(Number(inp.value)));
     const submit = () => { if (valid()) send(inp.value); };
@@ -152,7 +155,7 @@ function render(screen) {
     app.append(inp); app.append(b); inp.focus();
   } else if (screen.type === "timed") {
     app.append(el("div", { className: "descriptor", textContent: screen.message }));
-    const b = el("button", { textContent: "React!" });
+    const b = el("button", { textContent: "React!", className: "action" });
     b.onclick = () => send("");
     app.append(b);
   }

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -304,6 +304,15 @@ class WebUserInterface(BaseUserInterface):
         self._present({"type": "prompt", "text": promptText})
         return str(self._inputQueue.get())
 
+    def promptForNumber(self, promptText):
+        # Flag the prompt as numeric so the browser can offer a numeric keyboard
+        # and block submission of non-numbers (the base default can't say so).
+        self._present({"type": "prompt", "text": promptText, "numeric": True})
+        try:
+            return float(self._inputQueue.get())
+        except (ValueError, TypeError):
+            return None
+
     def timedKeyPress(self, message):
         self._present({"type": "timed", "message": message})
         startTime = time.time()

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -47,6 +47,7 @@ HTML_PAGE = """<!DOCTYPE html>
               margin-top: 1.5rem; padding-top: .5rem; }
   .low { color: #ff8a8a; font-weight: bold; }
   .notice { color: #9fd0ff; margin-top: 1rem; }
+  .notice.warning { color: #ffcf8f; border-left: 3px solid #c77b2a; padding-left: .6rem; }
 </style>
 </head>
 <body>
@@ -81,7 +82,7 @@ function renderNotice(text, className) {
 }
 function renderDisconnected() {
   currentScreen = null;
-  renderNotice("Lost connection to the game — is it still running? Retrying…");
+  renderNotice("Lost connection to the game — is it still running? Retrying…", "notice warning");
 }
 async function send(value) {
   currentScreen = null;  // ignore stray keypresses until the next screen arrives

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -39,6 +39,7 @@ HTML_PAGE = """<!DOCTYPE html>
   .tagline { font-size: .8rem; font-weight: normal; color: #7fb0d0; }
   .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
               margin-top: 1.5rem; padding-top: .5rem; }
+  .low { color: #ff8a8a; font-weight: bold; }
 </style>
 </head>
 <body>
@@ -92,10 +93,22 @@ function render(screen) {
   if (screen.type === "ended") { app.append("The game has ended. You can close this tab."); return; }
   if (screen.header) {
     const h = screen.header;
-    let line = `Day ${h.day}  |  ${h.time}  |  $${h.money.toFixed(2)}  |  Fish: ${h.fish}  |  Energy: ${h.energy}`;
-    if (h.location) line += `  |  ${h.location}`;
-    if (h.goal) line += `  |  Goal: ${h.goal}`;
-    app.append(el("div", { className: "header", textContent: line }));
+    const header = el("div", { className: "header" });
+    const addPart = (node) => {
+      if (header.childNodes.length) header.append("  |  ");
+      header.append(node);
+    };
+    addPart(`Day ${h.day}`);
+    addPart(h.time);
+    addPart(`$${h.money.toFixed(2)}`);
+    addPart(`Fish: ${h.fish}`);
+    // Below the fishing threshold (10) the player is too tired to fish — flag it.
+    const energy = el("span", { textContent: `Energy: ${h.energy}` });
+    if (h.energy < 10) energy.className = "low";
+    addPart(energy);
+    if (h.location) addPart(h.location);
+    if (h.goal) addPart(`Goal: ${h.goal}`);
+    app.append(header);
   }
   if (screen.descriptor) app.append(el("div", { className: "descriptor", textContent: screen.descriptor }));
   if (screen.prompt) app.append(el("div", { className: "prompt", textContent: screen.prompt }));

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -36,10 +36,11 @@ HTML_PAGE = """<!DOCTYPE html>
   input { width: 100%; padding: .6rem; font-family: monospace; font-size: 1rem;
           background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
           border-radius: 4px; }
+  .tagline { font-size: .8rem; font-weight: normal; color: #7fb0d0; }
 </style>
 </head>
 <body>
-<h2>FishE</h2>
+<h2>FishE <span class="tagline">— fish a seaside village and build a fortune of $10,000</span></h2>
 <div id="app">Connecting&hellip;</div>
 <script>
 let version = -1;

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -41,6 +41,7 @@ HTML_PAGE = """<!DOCTYPE html>
   .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
               margin-top: 1.5rem; padding-top: .5rem; }
   .low { color: #ff8a8a; font-weight: bold; }
+  .notice { color: #9fd0ff; margin-top: 1rem; }
 </style>
 </head>
 <body>
@@ -68,12 +69,14 @@ async function poll() {
   }
   setTimeout(poll, 300);
 }
-function renderDisconnected() {
-  currentScreen = null;
+function renderNotice(text, className) {
   const app = document.getElementById("app");
   app.innerHTML = "";
-  app.append(el("div", { className: "prompt",
-    textContent: "Lost connection to the game — is it still running? Retrying…" }));
+  app.append(el("div", { className: className || "notice", textContent: text }));
+}
+function renderDisconnected() {
+  currentScreen = null;
+  renderNotice("Lost connection to the game — is it still running? Retrying…");
 }
 async function send(value) {
   currentScreen = null;  // ignore stray keypresses until the next screen arrives
@@ -90,8 +93,8 @@ function render(screen) {
   const app = document.getElementById("app");
   app.innerHTML = "";
   currentScreen = screen;  // let keyboard shortcuts act on what's on screen
-  if (!screen || screen.type === "loading") { app.append("Waiting for the game…"); return; }
-  if (screen.type === "ended") { app.append("The game has ended. You can close this tab."); return; }
+  if (!screen || screen.type === "loading") { renderNotice("Waiting for the game…"); return; }
+  if (screen.type === "ended") { renderNotice("The game has ended. You can close this tab."); return; }
   if (screen.header) {
     const h = screen.header;
     const header = el("div", { className: "header" });

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -85,10 +85,13 @@ def test_promptForText_round_trips_text():
     assert box["result"] == "Gilbert"
 
 
-def test_promptForNumber_uses_web_input():
+def test_promptForNumber_marks_screen_numeric_and_parses():
     ui = makeWebUI()
     thread, box = runInThread(lambda: ui.promptForNumber("How much?"))
     waitForScreen(ui, "prompt")
+
+    # the prompt is flagged numeric so the browser can constrain input
+    assert ui.get_state()["screen"].get("numeric") is True
 
     ui.submit_input("12.5")
     thread.join(timeout=2)


### PR DESCRIPTION
## Summary
A multi-round Nielsen/Krug usability pass on the **web front-end** client (`src/ui/webUserInterface.py`). Every commit is one self-contained, heuristic-cited fix, scoped small for review. (Round 1 — keyboard control, destructive-color, disconnect handling — shipped earlier in #91.)

### Round 2 — Onboarding & control discoverability
1. **Tagline** under the heading explains the game and the $10,000 goal before the first click. (Nielsen #10; Krug: answer the obvious question)
2. **Controls hint** makes the keyboard shortcuts visible. (Nielsen #6; Krug: visible options)

### Round 3 — System-status visibility
3. **Low-energy cue** — energy turns bold red below the fishing threshold (10), warning before a wasted trip to the docks. (Nielsen #1, #5)
4. **Tab title** reflects Day + money so progress is visible from a background tab. (Nielsen #1)

### Round 4 — Aesthetic & layout
5. **Status header** is now a flex-wrap row of chips that degrades cleanly on narrow screens instead of one overflowing pipe-separated line. (Nielsen #8)
6. **Loading/ended states** render through a consistent styled notice instead of bare text nodes. (Nielsen #4, #8)

### Round 5 — Numeric input affordance & error prevention
7. **Numeric prompts flagged server-side** (`promptForNumber` tags the screen). (Nielsen #5, #6)
8. **Client guards numeric input** — decimal keypad, placeholder, and Submit/Enter disabled until the value parses as a number, so an invalid amount can't be sent. (Nielsen #5, #6)

### Round 6 — Action affordances & feedback consistency
9. **Single-action buttons** (Continue / React! / Submit) get a distinct accent style so the one thing to do doesn't look like one option among many. (Nielsen #4; Krug: self-evident)
10. **Disconnect banner** restyled as an amber warning, distinct from blue info notices. (Nielsen #9, #1)

## Test plan
- [x] `python3 -m pytest` — 198 passed; client JS passes `node --check`
- [ ] New player sees the tagline + controls hint; pressing a number key chooses an option
- [ ] Energy goes red when < 10; tab title shows Day/money
- [ ] On a phone-width window the status header wraps cleanly
- [ ] A bank/tavern amount field shows a number pad, rejects empty/non-numeric, and only enables Submit when valid
- [ ] Continue/React!/Submit look distinct from option lists; killing the game shows an amber "Lost connection" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_