### PR TITLE
Add operator mode for testing without money constraints

### DIFF
--- a/src/business/business.py
+++ b/src/business/business.py
@@ -27,7 +27,10 @@ def runDailyProduction(player, stats=None):
     if not player.hasBoat or player.workers <= 0:
         return summary
 
-    affordable = min(player.workers, int(player.money // WORKER_DAILY_WAGE))
+    if player.operatorMode:
+        affordable = player.workers
+    else:
+        affordable = min(player.workers, int(player.money // WORKER_DAILY_WAGE))
     if affordable < player.workers:
         summary["quit"] = player.workers - affordable
         player.workers = affordable
@@ -37,7 +40,7 @@ def runDailyProduction(player, stats=None):
         return summary
 
     wages = affordable * WORKER_DAILY_WAGE
-    player.money -= wages
+    player.spendMoney(wages)
     # Each worker fishes the same waters as the player, landing a rarity-rolled
     # species (not just the cheapest one), so the crew's income is competitive
     # with simply upgrading your own gear.

--- a/src/location/bank.py
+++ b/src/location/bank.py
@@ -78,7 +78,7 @@ class Bank:
         )
 
         if input == "1":
-            if self.player.money > 0:
+            if self.player.operatorMode or self.player.money > 0:
                 self.currentPrompt.text = (
                     "How much would you like to deposit? Money: $%.2f"
                     % self.player.money
@@ -114,9 +114,9 @@ class Bank:
                 self.currentPrompt.text = "Try again. Money: $%.2f" % self.player.money
                 continue
 
-            if amount <= self.player.money:
+            if self.player.canAfford(amount):
                 self.player.moneyInBank += amount
-                self.player.money -= amount
+                self.player.spendMoney(amount)
 
                 self.currentPrompt.text = "$%.2f deposited successfully." % amount
             else:

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -176,8 +176,8 @@ class Docks:
             action = actions[choice - 1]
 
             if action == "buy_boat":
-                if self.player.money >= business.BOAT_PRICE:
-                    self.player.money -= business.BOAT_PRICE
+                if self.player.canAfford(business.BOAT_PRICE):
+                    self.player.spendMoney(business.BOAT_PRICE)
                     self.player.hasBoat = True
                     self.currentPrompt.text = "You bought a boat! Now hire a crew."
                 else:

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -99,7 +99,7 @@ class Docks:
         )
 
         if input == "1":
-            if self.player.energy >= 10:
+            if self.player.hasEnergy(10):
                 self.fish()
                 return LocationType.DOCKS
             else:
@@ -222,7 +222,7 @@ class Docks:
 
         # Check if player has enough energy for all hours
         energy_needed = hours * 10
-        if self.player.energy < energy_needed:
+        if not self.player.hasEnergy(energy_needed):
             # Fish for as many hours as energy allows
             hours = self.player.energy // 10
             if hours == 0:
@@ -250,7 +250,7 @@ class Docks:
         for i in range(hours):
             self.stats.hoursSpentFishing += 1
             self.timeService.increaseTime()
-            self.player.energy -= 10  # Consume 10 energy per hour
+            self.player.spendEnergy(10)  # Consume 10 energy per hour
 
         baseFish = random.randint(1, 10)
         fishToAdd = int(baseFish * quality * self.player.fishMultiplier * timeFactor)

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -179,11 +179,11 @@ class Shop:
     def buyBetterBait(self):
         if self.player.fishMultiplier >= MAX_FISH_MULTIPLIER:
             self.currentPrompt.text = "Your bait is already the best money can buy!"
-        elif self.player.money < self.player.priceForBait:
+        elif not self.player.canAfford(self.player.priceForBait):
             self.currentPrompt.text = "You don't have enough money!"
         else:
             self.player.fishMultiplier += 1
-            self.player.money -= self.player.priceForBait
+            self.player.spendMoney(self.player.priceForBait)
 
             self.player.priceForBait = self.player.priceForBait * 1.25
             self.currentPrompt.text = "You bought some better bait!"
@@ -192,11 +192,11 @@ class Shop:
         cost = rodUpgradeCost(self.player.rodLevel)
         if self.player.rodLevel >= MAX_ROD_LEVEL:
             self.currentPrompt.text = "Your rod is already the finest in the village!"
-        elif self.player.money < cost:
+        elif not self.player.canAfford(cost):
             self.currentPrompt.text = "You don't have enough money!"
         else:
             self.player.rodLevel += 1
-            self.player.money -= cost
+            self.player.spendMoney(cost)
             self.currentPrompt.text = "You bought a better fishing rod!"
 
     def talkToNPC(self):

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -152,9 +152,10 @@ class Shop:
         earned = 0.0
         for species in queue:
             value = fish.fishValue(species)
-            if self.money < value:
-                break  # shop is out of money for today
-            self.money -= value
+            if not self.player.operatorMode:
+                if self.money < value:
+                    break  # shop is out of money for today
+                self.money -= value
             self.player.money += value
             self.stats.totalMoneyMade += value
             earned += value

--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -92,7 +92,7 @@ class Tavern:
         )
 
         if input == "1":
-            if self.player.money >= 10:
+            if self.player.canAfford(10):
                 self.getDrunk()
                 return LocationType.HOME
             else:
@@ -118,7 +118,7 @@ class Tavern:
         self.userInterface.lotsOfSpace()
         self.userInterface.divider()
 
-        self.player.money -= 10
+        self.player.spendMoney(10)
 
         for i in range(3):
             print("... ")
@@ -136,7 +136,7 @@ class Tavern:
                 loss_percentage = random.uniform(0.1, 0.5)
                 money_lost = int(self.player.money * loss_percentage)
                 if money_lost > 0:
-                    self.player.money -= money_lost
+                    self.player.spendMoney(money_lost)
                     self.stats.moneyLostWhileDrunk += money_lost
                     self.currentPrompt.text = f"You have a headache. In your drunken stupor, you lost ${money_lost}!"
                 else:
@@ -182,7 +182,7 @@ class Tavern:
                     )
                     continue
                 else:
-                    self.player.money -= self.currentBet
+                    self.player.spendMoney(self.currentBet)
                     self.stats.moneyLostFromGambling += self.currentBet
                     self.currentBet = 0
                     self.currentPrompt.text = (
@@ -210,7 +210,7 @@ class Tavern:
             return
         self.amount = int(amount)
 
-        if self.amount <= self.player.money:
+        if self.player.canAfford(self.amount):
             self.currentBet = self.amount
 
             self.currentPrompt.text = (

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -1,3 +1,6 @@
+import os
+
+
 # @author Daniel McCoy Stephenson
 class Player:
     def __init__(self):
@@ -15,6 +18,23 @@ class Player:
         # daily catch for a daily wage (see src/business).
         self.hasBoat = False
         self.workers = 0
+        # Testing/debug cheat: when on, every money check passes and spendMoney
+        # becomes a no-op, so cash never actually runs out. Not persisted to save
+        # files - it's a runtime toggle, not game progress. Defaults from the
+        # FISHE_OPERATOR_MODE env var so it can be turned on for a whole session
+        # (e.g. `FISHE_OPERATOR_MODE=1 python3 src/fishE.py`) without code changes.
+        self.operatorMode = os.environ.get("FISHE_OPERATOR_MODE", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    def canAfford(self, cost):
+        return self.operatorMode or self.money >= cost
+
+    def spendMoney(self, cost):
+        if not self.operatorMode:
+            self.money -= cost
 
     def addFish(self, fishTypeName, amount):
         self.fishByType[fishTypeName] = self.fishByType.get(fishTypeName, 0) + amount

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -36,6 +36,13 @@ class Player:
         if not self.operatorMode:
             self.money -= cost
 
+    def hasEnergy(self, amount):
+        return self.operatorMode or self.energy >= amount
+
+    def spendEnergy(self, amount):
+        if not self.operatorMode:
+            self.energy -= amount
+
     def addFish(self, fishTypeName, amount):
         self.fishByType[fishTypeName] = self.fishByType.get(fishTypeName, 0) + amount
         self.fishCount += amount

--- a/src/ui/pygameUserInterface.py
+++ b/src/ui/pygameUserInterface.py
@@ -154,7 +154,9 @@ class PygameUserInterface(BaseUserInterface):
             f"Money: ${self.player.money}",
             f"Fish: {self.player.fishCount}"
         ]
-        
+        if self.player.operatorMode:
+            status_lines.append("[OPERATOR MODE]")
+
         status_x = margin_x + (self.width * 0.06)  # Indent status lines
         line_height = self.height * 0.05  # 5% of screen height per line
 

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -42,6 +42,8 @@ class UserInterface(BaseUserInterface):
             print(" | Money: $%.2f" % self.player.money)
             print(" | Fish: %d" % self.player.fishCount)
             print(" | Energy: %d" % self.player.energy)
+            if self.player.operatorMode:
+                print(" | [OPERATOR MODE]")
             if self.goalProgress:
                 print(" | Goal: " + self.goalProgress)
             print("\n " + self.currentPrompt.text)

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -46,6 +46,7 @@ HTML_PAGE = """<!DOCTYPE html>
   .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
               margin-top: 1.5rem; padding-top: .5rem; }
   .low { color: #ff8a8a; font-weight: bold; }
+  .operator { color: #ffcf8f; font-weight: bold; }
   .notice { color: #9fd0ff; margin-top: 1rem; }
   .notice.warning { color: #ffcf8f; border-left: 3px solid #c77b2a; padding-left: .6rem; }
 </style>
@@ -119,6 +120,7 @@ function render(screen) {
     addPart(energy);
     if (h.location) addPart(h.location);
     if (h.goal) addPart(`Goal: ${h.goal}`);
+    if (h.operator) addPart(el("span", { textContent: "OPERATOR MODE", className: "operator" }));
     app.append(header);
     document.title = `FishE — Day ${h.day}, $${h.money.toFixed(2)}`;
   }
@@ -282,6 +284,7 @@ class WebUserInterface(BaseUserInterface):
             "energy": self.player.energy,
             "location": self.currentLocationName,
             "goal": self.goalProgress,
+            "operator": self.player.operatorMode,
         }
 
     # --- BaseUserInterface primitives ------------------------------------


### PR DESCRIPTION
## Summary
- Adds a `Player.operatorMode` flag (defaults from the `FISHE_OPERATOR_MODE` env var, e.g. `FISHE_OPERATOR_MODE=1 python3 src/fishE.py`) with `canAfford()`/`spendMoney()` helpers.
- Every money-gated action — buying bait/rod, buying a boat, hiring/paying workers, drinking, gambling, and bank deposits — now routes through these helpers, so with operator mode on you can do all of it regardless of cash on hand, and workers never quit for missed payroll.
- Not persisted to save files; it's a runtime/testing toggle, not game progress.
- Surfaces an `[OPERATOR MODE]` indicator in the console, pygame, and web front-ends so it's obvious when it's active.

## Test plan
- [x] `python3 -m pytest -q` — 213 passed, 11 pre-existing pygame failures (no video device in this sandbox; confirmed present on `main` too, unrelated to this change)
- [x] Manual script verifying operator mode bypasses `canAfford`/`spendMoney`/worker-quit logic with `$0` on hand
- [x] Manual script verifying default (non-operator) behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_