### PR TITLE
Rebalance the fishing business so the boat is worth buying

### DIFF
--- a/src/business/business.py
+++ b/src/business/business.py
@@ -4,11 +4,12 @@
 # bring in a passive catch each day in exchange for a daily wage. This turns
 # accumulated money into ongoing production rather than just a number that grows.
 
+from fish import fish
+
 BOAT_PRICE = 500
 MAX_WORKERS = 5
 WORKER_DAILY_WAGE = 10
-WORKER_FISH_PER_DAY = 6
-WORKER_CATCH_SPECIES = "Minnow"  # workers bring in the common catch
+WORKER_FISH_PER_DAY = 5
 
 
 def runDailyProduction(player, stats=None):
@@ -36,9 +37,14 @@ def runDailyProduction(player, stats=None):
         return summary
 
     wages = affordable * WORKER_DAILY_WAGE
-    caught = affordable * WORKER_FISH_PER_DAY
     player.money -= wages
-    player.addFish(WORKER_CATCH_SPECIES, caught)
+    # Each worker fishes the same waters as the player, landing a rarity-rolled
+    # species (not just the cheapest one), so the crew's income is competitive
+    # with simply upgrading your own gear.
+    caught = 0
+    for _ in range(affordable):
+        player.addFish(fish.rollFishType(), WORKER_FISH_PER_DAY)
+        caught += WORKER_FISH_PER_DAY
     summary["wagesPaid"] = wages
     summary["fishCaught"] = caught
     if stats is not None:

--- a/tests/business/test_business.py
+++ b/tests/business/test_business.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from src.business import business
 from src.player.player import Player
 from src.stats.stats import Stats
@@ -38,6 +40,22 @@ def test_workers_catch_fish_and_draw_wages():
     assert player.fishCount == expectedFish
     assert player.money == 1000 - expectedWages
     assert stats.totalFishCaught == expectedFish
+
+
+def test_workers_catch_rolled_species_not_just_minnow():
+    # prepare - a boat and one worker; force the rolled species to Bass
+    player = Player()
+    player.hasBoat = True
+    player.workers = 1
+    player.money = 1000
+
+    # call - workers fish a rarity-rolled species, not a hard-coded one
+    with patch.object(business.fish, "rollFishType", return_value="Bass"):
+        business.runDailyProduction(player)
+
+    # check - the catch landed as the rolled species
+    assert player.fishByType.get("Bass") == business.WORKER_FISH_PER_DAY
+    assert "Minnow" not in player.fishByType
 
 
 def test_unaffordable_workers_quit():


### PR DESCRIPTION
## Summary
Addresses the playtest finding in #94: the fishing business was strictly dominated by bait/rod upgrades because workers only ever caught the cheapest species.

- `src/business/business.py`: workers now land a **rarity-rolled species** (`fish.rollFishType`) each day instead of a hard-coded Minnow, so crew income tracks the same value distribution as the player's own fishing. Removed the now-unused `WORKER_CATCH_SPECIES`. `WORKER_FISH_PER_DAY` trimmed 6 → 5 so passive income supplements rather than overshadows active fishing.

## Balance (re-ran the playtest simulation on the real game code)
- Per-worker net income ~$8/day → **~$22/day**; full-crew boat payback ~12 days → **~4–5 days**.
- "Business" strategy time-to-$10k: median **25 days** (vs 20 for pure reinvest) — competitive, no longer a trap, and not dominant over active play.

## Test plan
- [x] `python3 -m compileall -q src` clean
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 211 passed
- [x] New `test_workers_catch_rolled_species_not_just_minnow` (patches `rollFishType`); existing count-based business/timeService tests still hold against `WORKER_FISH_PER_DAY`.

### Triage note
- #20 (shop money recharge) deferred again — it hinges on a design decision (should a depleting shop budget gate how many fish you can sell per day?) that warrants maintainer input rather than autonomous implementation.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_