### PR TITLE
docs: fix save-file manager description (drift from the #89 UI refactor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Once you can afford it, buy a **boat** at the docks ("Manage Boat & Crew") and *
 ### Multiple Save Files
 FishE supports multiple save files, allowing you to maintain different game progressions simultaneously. When you start the game, you'll see a save file manager that displays:
 
-- **Existing Saves**: View all your saved games with their progress (Day, Money, Fish count, Last Modified)
+- **Existing Saves**: each save slot is listed with a snapshot of its progress (Day, Money, and Fish count)
 - **Create New Save**: Start a fresh game in a new save slot
 - **Delete Save**: Remove unwanted save files
-- **Quick Load**: Load any existing save file to continue your adventure
+- **Load**: Pick any existing save slot to continue your adventure
 
 Each save file is stored in its own slot (slot_1, slot_2, etc.) in the `data/` directory, ensuring your saves never conflict with each other.
 


### PR DESCRIPTION
## Summary
A documentation-accuracy sweep (Stage A) of the whole repo against source. One real drift found and fixed:

- **README "Multiple Save Files"** claimed the manager shows each save's **"Last Modified"** time. Since the save manager was routed through the UI (#89), each slot is shown as a menu option labelled `Load Slot N (Day X, $Y, Z fish)` — no last-modified timestamp. Updated the section to match (Day, Money, Fish count; slots chosen as options).

## Swept and verified accurate (no change needed)
- README: web-interface instructions (`examples/web_app.py`, port 8000, stdlib-only), the $10,000 goal, the fishing-business description, and the trunk-based Contributing section.
- `install.sh` / `run.sh`: repo URL and run command match.
- **Schemas:** all persisted fields in `playerJsonReaderWriter` / `statsJsonReaderWriter` / `timeServiceJsonReaderWriter` are present in their `schemas/*.json` (checked programmatically — zero writer-keys missing from schema).

## Test plan
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 211 passed (docs-only change; no code touched)

### Triage note
- #20 (shop money recharge) deferred — design decision pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_