### PR TITLE
Test pygame showOptions selection paths

### DIFF
--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -129,3 +129,35 @@ def test_promptForText_handles_backspace():
         assert result == "a"
     finally:
         ui.cleanup()
+
+
+def test_showOptions_number_key_selects_directly():
+    ui = makeUI()
+    try:
+        with injected_events([keydown(key=pygame.K_2)]):
+            choice = ui.showOptions("Pick", ["A", "B", "C"])
+        assert choice == "2"
+    finally:
+        ui.cleanup()
+
+
+def test_showOptions_arrow_then_enter_selects():
+    ui = makeUI()
+    try:
+        # down moves the highlight from option 1 to option 2, Enter confirms it
+        with injected_events([keydown(key=pygame.K_DOWN), keydown(key=pygame.K_RETURN)]):
+            choice = ui.showOptions("Pick", ["A", "B", "C"])
+        assert choice == "2"
+    finally:
+        ui.cleanup()
+
+
+def test_showOptions_ignores_out_of_range_number():
+    ui = makeUI()
+    try:
+        # "9" exceeds the 2 options and is ignored; "1" then selects
+        with injected_events([keydown(key=pygame.K_9), keydown(key=pygame.K_1)]):
+            choice = ui.showOptions("Pick", ["A", "B"])
+        assert choice == "1"
+    finally:
+        ui.cleanup()


### PR DESCRIPTION
## Summary
Stage B test-expansion (final): `showOptions` — the pygame UI's primary menu loop — was the last interactive method with no coverage.

- `tests/ui/test_pygameUserInterface.py`: a number key selects directly; arrow-down + Enter moves the highlight and confirms (`["A","B","C"]` → "2"); an out-of-range number key (`9` with 2 options) is ignored until a valid one is pressed.

This completes the pygame front-end's interactive coverage (resize/font helpers + `showOptions`/`showDialogue`/`promptForText`/`timedKeyPress`). Characterization only; headless under dummy SDL.

## Test plan
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 221 passed (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_