### PR TITLE
Add Home Ownership (trade-up) and Investment Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Build a fortune of **$10,000** in total wealth (cash on hand plus savings in the
 ### Fishing Business
 Once you can afford it, buy a **boat** at the docks ("Manage Boat & Crew") and **hire workers**. Each day your crew brings in a passive catch in exchange for a daily wage — turning saved-up money into ongoing production. If you over-hire and can't make payroll, the workers you can't pay quit, so keep enough cash on hand to cover wages.
 
+### Home Ownership
+Your home is a property too. From the Home menu, choose **Manage Home** to see your current tier and upgrade to the next one: Driftwood Shack → Cozy Cottage → Sturdy Cabin → Waterfront Manor. Each upgrade costs money but raises the energy cap you refill to when you sleep (so you can fish longer between rests) and adds a small passive daily rental income, paid out automatically every new day alongside your bank interest and any crew wages.
+
 ### Selling Fish
 Sell your catch at the shop. The shop has a limited amount of money each day that refills overnight, so a very large haul may sell out the shop and need to be finished the next day — sell regularly, and park your earnings in the bank or reinvest them in gear and your crew.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Build a fortune of **$10,000** in total wealth (cash on hand plus savings in the
 Once you can afford it, buy a **boat** at the docks ("Manage Boat & Crew") and **hire workers**. Each day your crew brings in a passive catch in exchange for a daily wage — turning saved-up money into ongoing production. If you over-hire and can't make payroll, the workers you can't pay quit, so keep enough cash on hand to cover wages.
 
 ### Home Ownership
-Your home is a property too. From the Home menu, choose **Manage Home** to see your current tier and upgrade to the next one: Driftwood Shack → Cozy Cottage → Sturdy Cabin → Waterfront Manor. Each upgrade costs money but raises the energy cap you refill to when you sleep (so you can fish longer between rests) and adds a small passive daily rental income, paid out automatically every new day alongside your bank interest and any crew wages.
+Your home has tiers too: Driftwood Shack → Cozy Cottage → Sturdy Cabin → Waterfront Manor. From the Home menu, choose **Manage Home** to trade your current place in for a nicer (or more modest) one — the price is the difference between what you get for your old home and what the new one costs, so moving up costs money and moving down puts cash back in your pocket. A bigger home is pure personal comfort: it raises the energy cap you refill to when you sleep, letting you fish longer between rests.
+
+### Investment Properties
+Separately from where you live, you can build a real-estate portfolio. At the bank, choose **Manage Investment Properties** to buy rental units around the village — Dockside Cottage, Fisherman's Rowhouse, Harborview Flat — that you don't live in yourself. Every unit you own pays out its own daily rental income automatically each new day, alongside bank interest and any crew wages, and any unit can be sold back for a portion of its price.
 
 ### Selling Fish
 Sell your catch at the shop. The shop has a limited amount of money each day that refills overnight, so a very large haul may sell out the shop and need to be finished the next day — sell regularly, and park your earnings in the bank or reinvest them in gear and your crew.

--- a/schemas/player.json
+++ b/schemas/player.json
@@ -24,7 +24,7 @@
         "energy": {
             "type": "integer",
             "minimum": 0,
-            "maximum": 100
+            "maximum": 200
         },
         "rodLevel": {
             "type": "integer",
@@ -50,6 +50,10 @@
         },
         "businessName": {
             "type": "string"
+        },
+        "homeTier": {
+            "type": "integer",
+            "minimum": 1
         }
     },
     "required": [

--- a/schemas/player.json
+++ b/schemas/player.json
@@ -54,6 +54,13 @@
         "homeTier": {
             "type": "integer",
             "minimum": 1
+        },
+        "rentalProperties": {
+            "type": "array",
+            "items": {
+                "type": "integer",
+                "minimum": 1
+            }
         }
     },
     "required": [

--- a/schemas/stats.json
+++ b/schemas/stats.json
@@ -51,6 +51,14 @@
         "daysInBusiness": {
             "type": "integer",
             "description": "The number of days the fishing business has produced a catch."
+        },
+        "totalRentalIncome": {
+            "type": "number",
+            "description": "The lifetime total of passive rental income earned from the player's home."
+        },
+        "highestHomeTier": {
+            "type": "integer",
+            "description": "The highest home tier the player has owned."
         }
     }
 }

--- a/schemas/stats.json
+++ b/schemas/stats.json
@@ -54,11 +54,15 @@
         },
         "totalRentalIncome": {
             "type": "number",
-            "description": "The lifetime total of passive rental income earned from the player's home."
+            "description": "The lifetime total of passive rental income earned from investment properties."
         },
         "highestHomeTier": {
             "type": "integer",
             "description": "The highest home tier the player has owned."
+        },
+        "totalPropertiesBought": {
+            "type": "integer",
+            "description": "The lifetime number of investment properties bought."
         }
     }
 }

--- a/src/achievements/achievements.py
+++ b/src/achievements/achievements.py
@@ -73,6 +73,18 @@ MILESTONES = [
         "threshold": 4,
         "description": "Own the finest home in the village",
     },
+    {
+        "name": "Landlord",
+        "stat": "totalPropertiesBought",
+        "threshold": 1,
+        "description": "Buy your first investment property",
+    },
+    {
+        "name": "Property Mogul",
+        "stat": "totalPropertiesBought",
+        "threshold": 5,
+        "description": "Buy 5 investment properties over your career",
+    },
 ]
 
 

--- a/src/achievements/achievements.py
+++ b/src/achievements/achievements.py
@@ -61,6 +61,18 @@ MILESTONES = [
         "threshold": 500,
         "description": "Have your crew catch 500 fish total",
     },
+    {
+        "name": "Homeowner",
+        "stat": "highestHomeTier",
+        "threshold": 2,
+        "description": "Upgrade your home for the first time",
+    },
+    {
+        "name": "Waterfront Manor",
+        "stat": "highestHomeTier",
+        "threshold": 4,
+        "description": "Own the finest home in the village",
+    },
 ]
 
 
@@ -82,7 +94,10 @@ def getNewlyEarned(stats):
     """
     newly = []
     for milestone in MILESTONES:
-        if isEarned(milestone, stats) and milestone["name"] not in stats.earnedMilestones:
+        if (
+            isEarned(milestone, stats)
+            and milestone["name"] not in stats.earnedMilestones
+        ):
             stats.earnedMilestones.append(milestone["name"])
             newly.append(milestone)
     return newly

--- a/src/housing/housing.py
+++ b/src/housing/housing.py
@@ -1,0 +1,51 @@
+# @author Daniel McCoy Stephenson
+#
+# Home ownership: a second property-ownership track alongside the fishing
+# business (see src/business). Upgrading your home raises the energy cap you
+# refill to when you sleep and adds a small passive daily rental income (a
+# spare room let out to visiting fishermen), independent of any crew wages.
+
+# Housing tiers: tier 1 is exactly today's numbers (free, 100 energy, no
+# income), so existing saves and default-player behavior are unchanged until a
+# player chooses to upgrade - the same backward-compat approach BOAT_TIERS
+# uses in src/business/business.py.
+HOUSING_TIERS = [
+    {"name": "Driftwood Shack", "cost": 0, "maxEnergy": 100, "dailyRentalIncome": 0},
+    {"name": "Cozy Cottage", "cost": 750, "maxEnergy": 120, "dailyRentalIncome": 5},
+    {"name": "Sturdy Cabin", "cost": 3000, "maxEnergy": 150, "dailyRentalIncome": 15},
+    {
+        "name": "Waterfront Manor",
+        "cost": 10000,
+        "maxEnergy": 200,
+        "dailyRentalIncome": 40,
+    },
+]
+
+
+def currentTier(player):
+    """Resolve the player's effective home tier (always >= 1). Older
+    saves/tests may never touch homeTier, so an unset (0) tier is treated as
+    tier 1 - the original Driftwood Shack."""
+    return player.homeTier if player.homeTier > 0 else 1
+
+
+def tierInfo(tier):
+    return HOUSING_TIERS[tier - 1]
+
+
+def maxEnergy(player):
+    return tierInfo(currentTier(player))["maxEnergy"]
+
+
+def runDailyRentalIncome(player, stats=None):
+    """Apply one day of passive rental income from the player's home and
+    return the amount earned. A no-op at tier 1, which pays no rent."""
+    income = tierInfo(currentTier(player))["dailyRentalIncome"]
+    if income <= 0:
+        return 0
+
+    player.money += income
+    if stats is not None:
+        stats.totalRentalIncome += income
+        stats.totalMoneyMade += income
+    return income

--- a/src/housing/housing.py
+++ b/src/housing/housing.py
@@ -1,24 +1,20 @@
 # @author Daniel McCoy Stephenson
 #
-# Home ownership: a second property-ownership track alongside the fishing
-# business (see src/business). Upgrading your home raises the energy cap you
-# refill to when you sleep and adds a small passive daily rental income (a
-# spare room let out to visiting fishermen), independent of any crew wages.
+# Home ownership: the place you live. Moving to a nicer (or more modest) home
+# trades in your current one for the target tier - the net cost is the target
+# tier's price minus your current tier's resale value, so upgrading costs the
+# difference and downgrading puts cash back in your pocket. Benefits are
+# purely personal comfort (a higher energy cap): since you live here, there's
+# no rental income - that's what investment properties are for (see
+# src/investments), which the player owns but doesn't live in.
 
-# Housing tiers: tier 1 is exactly today's numbers (free, 100 energy, no
-# income), so existing saves and default-player behavior are unchanged until a
-# player chooses to upgrade - the same backward-compat approach BOAT_TIERS
-# uses in src/business/business.py.
+# Tier 1 is exactly today's numbers (free, 100 energy), so existing saves and
+# default-player behavior are unchanged until a player chooses to move.
 HOUSING_TIERS = [
-    {"name": "Driftwood Shack", "cost": 0, "maxEnergy": 100, "dailyRentalIncome": 0},
-    {"name": "Cozy Cottage", "cost": 750, "maxEnergy": 120, "dailyRentalIncome": 5},
-    {"name": "Sturdy Cabin", "cost": 3000, "maxEnergy": 150, "dailyRentalIncome": 15},
-    {
-        "name": "Waterfront Manor",
-        "cost": 10000,
-        "maxEnergy": 200,
-        "dailyRentalIncome": 40,
-    },
+    {"name": "Driftwood Shack", "cost": 0, "resaleValue": 0, "maxEnergy": 100},
+    {"name": "Cozy Cottage", "cost": 750, "resaleValue": 525, "maxEnergy": 120},
+    {"name": "Sturdy Cabin", "cost": 3000, "resaleValue": 2100, "maxEnergy": 150},
+    {"name": "Waterfront Manor", "cost": 10000, "resaleValue": 7000, "maxEnergy": 200},
 ]
 
 
@@ -37,15 +33,27 @@ def maxEnergy(player):
     return tierInfo(currentTier(player))["maxEnergy"]
 
 
-def runDailyRentalIncome(player, stats=None):
-    """Apply one day of passive rental income from the player's home and
-    return the amount earned. A no-op at tier 1, which pays no rent."""
-    income = tierInfo(currentTier(player))["dailyRentalIncome"]
-    if income <= 0:
-        return 0
+def netCostToMove(player, targetTier):
+    """Net cost to trade the current home in for targetTier: the target's
+    price minus the current home's resale value. Negative means the move
+    pays the player cash back (moving to a more modest home)."""
+    current = currentTier(player)
+    return tierInfo(targetTier)["cost"] - tierInfo(current)["resaleValue"]
 
-    player.money += income
+
+def moveHome(player, targetTier, stats=None):
+    """Trade the current home in for targetTier. Returns True if the move was
+    made; False if it would cost money the player doesn't have (a cash-back
+    move always succeeds)."""
+    netCost = netCostToMove(player, targetTier)
+    if netCost > 0:
+        if not player.canAfford(netCost):
+            return False
+        player.spendMoney(netCost)
+    else:
+        player.money += -netCost
+
+    player.homeTier = targetTier
     if stats is not None:
-        stats.totalRentalIncome += income
-        stats.totalMoneyMade += income
-    return income
+        stats.highestHomeTier = max(stats.highestHomeTier, targetTier)
+    return True

--- a/src/investments/investments.py
+++ b/src/investments/investments.py
@@ -1,0 +1,64 @@
+# @author Daniel McCoy Stephenson
+#
+# Investment properties: rental units elsewhere in the village that the
+# player owns but doesn't live in - unlike src/housing (the player's own
+# home), these are pure income assets, the same "you don't personally staff
+# it, but it earns" idea as the fishing business' hired crew (see
+# src/business). Any number of units can be owned at once, each paying its
+# daily rental income automatically every new day, and any unit can be sold
+# back for a portion of its price.
+
+PROPERTY_TYPES = [
+    {"name": "Dockside Cottage", "cost": 1200, "resaleValue": 840, "dailyIncome": 15},
+    {
+        "name": "Fisherman's Rowhouse",
+        "cost": 4000,
+        "resaleValue": 2800,
+        "dailyIncome": 45,
+    },
+    {"name": "Harborview Flat", "cost": 9000, "resaleValue": 6300, "dailyIncome": 90},
+]
+
+
+def typeInfo(typeId):
+    return PROPERTY_TYPES[typeId - 1]
+
+
+def countOwned(player, typeId):
+    return player.rentalProperties.count(typeId)
+
+
+def buyProperty(player, typeId, stats=None):
+    """Buy one unit of the given property type. Returns True if bought."""
+    cost = typeInfo(typeId)["cost"]
+    if not player.canAfford(cost):
+        return False
+    player.spendMoney(cost)
+    player.rentalProperties.append(typeId)
+    if stats is not None:
+        stats.totalPropertiesBought += 1
+    return True
+
+
+def sellProperty(player, typeId):
+    """Sell one owned unit of the given property type for its resale value.
+    Returns True if a unit was found and sold."""
+    if typeId not in player.rentalProperties:
+        return False
+    player.rentalProperties.remove(typeId)
+    player.money += typeInfo(typeId)["resaleValue"]
+    return True
+
+
+def runDailyIncome(player, stats=None):
+    """Apply one day of rental income from every owned property and return
+    the total earned."""
+    if not player.rentalProperties:
+        return 0
+
+    income = sum(typeInfo(typeId)["dailyIncome"] for typeId in player.rentalProperties)
+    player.money += income
+    if stats is not None:
+        stats.totalRentalIncome += income
+        stats.totalMoneyMade += income
+    return income

--- a/src/location/bank.py
+++ b/src/location/bank.py
@@ -6,6 +6,7 @@ from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
 from business import business
+from investments import investments
 
 
 # @author Daniel McCoy Stephenson
@@ -32,47 +33,47 @@ class Bank:
                 {
                     "question": "Tell me about yourself.",
                     "response": "I've worked at this bank for fifteen years and I take pride in keeping everyone's money safe. "
-                               "My grandmother taught me the value of saving, and I've helped many fishermen in this village "
-                               "secure their futures. A penny saved is a penny earned, as they say!"
+                    "My grandmother taught me the value of saving, and I've helped many fishermen in this village "
+                    "secure their futures. A penny saved is a penny earned, as they say!",
                 },
                 {
                     "question": "How does the bank work?",
                     "response": "The bank is simple and safe! You can deposit money when you have some on hand, "
-                               "and withdraw it whenever you need. We keep your money secure - "
-                               "no risk of losing it to gambling or spending it accidentally! "
-                               "Plus, your savings earn interest over time. The more you save, the more you earn. "
-                               "It's the smart way to grow your wealth!"
+                    "and withdraw it whenever you need. We keep your money secure - "
+                    "no risk of losing it to gambling or spending it accidentally! "
+                    "Plus, your savings earn interest over time. The more you save, the more you earn. "
+                    "It's the smart way to grow your wealth!",
                 },
                 {
                     "question": "Tell me about interest rates.",
                     "response": "Ah yes, interest! Every day that passes, your savings grow by a small percentage. "
-                               "It might not seem like much at first, but over time it really adds up! "
-                               "The interest is automatically added to your bank account. "
-                               "Think of it as the bank paying you for keeping your money with us. "
-                               "The more you save, the more interest you earn!"
+                    "It might not seem like much at first, but over time it really adds up! "
+                    "The interest is automatically added to your bank account. "
+                    "Think of it as the bank paying you for keeping your money with us. "
+                    "The more you save, the more interest you earn!",
                 },
                 {
                     "question": "Should I save or spend my money?",
                     "response": "That's the eternal question, isn't it? Here's my advice: "
-                               "Keep some money on hand for daily needs - buying bait, paying for drinks, gambling if you must. "
-                               "But save the rest in the bank! Your savings will grow with interest, "
-                               "and you'll have a nice cushion for the future. "
-                               "Many fishermen spend everything they earn and have nothing to show for it. "
-                               "Be smarter than that!"
+                    "Keep some money on hand for daily needs - buying bait, paying for drinks, gambling if you must. "
+                    "But save the rest in the bank! Your savings will grow with interest, "
+                    "and you'll have a nice cushion for the future. "
+                    "Many fishermen spend everything they earn and have nothing to show for it. "
+                    "Be smarter than that!",
                 },
                 {
                     "question": "What's the most important financial advice?",
                     "response": "Save regularly, even if it's just a little bit. Every coin counts! "
-                               "Don't gamble away your hard-earned money - the odds are rarely in your favor. "
-                               "Invest in good bait to improve your catches, but save the profits. "
-                               "And remember: it's not about how much you earn, it's about how much you keep. "
-                               "That's the secret to real wealth!"
+                    "Don't gamble away your hard-earned money - the odds are rarely in your favor. "
+                    "Invest in good bait to improve your catches, but save the profits. "
+                    "And remember: it's not about how much you earn, it's about how much you keep. "
+                    "That's the secret to real wealth!",
                 },
                 {
                     "question": "What do you think of my fishing business?",
                     "response": self._businessDialogue,
                 },
-            ]
+            ],
         )
 
     def _businessDialogue(self):
@@ -98,12 +99,17 @@ class Bank:
         return (
             "Your crew's brought in $%d in wages paid out so far - quite the "
             "little enterprise! Don't let it all burn a hole in your pocket, "
-            "park some of it here and let it earn interest."
-            % self.stats.totalWagesPaid
+            "park some of it here and let it earn interest." % self.stats.totalWagesPaid
         )
 
     def run(self):
-        li = ["Make a Deposit", "Make a Withdrawal", "Talk to %s" % self.npc.name, "Go to docks"]
+        li = [
+            "Make a Deposit",
+            "Make a Withdrawal",
+            "Talk to %s" % self.npc.name,
+            "Manage Investment Properties",
+            "Go to docks",
+        ]
         input = self.userInterface.showOptions(
             "You're at the front of the line and the teller asks you what you want to do.",
             li,
@@ -136,8 +142,69 @@ class Bank:
             return LocationType.BANK
 
         elif input == "4":
+            self.manageInvestments()
+            return LocationType.BANK
+
+        elif input == "5":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
+
+    def _investmentsStatus(self):
+        lines = ["Investment Properties:"]
+        if not self.player.rentalProperties:
+            lines.append("You don't own any yet - they pay rental income daily.")
+        else:
+            for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
+                owned = investments.countOwned(self.player, typeId)
+                if owned:
+                    info = investments.typeInfo(typeId)
+                    lines.append(
+                        "%s x%d - $%d/day each"
+                        % (info["name"], owned, info["dailyIncome"])
+                    )
+        return "\n".join(lines)
+
+    def manageInvestments(self):
+        while True:
+            options = []
+            actions = []
+            for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
+                info = investments.typeInfo(typeId)
+                options.append(
+                    "Buy a %s ($%d, earns $%d/day)"
+                    % (info["name"], info["cost"], info["dailyIncome"])
+                )
+                actions.append(("buy", typeId))
+            for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
+                if investments.countOwned(self.player, typeId) > 0:
+                    info = investments.typeInfo(typeId)
+                    options.append(
+                        "Sell a %s (+$%d)" % (info["name"], info["resaleValue"])
+                    )
+                    actions.append(("sell", typeId))
+            options.append("Back")
+            actions.append(("back", None))
+
+            choice = int(
+                self.userInterface.showOptions(self._investmentsStatus(), options)
+            )
+            action, typeId = actions[choice - 1]
+
+            if action == "buy":
+                if investments.buyProperty(self.player, typeId, self.stats):
+                    self.currentPrompt.text = (
+                        "You bought a %s!" % investments.typeInfo(typeId)["name"]
+                    )
+                else:
+                    self.currentPrompt.text = "You can't afford that property yet."
+            elif action == "sell":
+                investments.sellProperty(self.player, typeId)
+                self.currentPrompt.text = (
+                    "You sold a %s." % investments.typeInfo(typeId)["name"]
+                )
+            elif action == "back":
+                self.currentPrompt.text = "What would you like to do?"
+                return
 
     def deposit(self):
         while True:

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -58,22 +58,31 @@ class Home:
         info = housing.tierInfo(tier)
         lines = [
             "%s (tier %d/%d)" % (info["name"], tier, len(housing.HOUSING_TIERS)),
-            "Energy cap: %d. Daily rental income: $%d."
-            % (info["maxEnergy"], info["dailyRentalIncome"]),
+            "Energy cap: %d." % info["maxEnergy"],
         ]
         if tier < len(housing.HOUSING_TIERS):
             nextInfo = housing.tierInfo(tier + 1)
+            netCost = housing.netCostToMove(self.player, tier + 1)
             lines.append(
-                "Upgrade to a %s for $%d: energy cap %d, rental income $%d/day."
+                "Move to a %s for $%d net (energy cap %d): you'll sell your "
+                "%s and put the proceeds toward the new place."
+                % (nextInfo["name"], netCost, nextInfo["maxEnergy"], info["name"])
+            )
+        if tier > 1:
+            prevInfo = housing.tierInfo(tier - 1)
+            netCost = housing.netCostToMove(self.player, tier - 1)
+            lines.append(
+                "Move down to a %s (energy cap %d): %s."
                 % (
-                    nextInfo["name"],
-                    nextInfo["cost"],
-                    nextInfo["maxEnergy"],
-                    nextInfo["dailyRentalIncome"],
+                    prevInfo["name"],
+                    prevInfo["maxEnergy"],
+                    (
+                        "you'll pocket $%d" % -netCost
+                        if netCost <= 0
+                        else "costs $%d net" % netCost
+                    ),
                 )
             )
-        else:
-            lines.append("You already own the finest home in the village.")
         return "\n".join(lines)
 
     def manageHome(self):
@@ -83,27 +92,28 @@ class Home:
             actions = []
             if tier < len(housing.HOUSING_TIERS):
                 nextInfo = housing.tierInfo(tier + 1)
-                options.append(
-                    "Upgrade to a %s ($%d)" % (nextInfo["name"], nextInfo["cost"])
-                )
-                actions.append("upgrade")
+                netCost = housing.netCostToMove(self.player, tier + 1)
+                options.append("Move to a %s ($%d net)" % (nextInfo["name"], netCost))
+                actions.append(("move", tier + 1))
+            if tier > 1:
+                prevInfo = housing.tierInfo(tier - 1)
+                netCost = housing.netCostToMove(self.player, tier - 1)
+                label = "+$%d" % -netCost if netCost <= 0 else "$%d net" % netCost
+                options.append("Move down to a %s (%s)" % (prevInfo["name"], label))
+                actions.append(("move", tier - 1))
             options.append("Back")
-            actions.append("back")
+            actions.append(("back", None))
 
             choice = int(self.userInterface.showOptions(self._housingStatus(), options))
-            action = actions[choice - 1]
+            action, targetTier = actions[choice - 1]
 
-            if action == "upgrade":
-                nextInfo = housing.tierInfo(tier + 1)
-                if self.player.canAfford(nextInfo["cost"]):
-                    self.player.spendMoney(nextInfo["cost"])
-                    self.player.homeTier = tier + 1
-                    self.stats.highestHomeTier = max(
-                        self.stats.highestHomeTier, self.player.homeTier
+            if action == "move":
+                if housing.moveHome(self.player, targetTier, self.stats):
+                    self.currentPrompt.text = (
+                        "You moved into a %s!" % housing.tierInfo(targetTier)["name"]
                     )
-                    self.currentPrompt.text = "You upgraded to a %s!" % nextInfo["name"]
                 else:
-                    self.currentPrompt.text = "You can't afford that upgrade yet."
+                    self.currentPrompt.text = "You can't afford that move yet."
             elif action == "back":
                 self.currentPrompt.text = "What would you like to do?"
                 return
@@ -123,7 +133,6 @@ class Home:
             "",
             "Home: %s (tier %d/%d)"
             % (homeInfo["name"], homeTier, len(housing.HOUSING_TIERS)),
-            "Lifetime Rental Income: %d" % self.stats.totalRentalIncome,
         ]
         if self.player.hasBoat:
             lines += [
@@ -133,6 +142,12 @@ class Home:
                 "Crew Hired (lifetime): %d" % self.stats.totalWorkersHired,
                 "Fish Caught by Crew: %d" % self.stats.totalFishCaughtByCrew,
                 "Wages Paid: %d" % self.stats.totalWagesPaid,
+            ]
+        if self.player.rentalProperties:
+            lines += [
+                "",
+                "Investment Properties: %d owned" % len(self.player.rentalProperties),
+                "Lifetime Rental Income: %d" % self.stats.totalRentalIncome,
             ]
         lines += [
             "",

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -5,6 +5,7 @@ from world.timeService import TimeService
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from achievements import achievements
+from housing import housing
 
 
 # @author Daniel McCoy Stephenson
@@ -24,7 +25,7 @@ class Home:
         self.timeService = timeService
 
     def run(self):
-        li = ["Sleep", "See Stats", "Go to Docks", "Quit"]
+        li = ["Sleep", "See Stats", "Manage Home", "Go to Docks", "Quit"]
         self.input = self.userInterface.showOptions(
             "You sit at home, polishing one of your prized fishing poles.", li
         )
@@ -37,17 +38,75 @@ class Home:
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.HOME
         elif self.input == "3":
+            self.manageHome()
+            return LocationType.HOME
+        elif self.input == "4":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
-        elif self.input == "4":
+        elif self.input == "5":
             return LocationType.NONE
 
     def sleep(self):
         self.timeService.increaseDay()
-        self.player.energy = 100  # Restore full energy when sleeping
+        self.player.energy = housing.maxEnergy(self.player)  # Restore full energy
         self.currentPrompt.text = (
             "You sleep until the next morning. You feel refreshed!"
         )
+
+    def _housingStatus(self):
+        tier = housing.currentTier(self.player)
+        info = housing.tierInfo(tier)
+        lines = [
+            "%s (tier %d/%d)" % (info["name"], tier, len(housing.HOUSING_TIERS)),
+            "Energy cap: %d. Daily rental income: $%d."
+            % (info["maxEnergy"], info["dailyRentalIncome"]),
+        ]
+        if tier < len(housing.HOUSING_TIERS):
+            nextInfo = housing.tierInfo(tier + 1)
+            lines.append(
+                "Upgrade to a %s for $%d: energy cap %d, rental income $%d/day."
+                % (
+                    nextInfo["name"],
+                    nextInfo["cost"],
+                    nextInfo["maxEnergy"],
+                    nextInfo["dailyRentalIncome"],
+                )
+            )
+        else:
+            lines.append("You already own the finest home in the village.")
+        return "\n".join(lines)
+
+    def manageHome(self):
+        while True:
+            tier = housing.currentTier(self.player)
+            options = []
+            actions = []
+            if tier < len(housing.HOUSING_TIERS):
+                nextInfo = housing.tierInfo(tier + 1)
+                options.append(
+                    "Upgrade to a %s ($%d)" % (nextInfo["name"], nextInfo["cost"])
+                )
+                actions.append("upgrade")
+            options.append("Back")
+            actions.append("back")
+
+            choice = int(self.userInterface.showOptions(self._housingStatus(), options))
+            action = actions[choice - 1]
+
+            if action == "upgrade":
+                nextInfo = housing.tierInfo(tier + 1)
+                if self.player.canAfford(nextInfo["cost"]):
+                    self.player.spendMoney(nextInfo["cost"])
+                    self.player.homeTier = tier + 1
+                    self.stats.highestHomeTier = max(
+                        self.stats.highestHomeTier, self.player.homeTier
+                    )
+                    self.currentPrompt.text = "You upgraded to a %s!" % nextInfo["name"]
+                else:
+                    self.currentPrompt.text = "You can't afford that upgrade yet."
+            elif action == "back":
+                self.currentPrompt.text = "What would you like to do?"
+                return
 
     def displayStats(self):
         lines = [
@@ -57,6 +116,14 @@ class Home:
             "Money Made From Interest: %d" % self.stats.moneyMadeFromInterest,
             "Times Gotten Drunk: %d" % self.stats.timesGottenDrunk,
             "Money Lost Gambling: %d" % self.stats.moneyLostFromGambling,
+        ]
+        homeTier = housing.currentTier(self.player)
+        homeInfo = housing.tierInfo(homeTier)
+        lines += [
+            "",
+            "Home: %s (tier %d/%d)"
+            % (homeInfo["name"], homeTier, len(housing.HOUSING_TIERS)),
+            "Lifetime Rental Income: %d" % self.stats.totalRentalIncome,
         ]
         if self.player.hasBoat:
             lines += [

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -25,6 +25,11 @@ class Player:
         # src/housing). homeTier starts at 1 (the free Driftwood Shack) since,
         # unlike the boat, every player already has a home.
         self.homeTier = 1
+        # Investment properties: rental units the player owns but doesn't
+        # live in (see src/investments). A list of PROPERTY_TYPES tier ids,
+        # one entry per owned unit - not a single tier like homeTier, since
+        # any number of units (of any mix of types) can be owned at once.
+        self.rentalProperties = []
         # Testing/debug cheat: when on, every money check passes and spendMoney
         # becomes a no-op, so cash never actually runs out. Not persisted to save
         # files - it's a runtime toggle, not game progress. Defaults from the

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -21,6 +21,10 @@ class Player:
         self.workers = 0
         self.boatTier = 0
         self.businessName = ""
+        # Home ownership: a second, independent property track (see
+        # src/housing). homeTier starts at 1 (the free Driftwood Shack) since,
+        # unlike the boat, every player already has a home.
+        self.homeTier = 1
         # Testing/debug cheat: when on, every money check passes and spendMoney
         # becomes a no-op, so cash never actually runs out. Not persisted to save
         # files - it's a runtime toggle, not game progress. Defaults from the

--- a/src/player/playerJsonReaderWriter.py
+++ b/src/player/playerJsonReaderWriter.py
@@ -17,6 +17,7 @@ class PlayerJsonReaderWriter:
             "workers": player.workers,
             "boatTier": player.boatTier,
             "businessName": player.businessName,
+            "homeTier": player.homeTier,
         }
 
     def createPlayerFromJson(self, playerJson):
@@ -36,6 +37,7 @@ class PlayerJsonReaderWriter:
         player.workers = playerJson.get("workers", player.workers)
         player.boatTier = playerJson.get("boatTier", player.boatTier)
         player.businessName = playerJson.get("businessName", player.businessName)
+        player.homeTier = playerJson.get("homeTier", player.homeTier)
         return player
 
     def writePlayerToFile(self, player, jsonFile):

--- a/src/player/playerJsonReaderWriter.py
+++ b/src/player/playerJsonReaderWriter.py
@@ -18,6 +18,7 @@ class PlayerJsonReaderWriter:
             "boatTier": player.boatTier,
             "businessName": player.businessName,
             "homeTier": player.homeTier,
+            "rentalProperties": player.rentalProperties,
         }
 
     def createPlayerFromJson(self, playerJson):
@@ -38,6 +39,9 @@ class PlayerJsonReaderWriter:
         player.boatTier = playerJson.get("boatTier", player.boatTier)
         player.businessName = playerJson.get("businessName", player.businessName)
         player.homeTier = playerJson.get("homeTier", player.homeTier)
+        player.rentalProperties = playerJson.get(
+            "rentalProperties", player.rentalProperties
+        )
         return player
 
     def writePlayerToFile(self, player, jsonFile):

--- a/src/stats/stats.py
+++ b/src/stats/stats.py
@@ -17,5 +17,7 @@ class Stats:
         self.daysInBusiness = 0
         # Lifetime home-ownership totals (see src/housing). highestHomeTier
         # starts at 1 since every player already owns the base tier.
-        self.totalRentalIncome = 0
         self.highestHomeTier = 1
+        # Lifetime investment-property totals (see src/investments).
+        self.totalRentalIncome = 0
+        self.totalPropertiesBought = 0

--- a/src/stats/stats.py
+++ b/src/stats/stats.py
@@ -15,3 +15,7 @@ class Stats:
         self.totalFishCaughtByCrew = 0
         self.totalWagesPaid = 0
         self.daysInBusiness = 0
+        # Lifetime home-ownership totals (see src/housing). highestHomeTier
+        # starts at 1 since every player already owns the base tier.
+        self.totalRentalIncome = 0
+        self.highestHomeTier = 1

--- a/src/stats/statsJsonReaderWriter.py
+++ b/src/stats/statsJsonReaderWriter.py
@@ -17,6 +17,8 @@ class StatsJsonReaderWriter:
             "totalFishCaughtByCrew": stats.totalFishCaughtByCrew,
             "totalWagesPaid": stats.totalWagesPaid,
             "daysInBusiness": stats.daysInBusiness,
+            "totalRentalIncome": stats.totalRentalIncome,
+            "highestHomeTier": stats.highestHomeTier,
         }
 
     def createStatsFromJson(self, statsJson):
@@ -50,12 +52,12 @@ class StatsJsonReaderWriter:
         stats.totalFishCaughtByCrew = statsJson.get(
             "totalFishCaughtByCrew", stats.totalFishCaughtByCrew
         )
-        stats.totalWagesPaid = statsJson.get(
-            "totalWagesPaid", stats.totalWagesPaid
+        stats.totalWagesPaid = statsJson.get("totalWagesPaid", stats.totalWagesPaid)
+        stats.daysInBusiness = statsJson.get("daysInBusiness", stats.daysInBusiness)
+        stats.totalRentalIncome = statsJson.get(
+            "totalRentalIncome", stats.totalRentalIncome
         )
-        stats.daysInBusiness = statsJson.get(
-            "daysInBusiness", stats.daysInBusiness
-        )
+        stats.highestHomeTier = statsJson.get("highestHomeTier", stats.highestHomeTier)
         return stats
 
     def readStatsFromFile(self, statsJsonFile):

--- a/src/stats/statsJsonReaderWriter.py
+++ b/src/stats/statsJsonReaderWriter.py
@@ -19,6 +19,7 @@ class StatsJsonReaderWriter:
             "daysInBusiness": stats.daysInBusiness,
             "totalRentalIncome": stats.totalRentalIncome,
             "highestHomeTier": stats.highestHomeTier,
+            "totalPropertiesBought": stats.totalPropertiesBought,
         }
 
     def createStatsFromJson(self, statsJson):
@@ -58,6 +59,9 @@ class StatsJsonReaderWriter:
             "totalRentalIncome", stats.totalRentalIncome
         )
         stats.highestHomeTier = statsJson.get("highestHomeTier", stats.highestHomeTier)
+        stats.totalPropertiesBought = statsJson.get(
+            "totalPropertiesBought", stats.totalPropertiesBought
+        )
         return stats
 
     def readStatsFromFile(self, statsJsonFile):

--- a/src/world/timeService.py
+++ b/src/world/timeService.py
@@ -1,7 +1,7 @@
 import math
 
 from business import business
-from housing import housing
+from investments import investments
 
 
 # Daily bank interest is deliberately modest and capped so that saving is a
@@ -43,5 +43,5 @@ class TimeService:
         # The fishing business (if any) produces its daily catch and pays wages.
         business.runDailyProduction(self.player, self.stats)
 
-        # The player's home (if upgraded) pays out its daily rental income.
-        housing.runDailyRentalIncome(self.player, self.stats)
+        # Any investment properties (if owned) pay out their daily rental income.
+        investments.runDailyIncome(self.player, self.stats)

--- a/src/world/timeService.py
+++ b/src/world/timeService.py
@@ -1,6 +1,7 @@
 import math
 
 from business import business
+from housing import housing
 
 
 # Daily bank interest is deliberately modest and capped so that saving is a
@@ -41,3 +42,6 @@ class TimeService:
 
         # The fishing business (if any) produces its daily catch and pays wages.
         business.runDailyProduction(self.player, self.stats)
+
+        # The player's home (if upgraded) pays out its daily rental income.
+        housing.runDailyRentalIncome(self.player, self.stats)

--- a/tests/housing/test_housing.py
+++ b/tests/housing/test_housing.py
@@ -1,0 +1,88 @@
+from src.housing import housing
+from src.player.player import Player
+from src.stats.stats import Stats
+
+
+def test_currentTier_defaults_to_1_when_unset():
+    # prepare - an older save/test that never touches homeTier
+    player = Player()
+    player.homeTier = 0
+
+    # check - treated as the original (tier 1) Driftwood Shack
+    assert housing.currentTier(player) == 1
+
+
+def test_currentTier_reflects_upgrades():
+    # prepare
+    player = Player()
+    player.homeTier = 3
+
+    # check
+    assert housing.currentTier(player) == 3
+
+
+def test_tier1_matches_original_free_defaults():
+    # check - tier 1 preserves today's numbers exactly, so a fresh player's
+    # behavior is unchanged (free, 100 energy cap, no rental income)
+    info = housing.tierInfo(1)
+    assert info["cost"] == 0
+    assert info["maxEnergy"] == 100
+    assert info["dailyRentalIncome"] == 0
+
+
+def test_maxEnergy_reflects_tier():
+    # prepare
+    player = Player()
+    player.homeTier = 2
+
+    # check
+    assert housing.maxEnergy(player) == housing.tierInfo(2)["maxEnergy"]
+    assert housing.maxEnergy(player) > housing.tierInfo(1)["maxEnergy"]
+
+
+def test_no_rental_income_at_tier1():
+    # prepare
+    player = Player()
+    player.money = 100
+    stats = Stats()
+
+    # call
+    income = housing.runDailyRentalIncome(player, stats)
+
+    # check - a fresh player's Driftwood Shack pays no rent
+    assert income == 0
+    assert player.money == 100
+    assert stats.totalRentalIncome == 0
+
+
+def test_rental_income_paid_at_higher_tier():
+    # prepare
+    player = Player()
+    player.homeTier = 2
+    player.money = 100
+    stats = Stats()
+
+    # call
+    income = housing.runDailyRentalIncome(player, stats)
+
+    # check
+    expectedIncome = housing.tierInfo(2)["dailyRentalIncome"]
+    assert income == expectedIncome
+    assert player.money == 100 + expectedIncome
+    assert stats.totalRentalIncome == expectedIncome
+    assert stats.totalMoneyMade == expectedIncome
+
+
+def test_rental_income_accumulates_across_days():
+    # prepare
+    player = Player()
+    player.homeTier = 3
+    stats = Stats()
+
+    # call
+    housing.runDailyRentalIncome(player, stats)
+    housing.runDailyRentalIncome(player, stats)
+
+    # check - lifetime total accumulates rather than resets
+    expectedIncome = housing.tierInfo(3)["dailyRentalIncome"]
+    assert stats.totalRentalIncome == expectedIncome * 2

--- a/tests/housing/test_housing.py
+++ b/tests/housing/test_housing.py
@@ -12,7 +12,7 @@ def test_currentTier_defaults_to_1_when_unset():
     assert housing.currentTier(player) == 1
 
 
-def test_currentTier_reflects_upgrades():
+def test_currentTier_reflects_moves():
     # prepare
     player = Player()
     player.homeTier = 3
@@ -23,11 +23,11 @@ def test_currentTier_reflects_upgrades():
 
 def test_tier1_matches_original_free_defaults():
     # check - tier 1 preserves today's numbers exactly, so a fresh player's
-    # behavior is unchanged (free, 100 energy cap, no rental income)
+    # behavior is unchanged (free, no resale value, 100 energy cap)
     info = housing.tierInfo(1)
     assert info["cost"] == 0
+    assert info["resaleValue"] == 0
     assert info["maxEnergy"] == 100
-    assert info["dailyRentalIncome"] == 0
 
 
 def test_maxEnergy_reflects_tier():
@@ -40,49 +40,91 @@ def test_maxEnergy_reflects_tier():
     assert housing.maxEnergy(player) > housing.tierInfo(1)["maxEnergy"]
 
 
-def test_no_rental_income_at_tier1():
+def test_netCostToMove_up_from_free_tier_equals_target_price():
+    # prepare - tier 1 has no resale value, so moving up costs the full price
+    player = Player()
+
+    # check
+    assert housing.netCostToMove(player, 2) == housing.tierInfo(2)["cost"]
+
+
+def test_netCostToMove_up_is_discounted_by_current_resale_value():
+    # prepare - moving from tier 2 to tier 3 nets the tier-2 resale value off
+    player = Player()
+    player.homeTier = 2
+
+    # check
+    expected = housing.tierInfo(3)["cost"] - housing.tierInfo(2)["resaleValue"]
+    assert housing.netCostToMove(player, 3) == expected
+
+
+def test_netCostToMove_down_can_be_negative():
+    # prepare - moving from tier 2 down to the free tier 1 should pay cash
+    # back (tier 2's resale value exceeds tier 1's price of 0)
+    player = Player()
+    player.homeTier = 2
+
+    # check
+    assert housing.netCostToMove(player, 1) < 0
+
+
+def test_moveHome_up_spends_net_cost():
     # prepare
     player = Player()
-    player.money = 100
+    player.money = 1000
     stats = Stats()
+    netCost = housing.netCostToMove(player, 2)
 
     # call
-    income = housing.runDailyRentalIncome(player, stats)
+    moved = housing.moveHome(player, 2, stats)
 
-    # check - a fresh player's Driftwood Shack pays no rent
-    assert income == 0
-    assert player.money == 100
-    assert stats.totalRentalIncome == 0
+    # check
+    assert moved is True
+    assert player.homeTier == 2
+    assert player.money == 1000 - netCost
+    assert stats.highestHomeTier == 2
 
 
-def test_rental_income_paid_at_higher_tier():
+def test_moveHome_up_fails_when_unaffordable():
+    # prepare
+    player = Player()
+    player.money = 0
+
+    # call
+    moved = housing.moveHome(player, 2)
+
+    # check - nothing changes
+    assert moved is False
+    assert player.homeTier == 1
+    assert player.money == 0
+
+
+def test_moveHome_down_pays_cash_back():
     # prepare
     player = Player()
     player.homeTier = 2
-    player.money = 100
-    stats = Stats()
+    player.money = 0
+    refund = -housing.netCostToMove(player, 1)
 
     # call
-    income = housing.runDailyRentalIncome(player, stats)
+    moved = housing.moveHome(player, 1)
 
-    # check
-    expectedIncome = housing.tierInfo(2)["dailyRentalIncome"]
-    assert income == expectedIncome
-    assert player.money == 100 + expectedIncome
-    assert stats.totalRentalIncome == expectedIncome
-    assert stats.totalMoneyMade == expectedIncome
+    # check - a cash-back move always succeeds, even with no money
+    assert moved is True
+    assert player.homeTier == 1
+    assert player.money == refund
 
 
-def test_rental_income_accumulates_across_days():
-    # prepare
+def test_moveHome_highestHomeTier_does_not_regress():
+    # prepare - a player who has previously owned a higher tier
     player = Player()
     player.homeTier = 3
     stats = Stats()
+    stats.highestHomeTier = 3
 
-    # call
-    housing.runDailyRentalIncome(player, stats)
-    housing.runDailyRentalIncome(player, stats)
+    # call - move back down
+    housing.moveHome(player, 1, stats)
 
-    # check - lifetime total accumulates rather than resets
-    expectedIncome = housing.tierInfo(3)["dailyRentalIncome"]
-    assert stats.totalRentalIncome == expectedIncome * 2
+    # check - the lifetime "highest owned" stat remembers the peak
+    assert player.homeTier == 1
+    assert stats.highestHomeTier == 3

--- a/tests/investments/test_investments.py
+++ b/tests/investments/test_investments.py
@@ -1,0 +1,125 @@
+from src.investments import investments
+from src.player.player import Player
+from src.stats.stats import Stats
+
+
+def test_countOwned_reflects_holdings():
+    # prepare
+    player = Player()
+    player.rentalProperties = [1, 1, 2]
+
+    # check
+    assert investments.countOwned(player, 1) == 2
+    assert investments.countOwned(player, 2) == 1
+    assert investments.countOwned(player, 3) == 0
+
+
+def test_buyProperty_spends_money_and_adds_to_portfolio():
+    # prepare
+    player = Player()
+    player.money = 10000
+    stats = Stats()
+    cost = investments.typeInfo(1)["cost"]
+
+    # call
+    bought = investments.buyProperty(player, 1, stats)
+
+    # check
+    assert bought is True
+    assert player.rentalProperties == [1]
+    assert player.money == 10000 - cost
+    assert stats.totalPropertiesBought == 1
+
+
+def test_buyProperty_fails_when_unaffordable():
+    # prepare
+    player = Player()
+    player.money = 0
+
+    # call
+    bought = investments.buyProperty(player, 1)
+
+    # check
+    assert bought is False
+    assert player.rentalProperties == []
+    assert player.money == 0
+
+
+def test_sellProperty_refunds_resale_value_and_removes_one_unit():
+    # prepare - two of the same type owned
+    player = Player()
+    player.rentalProperties = [1, 1]
+    player.money = 0
+    resaleValue = investments.typeInfo(1)["resaleValue"]
+
+    # call
+    sold = investments.sellProperty(player, 1)
+
+    # check - only one unit removed, not both
+    assert sold is True
+    assert player.rentalProperties == [1]
+    assert player.money == resaleValue
+
+
+def test_sellProperty_fails_when_not_owned():
+    # prepare
+    player = Player()
+    startingMoney = player.money
+
+    # call
+    sold = investments.sellProperty(player, 1)
+
+    # check
+    assert sold is False
+    assert player.money == startingMoney
+
+
+def test_runDailyIncome_no_op_with_no_properties():
+    # prepare
+    player = Player()
+    player.money = 100
+    stats = Stats()
+
+    # call
+    income = investments.runDailyIncome(player, stats)
+
+    # check
+    assert income == 0
+    assert player.money == 100
+    assert stats.totalRentalIncome == 0
+
+
+def test_runDailyIncome_sums_across_owned_properties():
+    # prepare - one of type 1, two of type 2
+    player = Player()
+    player.rentalProperties = [1, 2, 2]
+    player.money = 100
+    stats = Stats()
+    expectedIncome = (
+        investments.typeInfo(1)["dailyIncome"]
+        + 2 * investments.typeInfo(2)["dailyIncome"]
+    )
+
+    # call
+    income = investments.runDailyIncome(player, stats)
+
+    # check
+    assert income == expectedIncome
+    assert player.money == 100 + expectedIncome
+    assert stats.totalRentalIncome == expectedIncome
+    assert stats.totalMoneyMade == expectedIncome
+
+
+def test_runDailyIncome_accumulates_across_days():
+    # prepare
+    player = Player()
+    player.rentalProperties = [1]
+    stats = Stats()
+
+    # call
+    investments.runDailyIncome(player, stats)
+    investments.runDailyIncome(player, stats)
+
+    # check - lifetime total accumulates rather than resets
+    expectedIncome = investments.typeInfo(1)["dailyIncome"]
+    assert stats.totalRentalIncome == expectedIncome * 2

--- a/tests/location/test_bank.py
+++ b/tests/location/test_bank.py
@@ -91,10 +91,24 @@ def test_run_make_withdrawal_failure_no_money():
     assert nextLocation == LocationType.BANK
 
 
-def test_run_go_to_docks_action():
+def test_run_manage_investments_action():
     # prepare
     bankInstance = createBank()
     bankInstance.userInterface.showOptions = MagicMock(return_value="4")
+    bankInstance.manageInvestments = MagicMock()
+
+    # call
+    nextLocation = bankInstance.run()
+
+    # check
+    bankInstance.manageInvestments.assert_called_once()
+    assert nextLocation == LocationType.BANK
+
+
+def test_run_go_to_docks_action():
+    # prepare
+    bankInstance = createBank()
+    bankInstance.userInterface.showOptions = MagicMock(return_value="5")
 
     # call
     nextLocation = bankInstance.run()
@@ -274,3 +288,68 @@ def test_withdraw_with_decimal():
     # check
     assert bankInstance.player.moneyInBank == 90.25
     assert bankInstance.player.money == 10.50
+
+
+def test_manageInvestments_buy_when_affordable():
+    # prepare
+    from src.investments import investments
+
+    bankInstance = createBank()
+    bankInstance.player.money = 10000
+    cost = investments.typeInfo(1)["cost"]
+    # no properties menu is (Buy1/Buy2/Buy3/Back) = "1" buys type 1; owning
+    # one adds a Sell option, so the follow-up menu's Back is "5"
+    bankInstance.userInterface.showOptions = MagicMock(side_effect=["1", "5"])
+
+    # call - buy, then back out
+    bankInstance.manageInvestments()
+
+    # check
+    assert bankInstance.player.rentalProperties == [1]
+    assert bankInstance.player.money == 10000 - cost
+    assert bankInstance.stats.totalPropertiesBought == 1
+
+
+def test_manageInvestments_buy_when_unaffordable():
+    # prepare
+    bankInstance = createBank()
+    bankInstance.player.money = 0
+    # the failed purchase leaves the menu unchanged (still no Sell option),
+    # so "4" backs out both times
+    bankInstance.userInterface.showOptions = MagicMock(side_effect=["1", "4"])
+
+    # call - attempt to buy (fails, loop continues), then back out
+    bankInstance.manageInvestments()
+
+    # check
+    assert bankInstance.player.rentalProperties == []
+    assert bankInstance.player.money == 0
+    assert bankInstance.stats.totalPropertiesBought == 0
+
+
+def test_manageInvestments_sell_refunds_resale_value():
+    # prepare - already own one Dockside Cottage
+    from src.investments import investments
+
+    bankInstance = createBank()
+    bankInstance.player.rentalProperties = [1]
+    bankInstance.player.money = 0
+    resaleValue = investments.typeInfo(1)["resaleValue"]
+    # owning one, the menu is (Buy1/Buy2/Buy3/Sell1/Back) = "4" sells it;
+    # selling drops back to (Buy1/Buy2/Buy3/Back), so "4" backs out
+    bankInstance.userInterface.showOptions = MagicMock(side_effect=["4", "4"])
+
+    # call - sell, then back out
+    bankInstance.manageInvestments()
+
+    # check
+    assert bankInstance.player.rentalProperties == []
+    assert bankInstance.player.money == resaleValue
+
+
+def test_manageInvestments_status_reflects_no_holdings():
+    # prepare
+    bankInstance = createBank()
+
+    # check
+    assert "don't own any yet" in bankInstance._investmentsStatus()

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -154,36 +154,58 @@ def test_displayStats_includes_home_block():
     # call
     homeInstance.displayStats()
 
-    # check - the home tier and lifetime rental income are always shown, even
-    # for a fresh player at the base tier
+    # check - the home tier is always shown, even for a fresh player at the
+    # base tier; a fresh player owns no investment properties, so that block
+    # (and any rental-income line) is omitted
     shownText = homeInstance.userInterface.showDialogue.call_args[0][0]
     assert "Home: Driftwood Shack" in shownText
-    assert "Lifetime Rental Income" in shownText
+    assert "Investment Properties" not in shownText
 
 
-def test_manageHome_upgrade_when_affordable():
+def test_displayStats_includes_investment_block_when_owned():
     # prepare
     homeInstance = createHome()
-    homeInstance.player.money = 10000
-    nextInfo = housing.tierInfo(2)
-    homeInstance.userInterface.showOptions = MagicMock(side_effect=["1", "2"])
+    homeInstance.player.rentalProperties = [1, 1]
+    homeInstance.stats.totalRentalIncome = 30
+    homeInstance.userInterface.showDialogue = MagicMock()
 
-    # call - upgrade, then back out
+    # call
+    homeInstance.displayStats()
+
+    # check
+    shownText = homeInstance.userInterface.showDialogue.call_args[0][0]
+    assert "Investment Properties: 2 owned" in shownText
+    assert "Lifetime Rental Income: 30" in shownText
+
+
+def test_manageHome_move_up_when_affordable():
+    # prepare - a trade-up from the free tier 1 costs exactly tier 2's price
+    # (tier 1 has no resale value)
+    homeInstance = createHome()
+    homeInstance.player.money = 10000
+    netCost = housing.netCostToMove(homeInstance.player, 2)
+    # tier 1 menu is (Move up/Back) = "1"; after moving, tier 2's menu is
+    # (Move up/Move down/Back), so "3" backs out
+    homeInstance.userInterface.showOptions = MagicMock(side_effect=["1", "3"])
+
+    # call - move up, then back out
     homeInstance.manageHome()
 
     # check
     assert homeInstance.player.homeTier == 2
-    assert homeInstance.player.money == 10000 - nextInfo["cost"]
+    assert homeInstance.player.money == 10000 - netCost
     assert homeInstance.stats.highestHomeTier == 2
 
 
-def test_manageHome_upgrade_when_unaffordable():
+def test_manageHome_move_up_when_unaffordable():
     # prepare
     homeInstance = createHome()
     homeInstance.player.money = 0
+    # the failed move leaves the tier-1 menu (Move up/Back) unchanged, so "2"
+    # backs out both times
     homeInstance.userInterface.showOptions = MagicMock(side_effect=["1", "2"])
 
-    # call - attempt to upgrade (fails, loop continues), then back out
+    # call - attempt to move up (fails, loop continues), then back out
     homeInstance.manageHome()
 
     # check - no tier change, no money spent
@@ -191,15 +213,50 @@ def test_manageHome_upgrade_when_unaffordable():
     assert homeInstance.player.money == 0
 
 
-def test_manageHome_at_top_tier_has_no_upgrade_option():
-    # prepare - already at the top tier
+def test_manageHome_move_down_pays_cash_back():
+    # prepare - own the Cozy Cottage (tier 2), move back down to the free
+    # Driftwood Shack (tier 1)
     homeInstance = createHome()
-    homeInstance.player.homeTier = len(housing.HOUSING_TIERS)
-    homeInstance.userInterface.showOptions = MagicMock(return_value="1")
+    homeInstance.player.homeTier = 2
+    homeInstance.player.money = 0
+    homeInstance.stats.highestHomeTier = 2
+    expectedRefund = -housing.netCostToMove(homeInstance.player, 1)
+    # tier 2 menu is (Move up/Move down/Back) = "2" moves down; tier 1's menu
+    # is (Move up/Back), so "2" backs out
+    homeInstance.userInterface.showOptions = MagicMock(side_effect=["2", "2"])
 
-    # call - the only option offered is "Back"
+    # call - move down, then back out
+    homeInstance.manageHome()
+
+    # check - cash back, and the lifetime "highest tier" stat doesn't regress
+    assert homeInstance.player.homeTier == 1
+    assert homeInstance.player.money == expectedRefund
+    assert homeInstance.stats.highestHomeTier == 2
+
+
+def test_manageHome_at_base_tier_has_no_move_down_option():
+    # prepare - a fresh player at tier 1 has nothing to move down to
+    homeInstance = createHome()
+    homeInstance.userInterface.showOptions = MagicMock(return_value="2")
+
+    # call - "Back" is the only other option besides "Move to a Cozy Cottage"
     homeInstance.manageHome()
 
     # check
     optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
-    assert optionsShown == ["Back"]
+    assert not any("down" in option.lower() for option in optionsShown)
+
+
+def test_manageHome_at_top_tier_has_no_move_up_option():
+    # prepare - already at the top tier
+    homeInstance = createHome()
+    homeInstance.player.homeTier = len(housing.HOUSING_TIERS)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="2")
+
+    # call - "Move down" and "Back" are offered, but no "Move up"
+    homeInstance.manageHome()
+
+    # check
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    assert not any("move to" in option.lower() for option in optionsShown)
+    assert any("down" in option.lower() for option in optionsShown)

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -6,6 +6,7 @@ from src.stats.stats import Stats
 from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
 from src.achievements import achievements
+from src.housing import housing
 from unittest.mock import MagicMock
 
 
@@ -58,10 +59,24 @@ def test_run_see_stats_action():
     assert nextLocation == LocationType.HOME
 
 
-def test_run_go_to_docks_action():
+def test_run_manage_home_action():
     # prepare
     homeInstance = createHome()
     homeInstance.userInterface.showOptions = MagicMock(return_value="3")
+    homeInstance.manageHome = MagicMock()
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check
+    homeInstance.manageHome.assert_called_once()
+    assert nextLocation == LocationType.HOME
+
+
+def test_run_go_to_docks_action():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.userInterface.showOptions = MagicMock(return_value="4")
 
     # call
     nextLocation = homeInstance.run()
@@ -73,7 +88,7 @@ def test_run_go_to_docks_action():
 def test_run_quit_action():
     # prepare
     homeInstance = createHome()
-    homeInstance.userInterface.showOptions = MagicMock(return_value="4")
+    homeInstance.userInterface.showOptions = MagicMock(return_value="5")
 
     # call
     nextLocation = homeInstance.run()
@@ -129,3 +144,62 @@ def test_displayStats():
     assert "Milestones:" in shownText
     for milestone in achievements.MILESTONES:
         assert milestone["name"] in shownText
+
+
+def test_displayStats_includes_home_block():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.userInterface.showDialogue = MagicMock()
+
+    # call
+    homeInstance.displayStats()
+
+    # check - the home tier and lifetime rental income are always shown, even
+    # for a fresh player at the base tier
+    shownText = homeInstance.userInterface.showDialogue.call_args[0][0]
+    assert "Home: Driftwood Shack" in shownText
+    assert "Lifetime Rental Income" in shownText
+
+
+def test_manageHome_upgrade_when_affordable():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.player.money = 10000
+    nextInfo = housing.tierInfo(2)
+    homeInstance.userInterface.showOptions = MagicMock(side_effect=["1", "2"])
+
+    # call - upgrade, then back out
+    homeInstance.manageHome()
+
+    # check
+    assert homeInstance.player.homeTier == 2
+    assert homeInstance.player.money == 10000 - nextInfo["cost"]
+    assert homeInstance.stats.highestHomeTier == 2
+
+
+def test_manageHome_upgrade_when_unaffordable():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.player.money = 0
+    homeInstance.userInterface.showOptions = MagicMock(side_effect=["1", "2"])
+
+    # call - attempt to upgrade (fails, loop continues), then back out
+    homeInstance.manageHome()
+
+    # check - no tier change, no money spent
+    assert homeInstance.player.homeTier == 1
+    assert homeInstance.player.money == 0
+
+
+def test_manageHome_at_top_tier_has_no_upgrade_option():
+    # prepare - already at the top tier
+    homeInstance = createHome()
+    homeInstance.player.homeTier = len(housing.HOUSING_TIERS)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="1")
+
+    # call - the only option offered is "Back"
+    homeInstance.manageHome()
+
+    # check
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    assert optionsShown == ["Back"]

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -19,6 +19,7 @@ def test_initialization():
     assert player.fishByType == {}
     assert player.hasBoat is False
     assert player.workers == 0
+    assert player.homeTier == 1
 
 
 def test_addFish_and_clearFish_keep_count_in_sync():

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -20,6 +20,7 @@ def test_initialization():
     assert player.hasBoat is False
     assert player.workers == 0
     assert player.homeTier == 1
+    assert player.rentalProperties == []
 
 
 def test_addFish_and_clearFish_keep_count_in_sync():

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -115,9 +115,7 @@ def test_readPlayerFromFile():
     }
 
     # Write test data to temp file
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".json"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         json.dump(playerJson, f)
         temp_file_path = f.name
 
@@ -284,3 +282,37 @@ def test_createPlayerFromJson_missingRodLevel_defaultsToOne():
 
     # check - backward compatible default
     assert player.rodLevel == 1
+
+
+def test_homeTier_round_trips():
+    # prepare
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    player = Player()
+    player.homeTier = 3
+
+    # call
+    playerJson = playerJsonReaderWriter.createJsonFromPlayer(player)
+    restored = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check
+    assert playerJson["homeTier"] == 3
+    assert restored.homeTier == 3
+
+
+def test_createPlayerFromJson_missingHomeTier_defaultsToOne():
+    # prepare - an older save with no homeTier field
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    playerJson = {
+        "fishCount": 5,
+        "fishMultiplier": 2,
+        "money": 100,
+        "moneyInBank": 50,
+        "priceForBait": 75,
+        "energy": 80,
+    }
+
+    # call
+    player = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check - backward compatible default
+    assert player.homeTier == 1

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -316,3 +316,37 @@ def test_createPlayerFromJson_missingHomeTier_defaultsToOne():
 
     # check - backward compatible default
     assert player.homeTier == 1
+
+
+def test_rentalProperties_round_trips():
+    # prepare
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    player = Player()
+    player.rentalProperties = [1, 1, 2]
+
+    # call
+    playerJson = playerJsonReaderWriter.createJsonFromPlayer(player)
+    restored = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check
+    assert playerJson["rentalProperties"] == [1, 1, 2]
+    assert restored.rentalProperties == [1, 1, 2]
+
+
+def test_createPlayerFromJson_missingRentalProperties_defaultsToEmpty():
+    # prepare - an older save with no rentalProperties field
+    playerJsonReaderWriter = createPlayerJsonReaderWriter()
+    playerJson = {
+        "fishCount": 5,
+        "fishMultiplier": 2,
+        "money": 100,
+        "moneyInBank": 50,
+        "priceForBait": 75,
+        "energy": 80,
+    }
+
+    # call
+    player = playerJsonReaderWriter.createPlayerFromJson(playerJson)
+
+    # check - backward compatible default
+    assert player.rentalProperties == []

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -16,3 +16,5 @@ def test_initialization():
     assert stats.moneyMadeFromInterest == 0
     assert stats.timesGottenDrunk == 0
     assert stats.moneyLostFromGambling == 0
+    assert stats.totalRentalIncome == 0
+    assert stats.highestHomeTier == 1

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -18,3 +18,4 @@ def test_initialization():
     assert stats.moneyLostFromGambling == 0
     assert stats.totalRentalIncome == 0
     assert stats.highestHomeTier == 1
+    assert stats.totalPropertiesBought == 0

--- a/tests/stats/test_statsJsonReaderWriter.py
+++ b/tests/stats/test_statsJsonReaderWriter.py
@@ -138,6 +138,43 @@ def test_createStatsFromJson_missingBusinessStats_defaultsToZero():
     assert stats.daysInBusiness == 0
 
 
+def test_housingStats_round_trip():
+    # prepare
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    stats = createStats()
+    stats.totalRentalIncome = 85
+    stats.highestHomeTier = 3
+
+    # call - serialize then deserialize
+    statsJson = statsJsonReaderWriter.createJsonFromStats(stats)
+    restored = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check
+    assert statsJson["totalRentalIncome"] == 85
+    assert statsJson["highestHomeTier"] == 3
+    assert restored.totalRentalIncome == 85
+    assert restored.highestHomeTier == 3
+
+    # validate against the schema
+    validate(statsJson, getStatsSchema())
+
+
+def test_createStatsFromJson_missingHousingStats_defaults():
+    # prepare - an older save with no housing-stat fields
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    statsJson = {
+        "totalFishCaught": 1,
+        "totalMoneyMade": 1,
+    }
+
+    # call
+    stats = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check - backward compatible defaults
+    assert stats.totalRentalIncome == 0
+    assert stats.highestHomeTier == 1
+
+
 def test_writeStatsToFile():
     # prepare
     import tempfile
@@ -179,9 +216,7 @@ def test_readStatsFromFile():
     }
 
     # Write test data to temp file
-    with tempfile.NamedTemporaryFile(
-        mode="w", delete=False, suffix=".json"
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         json.dump(statsJson, f)
         temp_file_path = f.name
 

--- a/tests/stats/test_statsJsonReaderWriter.py
+++ b/tests/stats/test_statsJsonReaderWriter.py
@@ -142,7 +142,6 @@ def test_housingStats_round_trip():
     # prepare
     statsJsonReaderWriter = createStatsJsonReaderWriter()
     stats = createStats()
-    stats.totalRentalIncome = 85
     stats.highestHomeTier = 3
 
     # call - serialize then deserialize
@@ -150,17 +149,36 @@ def test_housingStats_round_trip():
     restored = statsJsonReaderWriter.createStatsFromJson(statsJson)
 
     # check
-    assert statsJson["totalRentalIncome"] == 85
     assert statsJson["highestHomeTier"] == 3
-    assert restored.totalRentalIncome == 85
     assert restored.highestHomeTier == 3
 
     # validate against the schema
     validate(statsJson, getStatsSchema())
 
 
-def test_createStatsFromJson_missingHousingStats_defaults():
-    # prepare - an older save with no housing-stat fields
+def test_investmentStats_round_trip():
+    # prepare
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    stats = createStats()
+    stats.totalRentalIncome = 85
+    stats.totalPropertiesBought = 4
+
+    # call - serialize then deserialize
+    statsJson = statsJsonReaderWriter.createJsonFromStats(stats)
+    restored = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check
+    assert statsJson["totalRentalIncome"] == 85
+    assert statsJson["totalPropertiesBought"] == 4
+    assert restored.totalRentalIncome == 85
+    assert restored.totalPropertiesBought == 4
+
+    # validate against the schema
+    validate(statsJson, getStatsSchema())
+
+
+def test_createStatsFromJson_missingHousingAndInvestmentStats_defaults():
+    # prepare - an older save with no housing/investment-stat fields
     statsJsonReaderWriter = createStatsJsonReaderWriter()
     statsJson = {
         "totalFishCaught": 1,
@@ -171,8 +189,9 @@ def test_createStatsFromJson_missingHousingStats_defaults():
     stats = statsJsonReaderWriter.createStatsFromJson(statsJson)
 
     # check - backward compatible defaults
-    assert stats.totalRentalIncome == 0
     assert stats.highestHomeTier == 1
+    assert stats.totalRentalIncome == 0
+    assert stats.totalPropertiesBought == 0
 
 
 def test_writeStatsToFile():

--- a/tests/world/test_timeService.py
+++ b/tests/world/test_timeService.py
@@ -103,3 +103,21 @@ def test_increaseDay_runs_business_production():
     # check - the worker fished and was paid as part of the day rollover
     assert timeService.player.fishCount == business.WORKER_FISH_PER_DAY
     assert timeService.player.money == 1000 - business.WORKER_DAILY_WAGE
+
+
+def test_increaseDay_runs_housing_rental_income():
+    # prepare - an upgraded home, no bank balance (isolate from interest)
+    from src.housing import housing
+
+    timeService = createTimeService()
+    timeService.player.homeTier = 2
+    timeService.player.money = 100
+    timeService.player.moneyInBank = 0
+
+    # call
+    timeService.increaseDay()
+
+    # check - rental income was paid out as part of the day rollover
+    expectedIncome = housing.tierInfo(2)["dailyRentalIncome"]
+    assert timeService.player.money == 100 + expectedIncome
+    assert timeService.stats.totalRentalIncome == expectedIncome

--- a/tests/world/test_timeService.py
+++ b/tests/world/test_timeService.py
@@ -105,12 +105,12 @@ def test_increaseDay_runs_business_production():
     assert timeService.player.money == 1000 - business.WORKER_DAILY_WAGE
 
 
-def test_increaseDay_runs_housing_rental_income():
-    # prepare - an upgraded home, no bank balance (isolate from interest)
-    from src.housing import housing
+def test_increaseDay_runs_investment_property_income():
+    # prepare - an owned rental property, no bank balance (isolate from interest)
+    from src.investments import investments
 
     timeService = createTimeService()
-    timeService.player.homeTier = 2
+    timeService.player.rentalProperties = [1]
     timeService.player.money = 100
     timeService.player.moneyInBank = 0
 
@@ -118,6 +118,6 @@ def test_increaseDay_runs_housing_rental_income():
     timeService.increaseDay()
 
     # check - rental income was paid out as part of the day rollover
-    expectedIncome = housing.tierInfo(2)["dailyRentalIncome"]
+    expectedIncome = investments.typeInfo(1)["dailyIncome"]
     assert timeService.player.money == 100 + expectedIncome
     assert timeService.stats.totalRentalIncome == expectedIncome


### PR DESCRIPTION
## Summary
- **Home** (`src/housing`): a trade-up model. From the Home menu's "Manage Home", moving to a different tier (Driftwood Shack → Cozy Cottage → Sturdy Cabin → Waterfront Manor) sells your current home and buys the target one — net cost is the price difference, so upgrading costs money and downgrading pays cash back. The only benefit is personal comfort (higher energy cap on sleep); there's no rental income, since you live there.
- **Investment Properties** (new `src/investments` module): rental units the player owns but doesn't live in — any number of units, of any mix of 3 types (Dockside Cottage, Fisherman's Rowhouse, Harborview Flat), bought/sold individually. Each owned unit pays its own daily rental income automatically during `TimeService.increaseDay()`, mirroring how the fishing business' hired crew works (`src/business`) — you don't personally staff it, but it earns. Managed from the Bank ("Manage Investment Properties"), fitting Margaret the Teller's role.
- Two new milestone pairs: `Homeowner`/`Waterfront Manor` (home tier progress) and `Landlord`/`Property Mogul` (lifetime properties bought).
- `player.homeTier`, `player.rentalProperties`, and the new `Stats` fields follow the codebase's existing `.get(key, default)` backwards-compatible save/load pattern; `schemas/player.json` and `schemas/stats.json` are updated to match.

This replaces an earlier version of this PR where upgrading your own home paid you rental income (didn't make sense — you live there) and tiers only stacked with no way to sell back. Splitting "the place you live" (comfort, trade-up economics) from "assets you rent out" (pure income, buy/sell) fixes both.

## Test plan
- [x] `python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing` — 293 passed (up from 254 on `main`), including `tests/housing/test_housing.py` (rewritten for the trade-up model), new `tests/investments/test_investments.py`, and updates to `tests/location/test_home.py`, `tests/location/test_bank.py`, `tests/player/*`, `tests/stats/*`, `tests/world/test_timeService.py`.
- [x] Manual smoke test via direct API calls: moved a home from tier 1 → 2 → 1 (confirmed $750 net cost up, $525 cash back down, `highestHomeTier` doesn't regress); bought 2 Dockside Cottages + 1 Fisherman's Rowhouse, confirmed daily income ($75/day) accrues on `increaseDay()`, then sold one Cottage for its resale value.
- [x] Verified tier-1 home defaults (free, 100 energy) match pre-existing behavior exactly, so existing saves are unaffected until a player moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_