### PR TITLE
Test the pygame UI input primitives via injected events

### DIFF
--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -54,3 +54,78 @@ def test_update_fonts_keeps_fonts_usable_when_tiny():
             assert surface.get_width() > 0 and surface.get_height() > 0
     finally:
         ui.cleanup()
+
+
+# --- interactive input primitives (events injected via patched pygame.event.get) ---
+import contextlib  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+import pygame  # noqa: E402
+
+
+def keydown(key=0, unicode=""):
+    return SimpleNamespace(type=pygame.KEYDOWN, key=key, unicode=unicode)
+
+
+@contextlib.contextmanager
+def injected_events(events):
+    # Feed the given events to the UI's event loop and stub out the per-frame
+    # display flip / clock so the loop runs without a real frame delay.
+    with patch("ui.pygameUserInterface.pygame.event.get", return_value=events), patch(
+        "ui.pygameUserInterface.pygame.display.flip"
+    ), patch("ui.pygameUserInterface.pygame.time.Clock"):
+        yield
+
+
+def test_showDialogue_returns_on_keypress():
+    ui = makeUI()
+    try:
+        ui.currentPrompt.text = "before"
+        with injected_events([keydown()]):
+            ui.showDialogue("some text")
+        assert ui.currentPrompt.text == "What would you like to do?"
+    finally:
+        ui.cleanup()
+
+
+def test_timedKeyPress_returns_nonnegative_seconds():
+    ui = makeUI()
+    try:
+        with injected_events([keydown()]):
+            reaction = ui.timedKeyPress("React!")
+        assert isinstance(reaction, float)
+        assert reaction >= 0.0
+    finally:
+        ui.cleanup()
+
+
+def test_promptForText_collects_typed_characters():
+    ui = makeUI()
+    try:
+        events = [
+            keydown(unicode="h"),
+            keydown(unicode="i"),
+            keydown(key=pygame.K_RETURN),
+        ]
+        with injected_events(events):
+            result = ui.promptForText("Name?")
+        assert result == "hi"
+    finally:
+        ui.cleanup()
+
+
+def test_promptForText_handles_backspace():
+    ui = makeUI()
+    try:
+        events = [
+            keydown(unicode="a"),
+            keydown(unicode="b"),
+            keydown(key=pygame.K_BACKSPACE),
+            keydown(key=pygame.K_RETURN),
+        ]
+        with injected_events(events):
+            result = ui.promptForText("Name?")
+        assert result == "a"
+    finally:
+        ui.cleanup()


### PR DESCRIPTION
## Summary
Stage B test-expansion (continued): the pygame interactive input primitives had zero coverage. This injects events through a patched `pygame.event.get` (with the per-frame `display.flip`/`Clock` stubbed) to exercise their key handling.

- `showDialogue`: a keypress ends the wait and resets the prompt to "What would you like to do?"
- `timedKeyPress`: returns a non-negative float reaction time after a keypress.
- `promptForText`: accumulates typed characters, honors Backspace, and submits on Enter (`"h","i",Enter` → `"hi"`; `"a","b",Backspace,Enter` → `"a"`).

Characterization only — no production code changed; runs headless under dummy SDL.

## Test plan
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 218 passed (4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_