### PR TITLE
Fix correctness bugs and UX gaps in the housing stack

### DIFF
--- a/schemas/player.json
+++ b/schemas/player.json
@@ -53,13 +53,15 @@
         },
         "homeTier": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 5
         },
         "rentalProperties": {
             "type": "array",
             "items": {
                 "type": "integer",
-                "minimum": 1
+                "minimum": 1,
+                "maximum": 3
             }
         }
     },

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -13,6 +13,7 @@ from ui.userInterfaceFactory import UserInterfaceFactory
 from ui.enum.uiType import UIType
 from saveFileManager import SaveFileManager
 from achievements import achievements
+from housing import housing
 
 
 # Total wealth (cash + bank) the player is working toward. Reaching it triggers
@@ -162,9 +163,7 @@ class FishE:
         options = ["Delete Slot %d" % save["slot"] for save in save_files]
         options.append("Cancel")
 
-        choice = int(
-            self.userInterface.showOptions("Delete a Save File", options)
-        )
+        choice = int(self.userInterface.showOptions("Delete a Save File", options))
         if choice == len(options):  # Cancel
             return False
 
@@ -211,8 +210,13 @@ class FishE:
             # announce reaching the wealth goal once (the run continues)
             self.announceGoalIfReached()
 
-            # increase time & save
-            self.timeService.increaseTime()
+            # increase time - almost any action can roll a day over, so this
+            # is the one place guaranteed to catch an eviction regardless of
+            # what triggered it (appended so the action's own message is
+            # preserved on the next screen, same as milestones above)
+            if self.timeService.increaseTime()["evicted"]:
+                self.prompt.text += "  " + housing.EVICTION_MESSAGE
+
             self.save()
 
     def getTotalWealth(self):
@@ -242,15 +246,23 @@ class FishE:
             os.makedirs(self.saveFileManager.data_directory, exist_ok=True)
 
         try:
-            with open(self.saveFileManager.get_save_path("player.json"), "w") as playerSaveFile:
-                self.playerJsonReaderWriter.writePlayerToFile(self.player, playerSaveFile)
+            with open(
+                self.saveFileManager.get_save_path("player.json"), "w"
+            ) as playerSaveFile:
+                self.playerJsonReaderWriter.writePlayerToFile(
+                    self.player, playerSaveFile
+                )
 
-            with open(self.saveFileManager.get_save_path("timeService.json"), "w") as timeServiceSaveFile:
+            with open(
+                self.saveFileManager.get_save_path("timeService.json"), "w"
+            ) as timeServiceSaveFile:
                 self.timeServiceJsonReaderWriter.writeTimeServiceToFile(
                     self.timeService, timeServiceSaveFile
                 )
 
-            with open(self.saveFileManager.get_save_path("stats.json"), "w") as statsSaveFile:
+            with open(
+                self.saveFileManager.get_save_path("stats.json"), "w"
+            ) as statsSaveFile:
                 self.statsJsonReaderWriter.writeStatsToFile(self.stats, statsSaveFile)
         except (IOError, OSError) as e:
             print(f"\n Warning: Failed to save game: {e}")
@@ -258,8 +270,12 @@ class FishE:
 
     def loadPlayer(self):
         try:
-            with open(self.saveFileManager.get_save_path("player.json"), "r") as playerSaveFile:
-                self.player = self.playerJsonReaderWriter.readPlayerFromFile(playerSaveFile)
+            with open(
+                self.saveFileManager.get_save_path("player.json"), "r"
+            ) as playerSaveFile:
+                self.player = self.playerJsonReaderWriter.readPlayerFromFile(
+                    playerSaveFile
+                )
         except (IOError, OSError, json.JSONDecodeError) as e:
             print(f"\n Warning: Failed to load player data: {e}")
             print(" Creating new player...")
@@ -267,7 +283,9 @@ class FishE:
 
     def loadStats(self):
         try:
-            with open(self.saveFileManager.get_save_path("stats.json"), "r") as statsSaveFile:
+            with open(
+                self.saveFileManager.get_save_path("stats.json"), "r"
+            ) as statsSaveFile:
                 self.stats = self.statsJsonReaderWriter.readStatsFromFile(statsSaveFile)
         except (IOError, OSError, json.JSONDecodeError) as e:
             print(f"\n Warning: Failed to load stats data: {e}")
@@ -276,9 +294,13 @@ class FishE:
 
     def loadTimeService(self):
         try:
-            with open(self.saveFileManager.get_save_path("timeService.json"), "r") as timeServiceSaveFile:
-                self.timeService = self.timeServiceJsonReaderWriter.readTimeServiceFromFile(
-                    timeServiceSaveFile, self.player, self.stats
+            with open(
+                self.saveFileManager.get_save_path("timeService.json"), "r"
+            ) as timeServiceSaveFile:
+                self.timeService = (
+                    self.timeServiceJsonReaderWriter.readTimeServiceFromFile(
+                        timeServiceSaveFile, self.player, self.stats
+                    )
                 )
         except (IOError, OSError, json.JSONDecodeError) as e:
             print(f"\n Warning: Failed to load time service data: {e}")

--- a/src/housing/housing.py
+++ b/src/housing/housing.py
@@ -15,6 +15,10 @@
 # Investment properties (src/investments) are the opposite idea: assets the
 # player owns but doesn't live in, bought purely for income.
 
+# Shared string so every call site that surfaces an eviction to the player
+# (see TimeService.increaseDay's return value) says the same thing.
+EVICTION_MESSAGE = "You couldn't cover your rent and were evicted from your room!"
+
 HOUSING_TIERS = [
     {"name": "Homeless", "status": "homeless", "maxEnergy": 60},
     {"name": "Rented Room", "status": "renting", "maxEnergy": 90, "dailyRent": 10},
@@ -56,6 +60,8 @@ def currentTier(player):
 
 
 def tierInfo(tier):
+    if tier < 0 or tier >= len(HOUSING_TIERS):
+        raise ValueError("Invalid housing tier: %r" % (tier,))
     return HOUSING_TIERS[tier]
 
 
@@ -65,16 +71,13 @@ def maxEnergy(player):
 
 def netCostToMove(player, targetTier):
     """Net cost to move from the current rung to targetTier: the target's
-    purchase price (0 unless it's an owned tier) minus the current rung's
-    resale value (0 unless the player currently owns their home). Negative
-    means the move pays the player cash back."""
+    purchase price minus the current rung's resale value. Only owned tiers
+    define a "cost"/"resaleValue" at all, so a homeless or renting rung on
+    either side of the move contributes 0 via the dict defaults below.
+    Negative means the move pays the player cash back."""
     currentInfo = tierInfo(currentTier(player))
     targetInfo = tierInfo(targetTier)
-    proceeds = (
-        currentInfo.get("resaleValue", 0) if currentInfo["status"] == "owned" else 0
-    )
-    price = targetInfo.get("cost", 0) if targetInfo["status"] == "owned" else 0
-    return price - proceeds
+    return targetInfo.get("cost", 0) - currentInfo.get("resaleValue", 0)
 
 
 def moveHome(player, targetTier, stats=None):
@@ -90,6 +93,9 @@ def moveHome(player, targetTier, stats=None):
         player.money += -netCost
 
     player.homeTier = targetTier
+    # A move to a lower-cap tier (including eviction) shouldn't leave the
+    # player above their new cap until their next sleep.
+    player.energy = min(player.energy, tierInfo(targetTier)["maxEnergy"])
     if stats is not None:
         stats.highestHomeTier = max(stats.highestHomeTier, targetTier)
     return True
@@ -99,18 +105,21 @@ def runDailyRent(player, stats=None):
     """Charge the player's daily rent if they're currently renting. If they
     can't cover it, they're evicted back to Homeless - the same "shrinks
     instead of going into debt" idea used for unaffordable crew wages in
-    src/business. Returns the rent actually paid (0 if not renting, or if
-    evicted)."""
+    src/business. Returns a summary dict: {"rentPaid": int, "evicted": bool}
+    so callers can tell the player what happened."""
     info = tierInfo(currentTier(player))
     if info["status"] != "renting":
-        return 0
+        return {"rentPaid": 0, "evicted": False}
 
     rent = info["dailyRent"]
     if not player.canAfford(rent):
-        player.homeTier = 0  # evicted; no refund, renting was never equity
-        return 0
+        # Evicted; no refund, renting was never equity. Routed through
+        # moveHome so eviction gets the same energy-cap reconciliation as
+        # any other move, instead of duplicating that logic here.
+        moveHome(player, 0, stats)
+        return {"rentPaid": 0, "evicted": True}
 
     player.spendMoney(rent)
     if stats is not None:
         stats.totalRentPaid += rent
-    return rent
+    return {"rentPaid": rent, "evicted": False}

--- a/src/investments/investments.py
+++ b/src/investments/investments.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 # @author Daniel McCoy Stephenson
 #
 # Investment properties: rental units elsewhere in the village that the
@@ -21,11 +23,20 @@ PROPERTY_TYPES = [
 
 
 def typeInfo(typeId):
+    if typeId < 1 or typeId > len(PROPERTY_TYPES):
+        raise ValueError("Invalid property type id: %r" % (typeId,))
     return PROPERTY_TYPES[typeId - 1]
 
 
 def countOwned(player, typeId):
     return player.rentalProperties.count(typeId)
+
+
+def ownedCounts(player):
+    """Map of {typeId: count} for the player's whole portfolio in one pass,
+    for callers (e.g. the investments menu) that need every type's count
+    rather than checking one type at a time via countOwned()."""
+    return Counter(player.rentalProperties)
 
 
 def buyProperty(player, typeId, stats=None):

--- a/src/location/bank.py
+++ b/src/location/bank.py
@@ -151,16 +151,17 @@ class Bank:
 
     def _investmentsStatus(self):
         lines = ["Investment Properties:"]
-        if not self.player.rentalProperties:
+        owned = investments.ownedCounts(self.player)
+        if not owned:
             lines.append("You don't own any yet - they pay rental income daily.")
         else:
             for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
-                owned = investments.countOwned(self.player, typeId)
-                if owned:
+                count = owned.get(typeId, 0)
+                if count:
                     info = investments.typeInfo(typeId)
                     lines.append(
                         "%s x%d - $%d/day each"
-                        % (info["name"], owned, info["dailyIncome"])
+                        % (info["name"], count, info["dailyIncome"])
                     )
         return "\n".join(lines)
 
@@ -168,6 +169,7 @@ class Bank:
         while True:
             options = []
             actions = []
+            owned = investments.ownedCounts(self.player)
             for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
                 info = investments.typeInfo(typeId)
                 options.append(
@@ -175,9 +177,7 @@ class Bank:
                     % (info["name"], info["cost"], info["dailyIncome"])
                 )
                 actions.append(("buy", typeId))
-            for typeId in range(1, len(investments.PROPERTY_TYPES) + 1):
-                if investments.countOwned(self.player, typeId) > 0:
-                    info = investments.typeInfo(typeId)
+                if owned.get(typeId, 0) > 0:
                     options.append(
                         "Sell a %s (+$%d)" % (info["name"], info["resaleValue"])
                     )

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -11,6 +11,7 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 from fish import fish
 from business import business
+from housing import housing
 
 
 # The catch reaction window widens with the player's rod level, so a better rod
@@ -45,47 +46,47 @@ class Docks:
                 {
                     "question": "Tell me about yourself.",
                     "response": "Been working these docks since I was knee-high to a grasshopper. "
-                               "My pa was a fisherman, and his pa before him. I help maintain the boats and docks, "
-                               "and I've learned a thing or two about fishing over the years. "
-                               "The sea provides for those who respect her!"
+                    "My pa was a fisherman, and his pa before him. I help maintain the boats and docks, "
+                    "and I've learned a thing or two about fishing over the years. "
+                    "The sea provides for those who respect her!",
                 },
                 {
                     "question": "How do I fish at the docks?",
                     "response": "Fishing is what this village is all about! You need at least 10 energy to fish. "
-                               "When you cast your line, you'll spend several random hours (1-10) fishing. "
-                               "Each hour uses 10 energy. When a fish bites, press Enter fast - within 2 seconds! "
-                               "Your reaction time matters. The more successful catches, the more fish you'll get. "
-                               "Don't worry if you miss a few - you'll still catch at least one fish if you tried!"
+                    "When you cast your line, you'll spend several random hours (1-10) fishing. "
+                    "Each hour uses 10 energy. When a fish bites, press Enter fast - within 2 seconds! "
+                    "Your reaction time matters. The more successful catches, the more fish you'll get. "
+                    "Don't worry if you miss a few - you'll still catch at least one fish if you tried!",
                 },
                 {
                     "question": "What other locations can I visit?",
                     "response": "From the docks, you can get to anywhere in the village! "
-                               "There's your home - that's where you sleep to restore energy. "
-                               "Gilbert's shop is where you sell fish and buy better bait. "
-                               "The tavern is run by Old Tom - gambling and drinks there. "
-                               "And the bank, where Margaret will keep your money safe and even give you interest!"
+                    "There's your home - that's where you sleep to restore energy. "
+                    "Gilbert's shop is where you sell fish and buy better bait. "
+                    "The tavern is run by Old Tom - gambling and drinks there. "
+                    "And the bank, where Margaret will keep your money safe and even give you interest!",
                 },
                 {
                     "question": "Tell me about energy and rest.",
                     "response": "Energy is your lifeblood as a fisherman! You start each day with it, "
-                               "and fishing uses it up - 10 energy per hour of fishing. "
-                               "When you're running low, head home and sleep. That'll restore you for the next day. "
-                               "The game keeps track of time - each action moves the clock forward. "
-                               "Plan your day wisely!"
+                    "and fishing uses it up - 10 energy per hour of fishing. "
+                    "When you're running low, head home and sleep. That'll restore you for the next day. "
+                    "The game keeps track of time - each action moves the clock forward. "
+                    "Plan your day wisely!",
                 },
                 {
                     "question": "What makes a good fisherman?",
                     "response": "Patience and quick reflexes! When that fish bites, you gotta be ready. "
-                               "Invest in better bait from Gilbert - it makes a huge difference. "
-                               "Fish when you have energy, sell regularly, and save your money. "
-                               "The sea has its rhythms - you'll learn them in time. "
-                               "And remember: it's not just about catching fish, it's about enjoying the life!"
+                    "Invest in better bait from Gilbert - it makes a huge difference. "
+                    "Fish when you have energy, sell regularly, and save your money. "
+                    "The sea has its rhythms - you'll learn them in time. "
+                    "And remember: it's not just about catching fish, it's about enjoying the life!",
                 },
                 {
                     "question": "How's my fishing business doing?",
                     "response": self._businessDialogue,
                 },
-            ]
+            ],
         )
 
     def run(self):
@@ -99,7 +100,9 @@ class Docks:
             "Manage Boat & Crew",
         ]
         if self.player.hasBoat and self.player.businessName:
-            descriptor = "%s is docked and ready for the day." % self.player.businessName
+            descriptor = (
+                "%s is docked and ready for the day." % self.player.businessName
+            )
         else:
             descriptor = "You breathe in the fresh air. Salty."
         input = self.userInterface.showOptions(descriptor, li)
@@ -259,9 +262,7 @@ class Docks:
                 if self.player.canAfford(nextInfo["cost"]):
                     self.player.spendMoney(nextInfo["cost"])
                     self.player.boatTier = tier + 1
-                    self.currentPrompt.text = (
-                        "You upgraded to a %s!" % nextInfo["name"]
-                    )
+                    self.currentPrompt.text = "You upgraded to a %s!" % nextInfo["name"]
                 else:
                     self.currentPrompt.text = "You can't afford that upgrade yet."
             elif action == "rename":
@@ -319,7 +320,9 @@ class Docks:
                 return
 
         # A better rod widens the timing window, making catches more forgiving.
-        reactionWindow = REACTION_BASE_WINDOW + (self.player.rodLevel - 1) * ROD_WINDOW_STEP
+        reactionWindow = (
+            REACTION_BASE_WINDOW + (self.player.rodLevel - 1) * ROD_WINDOW_STEP
+        )
 
         # One timing challenge per cast (not a pass/fail repeated every hour):
         # how quickly you set the hook maps to a catch-quality tier. The active
@@ -335,10 +338,15 @@ class Docks:
         else:
             quality, qualityLabel = 0.25, "The fish nearly got away."
 
-        # Spend the fishing hours: time passes and energy is consumed.
+        # Spend the fishing hours: time passes and energy is consumed. A long
+        # enough trip can cross a day boundary (and so, e.g., miss a rent
+        # payment) without the player ever seeing a "new day" screen, so
+        # track that across the loop to mention it in the trip's own report.
+        evicted = False
         for i in range(hours):
             self.stats.hoursSpentFishing += 1
-            self.timeService.increaseTime()
+            if self.timeService.increaseTime()["evicted"]:
+                evicted = True
             self.player.spendEnergy(10)  # Consume 10 energy per hour
 
         baseFish = random.randint(1, 10)
@@ -360,6 +368,9 @@ class Docks:
 
         if timeLabel:
             self.currentPrompt.text += " " + timeLabel
+
+        if evicted:
+            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
 
     def talkToNPC(self):
         self.userInterface.showInteractiveDialogue(self.npc)

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -53,18 +53,45 @@ class Home:
         return "You sit at home, polishing one of your prized fishing poles."
 
     def sleep(self):
-        self.timeService.increaseDay()
+        summary = self.timeService.increaseDay()
         self.player.energy = housing.maxEnergy(self.player)  # Restore full energy
         self.currentPrompt.text = (
             "You sleep until the next morning. You feel refreshed!"
         )
+        if summary["evicted"]:
+            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
 
     def _moveCostLabel(self, netCost):
         if netCost > 0:
             return "$%d net" % netCost
         if netCost < 0:
-            return "+$%d" % -netCost
+            return "get $%d back" % -netCost
         return "free"
+
+    def _availableMoves(self):
+        """(targetTier, targetInfo, netCost) for each adjacent rung the
+        player can move to (up and/or down), computed once so
+        _housingStatus() and manageHome() don't each redo the same lookups
+        on every render."""
+        tier = housing.currentTier(self.player)
+        moves = []
+        if tier < len(housing.HOUSING_TIERS) - 1:
+            moves.append((tier + 1, housing.tierInfo(tier + 1)))
+        if tier > 0:
+            moves.append((tier - 1, housing.tierInfo(tier - 1)))
+        return [
+            (targetTier, info, housing.netCostToMove(self.player, targetTier))
+            for targetTier, info in moves
+        ]
+
+    def _moveLabel(self, currentTier, targetTier, info, netCost):
+        # Disclose a recurring rent obligation up front, not just after the
+        # player has already moved in and checked the status screen again.
+        costLabel = self._moveCostLabel(netCost)
+        if info["status"] == "renting":
+            costLabel += ", then $%d/day rent" % info["dailyRent"]
+        verb = "Move to" if targetTier > currentTier else "Move down to"
+        return "%s %s (%s)" % (verb, info["name"], costLabel)
 
     def _housingStatus(self):
         tier = housing.currentTier(self.player)
@@ -85,26 +112,12 @@ class Home:
                 "You own a %s. Energy cap: %d." % (info["name"], info["maxEnergy"])
             ]
 
-        if tier < len(housing.HOUSING_TIERS) - 1:
-            nextInfo = housing.tierInfo(tier + 1)
-            netCost = housing.netCostToMove(self.player, tier + 1)
+        for targetTier, targetInfo, netCost in self._availableMoves():
             lines.append(
-                "Move to %s (%s, energy cap %d)."
+                "%s, energy cap %d."
                 % (
-                    nextInfo["name"],
-                    self._moveCostLabel(netCost),
-                    nextInfo["maxEnergy"],
-                )
-            )
-        if tier > 0:
-            prevInfo = housing.tierInfo(tier - 1)
-            netCost = housing.netCostToMove(self.player, tier - 1)
-            lines.append(
-                "Move down to %s (%s, energy cap %d)."
-                % (
-                    prevInfo["name"],
-                    self._moveCostLabel(netCost),
-                    prevInfo["maxEnergy"],
+                    self._moveLabel(tier, targetTier, targetInfo, netCost),
+                    targetInfo["maxEnergy"],
                 )
             )
         return "\n".join(lines)
@@ -114,21 +127,9 @@ class Home:
             tier = housing.currentTier(self.player)
             options = []
             actions = []
-            if tier < len(housing.HOUSING_TIERS) - 1:
-                nextInfo = housing.tierInfo(tier + 1)
-                netCost = housing.netCostToMove(self.player, tier + 1)
-                options.append(
-                    "Move to %s (%s)" % (nextInfo["name"], self._moveCostLabel(netCost))
-                )
-                actions.append(("move", tier + 1))
-            if tier > 0:
-                prevInfo = housing.tierInfo(tier - 1)
-                netCost = housing.netCostToMove(self.player, tier - 1)
-                options.append(
-                    "Move down to %s (%s)"
-                    % (prevInfo["name"], self._moveCostLabel(netCost))
-                )
-                actions.append(("move", tier - 1))
+            for targetTier, targetInfo, netCost in self._availableMoves():
+                options.append(self._moveLabel(tier, targetTier, targetInfo, netCost))
+                actions.append(("move", targetTier))
             options.append("Back")
             actions.append(("back", None))
 

--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -11,6 +11,7 @@ from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
 from business import business
+from housing import housing
 
 
 # Dice has 6 equally likely faces, so a correct guess pays 5x the bet to make
@@ -51,43 +52,43 @@ class Tavern:
                 {
                     "question": "Tell me about yourself.",
                     "response": "I sailed the seven seas for forty years before settling down here. "
-                               "Lost my leg to a shark near the Caribbean, but I got plenty of stories to make up for it. "
-                               "These days I pour drinks and listen to folks' troubles. Best job I ever had!"
+                    "Lost my leg to a shark near the Caribbean, but I got plenty of stories to make up for it. "
+                    "These days I pour drinks and listen to folks' troubles. Best job I ever had!",
                 },
                 {
                     "question": "How do I make money in this village?",
                     "response": "Well now, there's a few ways to fill your pockets around here! "
-                               "The most reliable is fishing at the docks - catch some fish and sell 'em at Gilbert's shop. "
-                               "You can also try your luck at gambling right here in the tavern, but be warned - "
-                               "the dice don't always roll in your favor! And if you're patient, the bank offers "
-                               "interest on your savings."
+                    "The most reliable is fishing at the docks - catch some fish and sell 'em at Gilbert's shop. "
+                    "You can also try your luck at gambling right here in the tavern, but be warned - "
+                    "the dice don't always roll in your favor! And if you're patient, the bank offers "
+                    "interest on your savings.",
                 },
                 {
                     "question": "What can I do at the tavern?",
                     "response": "Ah, the tavern! This is the place to unwind after a long day. "
-                               "You can get yourself drunk for $10 - though you'll wake up at home with a headache the next day! "
-                               "Or if you're feeling lucky, you can gamble with the dice. Place a bet, pick a number from 1 to 6, "
-                               "and if the dice matches your choice, you'll double your money!"
+                    "You can get yourself drunk for $10 - though you'll wake up at home with a headache the next day! "
+                    "Or if you're feeling lucky, you can gamble with the dice. Place a bet, pick a number from 1 to 6, "
+                    "and if the dice matches your choice, you'll double your money!",
                 },
                 {
                     "question": "Tell me about the other villagers.",
                     "response": "Let me see... There's Gilbert the shopkeeper - been running that shop for thirty years. "
-                               "He'll buy your fish and sell you better bait. Then there's Sam down at the docks, "
-                               "knows everything about fishing. Margaret at the bank will keep your money safe. "
-                               "All good folk, they are!"
+                    "He'll buy your fish and sell you better bait. Then there's Sam down at the docks, "
+                    "knows everything about fishing. Margaret at the bank will keep your money safe. "
+                    "All good folk, they are!",
                 },
                 {
                     "question": "Any advice for a newcomer?",
                     "response": "Aye, I've seen many fishermen come through these doors. Here's what I tell 'em all: "
-                               "Start small, fish when you have energy, and sell your catch regularly. "
-                               "Don't gamble away all your coin - save some at the bank. "
-                               "And remember, better bait means better catches. Take your time and enjoy the village!"
+                    "Start small, fish when you have energy, and sell your catch regularly. "
+                    "Don't gamble away all your coin - save some at the bank. "
+                    "And remember, better bait means better catches. Take your time and enjoy the village!",
                 },
                 {
                     "question": "What do you make of my fishing business?",
                     "response": self._businessDialogue,
                 },
-            ]
+            ],
         )
 
     def _businessDialogue(self):
@@ -116,7 +117,12 @@ class Tavern:
         )
 
     def run(self):
-        li = ["Get drunk ( $10 )", "Gamble", "Talk to %s" % self.npc.name, "Go to Docks"]
+        li = [
+            "Get drunk ( $10 )",
+            "Gamble",
+            "Talk to %s" % self.npc.name,
+            "Go to Docks",
+        ]
         input = self.userInterface.showOptions(
             "You sit at the bar, watching the barkeep clean a mug with a dirty rag.", li
         )
@@ -178,13 +184,13 @@ class Tavern:
             tip = random.randint(15, 30)
             self.player.money += tip
             self.stats.totalMoneyMade += tip
-            self.currentPrompt.text = (
-                f"You have a headache, but a regular tipped you off to a hot catch — you earned ${tip}!"
-            )
+            self.currentPrompt.text = f"You have a headache, but a regular tipped you off to a hot catch — you earned ${tip}!"
         else:
             self.currentPrompt.text = "You have a headache."
 
-        self.timeService.increaseDay()
+        summary = self.timeService.increaseDay()
+        if summary["evicted"]:
+            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
 
     def gamble(self):
         while True:

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -1,5 +1,7 @@
 import os
 
+from housing import housing
+
 
 # @author Daniel McCoy Stephenson
 class Player:
@@ -9,7 +11,9 @@ class Player:
         self.moneyInBank = 0.01
         self.fishMultiplier = 1
         self.priceForBait = 50
-        self.energy = 100
+        # Starts at the Homeless tier's energy cap (see src/housing) - a
+        # fresh player hasn't found anywhere to stay yet.
+        self.energy = housing.HOUSING_TIERS[0]["maxEnergy"]
         self.rodLevel = 1
         # Per-species breakdown of the fish currently held. fishCount remains the
         # aggregate total; addFish/clearFish keep the two in sync.

--- a/src/ui/pygameUserInterface.py
+++ b/src/ui/pygameUserInterface.py
@@ -5,26 +5,29 @@ from ui.baseUserInterface import BaseUserInterface
 from prompt.prompt import Prompt
 from player.player import Player
 from world.timeService import TimeService
+from housing import housing
 
 
 # @author Daniel McCoy Stephenson
 class PygameUserInterface(BaseUserInterface):
     """Pygame-based user interface implementation"""
-    
+
     def __init__(self, currentPrompt: Prompt, timeService: TimeService, player: Player):
         super().__init__(currentPrompt, timeService, player)
-        
+
         # Initialize pygame
         pygame.init()
-        
+
         # Screen settings - now supports resizing
         self.min_width = 600
         self.min_height = 400
         self.width = 800
         self.height = 600
-        self.screen = pygame.display.set_mode((self.width, self.height), pygame.RESIZABLE)
+        self.screen = pygame.display.set_mode(
+            (self.width, self.height), pygame.RESIZABLE
+        )
         pygame.display.set_caption("FishE - Text-based Fishing Game")
-        
+
         # Colors
         self.BLACK = (0, 0, 0)
         self.WHITE = (255, 255, 255)
@@ -32,7 +35,7 @@ class PygameUserInterface(BaseUserInterface):
         self.DARK_GRAY = (64, 64, 64)
         self.BLUE = (0, 100, 200)
         self.LIGHT_BLUE = (100, 150, 255)
-        
+
         # Font sizes that scale with screen size
         self._update_fonts()
 
@@ -75,7 +78,9 @@ class PygameUserInterface(BaseUserInterface):
         self.height = max(new_height, self.min_height)
 
         # Recreate the display surface with new dimensions
-        self.screen = pygame.display.set_mode((self.width, self.height), pygame.RESIZABLE)
+        self.screen = pygame.display.set_mode(
+            (self.width, self.height), pygame.RESIZABLE
+        )
 
         # Update fonts for new screen size
         self._update_fonts()
@@ -93,7 +98,7 @@ class PygameUserInterface(BaseUserInterface):
         self.current_options = optionList
         self.selected_option = 0
         self.waiting_for_input = True
-        
+
         while self.waiting_for_input:
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
@@ -104,9 +109,13 @@ class PygameUserInterface(BaseUserInterface):
                     self._handle_resize(event.w, event.h)
                 elif event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_UP:
-                        self.selected_option = (self.selected_option - 1) % len(optionList)
+                        self.selected_option = (self.selected_option - 1) % len(
+                            optionList
+                        )
                     elif event.key == pygame.K_DOWN:
-                        self.selected_option = (self.selected_option + 1) % len(optionList)
+                        self.selected_option = (self.selected_option + 1) % len(
+                            optionList
+                        )
                     elif event.key == pygame.K_RETURN or event.key == pygame.K_SPACE:
                         self.waiting_for_input = False
                         return str(self.selected_option + 1)
@@ -115,21 +124,36 @@ class PygameUserInterface(BaseUserInterface):
                         if option_num <= len(optionList):
                             self.waiting_for_input = False
                             return str(option_num)
-            
+
             # Draw the UI
             self._draw_game_screen(descriptor, optionList)
-            
+
             # Update display
             pygame.display.flip()
             pygame.time.Clock().tick(60)  # 60 FPS
-        
+
         return str(self.selected_option + 1)
-    
+
+    def _statusLines(self):
+        """Plain-text status rows shown on the game screen. Split out from
+        _draw_game_screen so the content can be tested without a real font
+        (pygame.font.Font doesn't allow mocking its render method)."""
+        lines = [
+            f"Day {self.timeService.day}",
+            f"Time: {self.times[self.timeService.time]}",
+            f"Money: ${self.player.money}",
+            f"Fish: {self.player.fishCount}",
+            f"Energy: {self.player.energy}/{housing.maxEnergy(self.player)}",
+        ]
+        if self.player.operatorMode:
+            lines.append("[OPERATOR MODE]")
+        return lines
+
     def _draw_game_screen(self, descriptor, optionList):
         """Draw the main game screen with responsive layout"""
         # Clear screen
         self.screen.fill(self.BLACK)
-        
+
         # Use proportional positioning based on screen dimensions
         margin_x = self.width * 0.06  # 6% margin from left/right
         margin_y = self.height * 0.08  # 8% margin from top
@@ -144,18 +168,17 @@ class PygameUserInterface(BaseUserInterface):
         # Draw divider - proportional margins
         divider_start = margin_x
         divider_end = self.width - margin_x
-        pygame.draw.line(self.screen, self.GRAY, (divider_start, y_offset), (divider_end, y_offset), 2)
+        pygame.draw.line(
+            self.screen,
+            self.GRAY,
+            (divider_start, y_offset),
+            (divider_end, y_offset),
+            2,
+        )
         y_offset += self.height * 0.05  # 5% spacing
 
         # Draw game status
-        status_lines = [
-            f"Day {self.timeService.day}",
-            f"Time: {self.times[self.timeService.time]}",
-            f"Money: ${self.player.money}",
-            f"Fish: {self.player.fishCount}"
-        ]
-        if self.player.operatorMode:
-            status_lines.append("[OPERATOR MODE]")
+        status_lines = self._statusLines()
 
         status_x = margin_x + (self.width * 0.06)  # Indent status lines
         line_height = self.height * 0.05  # 5% of screen height per line
@@ -168,45 +191,59 @@ class PygameUserInterface(BaseUserInterface):
         y_offset += self.height * 0.03  # 3% extra spacing
 
         # Draw current prompt
-        prompt_surface = self.font_medium.render(self.currentPrompt.text, True, self.LIGHT_BLUE)
+        prompt_surface = self.font_medium.render(
+            self.currentPrompt.text, True, self.LIGHT_BLUE
+        )
         self.screen.blit(prompt_surface, (status_x, y_offset))
         y_offset += self.height * 0.08  # 8% spacing
 
         # Draw another divider
-        pygame.draw.line(self.screen, self.GRAY, (divider_start, y_offset), (divider_end, y_offset), 2)
+        pygame.draw.line(
+            self.screen,
+            self.GRAY,
+            (divider_start, y_offset),
+            (divider_end, y_offset),
+            2,
+        )
         y_offset += self.height * 0.05  # 5% spacing
 
         # Draw options with responsive sizing
-        option_height = max(25, self.height * 0.06)  # At least 25px, or 6% of screen height
+        option_height = max(
+            25, self.height * 0.06
+        )  # At least 25px, or 6% of screen height
         highlight_margin = self.width * 0.02  # 2% margin for highlight
 
         # Draw options
         for i, option in enumerate(optionList):
             color = self.LIGHT_BLUE if i == self.selected_option else self.WHITE
             option_text = f"[{i + 1}] {option}"
-            
+
             # Draw selection highlight with proportional sizing
             if i == self.selected_option:
                 highlight_x = margin_x + highlight_margin
                 highlight_width = self.width - 2 * (margin_x + highlight_margin)
-                rect = pygame.Rect(highlight_x, y_offset - 5, highlight_width, option_height)
+                rect = pygame.Rect(
+                    highlight_x, y_offset - 5, highlight_width, option_height
+                )
                 pygame.draw.rect(self.screen, self.DARK_GRAY, rect)
-            
+
             option_surface = self.font_medium.render(option_text, True, color)
             self.screen.blit(option_surface, (status_x, y_offset))
             y_offset += option_height
 
         # Draw instructions at bottom with proportional spacing
         instructions_start_y = self.height - (self.height * 0.15)  # 15% from bottom
-        y_offset = max(y_offset + self.height * 0.05, instructions_start_y)  # Ensure minimum spacing
+        y_offset = max(
+            y_offset + self.height * 0.05, instructions_start_y
+        )  # Ensure minimum spacing
 
         # Draw instructions
         y_offset += 30
         instructions = [
             "Use UP/DOWN arrows or number keys to select",
-            "Press ENTER or SPACE to choose"
+            "Press ENTER or SPACE to choose",
         ]
-        
+
         instruction_spacing = self.height * 0.04  # 4% spacing between instructions
 
         for instruction in instructions:
@@ -267,7 +304,9 @@ class PygameUserInterface(BaseUserInterface):
             margin_x = self.width * 0.06
             prompt_surface = self.font_medium.render(promptText, True, self.WHITE)
             self.screen.blit(prompt_surface, (margin_x, self.height * 0.3))
-            entry_surface = self.font_medium.render("> " + entered, True, self.LIGHT_BLUE)
+            entry_surface = self.font_medium.render(
+                "> " + entered, True, self.LIGHT_BLUE
+            )
             self.screen.blit(entry_surface, (margin_x, self.height * 0.45))
             hint_surface = self.font_small.render(
                 "Type your answer and press ENTER", True, self.GRAY

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -4,6 +4,7 @@ from ui.baseUserInterface import BaseUserInterface
 from prompt.prompt import Prompt
 from player.player import Player
 from world.timeService import TimeService
+from housing import housing
 
 
 # @author Daniel McCoy Stephenson
@@ -41,7 +42,10 @@ class UserInterface(BaseUserInterface):
             print(" | " + self.times[self.timeService.time])
             print(" | Money: $%.2f" % self.player.money)
             print(" | Fish: %d" % self.player.fishCount)
-            print(" | Energy: %d" % self.player.energy)
+            print(
+                " | Energy: %d/%d"
+                % (self.player.energy, housing.maxEnergy(self.player))
+            )
             if self.player.operatorMode:
                 print(" | [OPERATOR MODE]")
             if self.goalProgress:
@@ -69,7 +73,7 @@ class UserInterface(BaseUserInterface):
         self.divider()
         input(" [ CONTINUE ]")
         self.currentPrompt.text = "What would you like to do?"
-    
+
     def showInteractiveDialogue(self, npc):
         """Shows an interactive dialogue menu with the NPC"""
         while True:
@@ -77,7 +81,7 @@ class UserInterface(BaseUserInterface):
             self.divider()
             print(f" Talking with {npc.name}")
             self.divider()
-            
+
             # Show dialogue options
             dialogue_options = npc.get_dialogue_options()
             if not dialogue_options:
@@ -87,27 +91,27 @@ class UserInterface(BaseUserInterface):
                 input(" [ CONTINUE ]")
                 self.currentPrompt.text = "What would you like to do?"
                 break
-            
+
             print(" What would you like to ask?\n")
             option_list = []
             for i, option in enumerate(dialogue_options):
                 question = option.get("question", f"Option {i+1}")
                 print(f" [{i+1}] {question}")
-                option_list.append(str(i+1))
-            
+                option_list.append(str(i + 1))
+
             print(f" [{len(option_list)+1}] [Back]")
-            option_list.append(str(len(option_list)+1))
-            
+            option_list.append(str(len(option_list) + 1))
+
             choice = input("\n> ")
-            
+
             if choice in option_list:
                 choice_idx = int(choice) - 1
-                
+
                 # Check if user chose to go back
                 if choice_idx == len(dialogue_options):
                     self.currentPrompt.text = "What would you like to do?"
                     break
-                
+
                 # Show the response
                 response = npc.get_dialogue_response(choice_idx)
                 self.lotsOfSpace()

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -8,6 +8,7 @@ from ui.baseUserInterface import BaseUserInterface
 from prompt.prompt import Prompt
 from player.player import Player
 from world.timeService import TimeService
+from housing import housing
 
 
 # The single-page client. It polls /state and renders whatever screen the game
@@ -115,7 +116,7 @@ function render(screen) {
     addPart(`$${h.money.toFixed(2)}`);
     addPart(`Fish: ${h.fish}`);
     // Below the fishing threshold (10) the player is too tired to fish — flag it.
-    const energy = el("span", { textContent: `Energy: ${h.energy}` });
+    const energy = el("span", { textContent: `Energy: ${h.energy}/${h.maxEnergy}` });
     if (h.energy < 10) energy.className = "low";
     addPart(energy);
     if (h.location) addPart(h.location);
@@ -282,6 +283,7 @@ class WebUserInterface(BaseUserInterface):
             "money": float(self.player.money),
             "fish": self.player.fishCount,
             "energy": self.player.energy,
+            "maxEnergy": housing.maxEnergy(self.player),
             "location": self.currentLocationName,
             "goal": self.goalProgress,
             "operator": self.player.operatorMode,

--- a/src/world/timeService.py
+++ b/src/world/timeService.py
@@ -23,15 +23,22 @@ class TimeService:
         self.time = 8
 
     def increaseTime(self):
+        """Advance the clock by an hour. Returns {"evicted": bool} so callers
+        can tell the player if a day rolled over during this call and they
+        lost a rented room - since any action can advance time, this is the
+        only reliable place to catch that regardless of what triggered it."""
         self.time += 1
 
         if self.time > 23:
             self.time = 0
 
         if self.time == 8:
-            self.increaseDay()
+            return self.increaseDay()
+        return {"evicted": False}
 
     def increaseDay(self):
+        """Roll the clock to a new day and run every daily-tick system.
+        Returns {"evicted": bool} - see housing.runDailyRent."""
         self.time = 8
         self.day += 1
 
@@ -49,4 +56,5 @@ class TimeService:
 
         # A rented room (if any) charges its daily rent, evicting the player
         # back to Homeless if they can't cover it.
-        housing.runDailyRent(self.player, self.stats)
+        rentSummary = housing.runDailyRent(self.player, self.stats)
+        return {"evicted": rentSummary["evicted"]}

--- a/tests/housing/test_housing.py
+++ b/tests/housing/test_housing.py
@@ -1,6 +1,17 @@
+import pytest
+
 from src.housing import housing
 from src.player.player import Player
 from src.stats.stats import Stats
+
+
+def test_tierInfo_rejects_out_of_range_tier():
+    # check - fails loudly on bad data instead of silently wrapping around
+    # via Python's negative-index behavior
+    with pytest.raises(ValueError):
+        housing.tierInfo(-1)
+    with pytest.raises(ValueError):
+        housing.tierInfo(len(housing.HOUSING_TIERS))
 
 
 def test_currentTier_defaults_to_homeless():
@@ -166,6 +177,35 @@ def test_moveHome_down_from_owned_pays_cash_back():
     assert player.money == refund
 
 
+def test_moveHome_down_reclamps_energy_to_new_cap():
+    # prepare - Waterfront Manor (cap 200) full energy, trading down to
+    # Driftwood Shack (cap 100)
+    player = Player()
+    player.homeTier = 5
+    player.energy = 200
+    player.money = 10000
+
+    # call
+    housing.moveHome(player, 2)
+
+    # check - energy is clamped immediately, not left over-cap until sleep
+    assert player.energy == housing.tierInfo(2)["maxEnergy"]
+
+
+def test_moveHome_up_does_not_raise_energy_above_current():
+    # prepare - low energy shouldn't be topped up just by moving to a home
+    # with a higher cap; only sleeping restores energy
+    player = Player()
+    player.energy = 10
+    player.money = 10000
+
+    # call
+    housing.moveHome(player, 2)
+
+    # check
+    assert player.energy == 10
+
+
 def test_moveHome_highestHomeTier_does_not_regress():
     # prepare - a player who has previously owned a higher tier
     player = Player()
@@ -188,10 +228,10 @@ def test_runDailyRent_no_op_when_not_renting():
     stats = Stats()
 
     # call
-    rent = housing.runDailyRent(player, stats)
+    summary = housing.runDailyRent(player, stats)
 
     # check
-    assert rent == 0
+    assert summary == {"rentPaid": 0, "evicted": False}
     assert player.money == 100
     assert stats.totalRentPaid == 0
 
@@ -205,10 +245,10 @@ def test_runDailyRent_charges_rent_while_renting():
     expectedRent = housing.tierInfo(1)["dailyRent"]
 
     # call
-    rent = housing.runDailyRent(player, stats)
+    summary = housing.runDailyRent(player, stats)
 
     # check
-    assert rent == expectedRent
+    assert summary == {"rentPaid": expectedRent, "evicted": False}
     assert player.money == 100 - expectedRent
     assert stats.totalRentPaid == expectedRent
 
@@ -221,13 +261,29 @@ def test_runDailyRent_evicts_when_unaffordable():
     stats = Stats()
 
     # call
-    rent = housing.runDailyRent(player, stats)
+    summary = housing.runDailyRent(player, stats)
 
     # check - evicted back to homeless, no partial payment
-    assert rent == 0
+    assert summary == {"rentPaid": 0, "evicted": True}
     assert player.homeTier == 0
     assert player.money == 0
     assert stats.totalRentPaid == 0
+
+
+def test_runDailyRent_evicting_reclamps_energy_to_homeless_cap():
+    # prepare - renting (energy cap 90) with more energy than Homeless allows
+    player = Player()
+    player.homeTier = 1
+    player.energy = 90
+    player.money = 0
+    stats = Stats()
+
+    # call
+    housing.runDailyRent(player, stats)
+
+    # check - energy is clamped down to the new (Homeless) cap immediately,
+    # not left over-cap until the next sleep
+    assert player.energy == housing.tierInfo(0)["maxEnergy"]
 
 
 def test_runDailyRent_does_not_charge_owned_homes():
@@ -238,8 +294,8 @@ def test_runDailyRent_does_not_charge_owned_homes():
     stats = Stats()
 
     # call
-    rent = housing.runDailyRent(player, stats)
+    summary = housing.runDailyRent(player, stats)
 
     # check - owning is a one-time cost, not a recurring one
-    assert rent == 0
+    assert summary == {"rentPaid": 0, "evicted": False}
     assert player.money == 100

--- a/tests/investments/test_investments.py
+++ b/tests/investments/test_investments.py
@@ -1,6 +1,17 @@
+import pytest
+
 from src.investments import investments
 from src.player.player import Player
 from src.stats.stats import Stats
+
+
+def test_typeInfo_rejects_out_of_range_id():
+    # check - fails loudly on bad data instead of silently wrapping around
+    # to the last entry via Python's negative-index behavior
+    with pytest.raises(ValueError):
+        investments.typeInfo(0)
+    with pytest.raises(ValueError):
+        investments.typeInfo(len(investments.PROPERTY_TYPES) + 1)
 
 
 def test_countOwned_reflects_holdings():
@@ -12,6 +23,26 @@ def test_countOwned_reflects_holdings():
     assert investments.countOwned(player, 1) == 2
     assert investments.countOwned(player, 2) == 1
     assert investments.countOwned(player, 3) == 0
+
+
+def test_ownedCounts_maps_every_owned_type_in_one_pass():
+    # prepare
+    player = Player()
+    player.rentalProperties = [1, 1, 2]
+
+    # check - only owned types show up; type 3 (never bought) is absent
+    # rather than present with a 0
+    counts = investments.ownedCounts(player)
+    assert counts == {1: 2, 2: 1}
+    assert 3 not in counts
+
+
+def test_ownedCounts_empty_for_fresh_player():
+    # prepare
+    player = Player()
+
+    # check
+    assert investments.ownedCounts(player) == {}
 
 
 def test_buyProperty_spends_money_and_adds_to_portfolio():

--- a/tests/location/test_bank.py
+++ b/tests/location/test_bank.py
@@ -298,7 +298,7 @@ def test_manageInvestments_buy_when_affordable():
     bankInstance.player.money = 10000
     cost = investments.typeInfo(1)["cost"]
     # no properties menu is (Buy1/Buy2/Buy3/Back) = "1" buys type 1; owning
-    # one adds a Sell option, so the follow-up menu's Back is "5"
+    # one inserts a Sell1 right after Buy1, pushing Back to "5"
     bankInstance.userInterface.showOptions = MagicMock(side_effect=["1", "5"])
 
     # call - buy, then back out
@@ -335,9 +335,9 @@ def test_manageInvestments_sell_refunds_resale_value():
     bankInstance.player.rentalProperties = [1]
     bankInstance.player.money = 0
     resaleValue = investments.typeInfo(1)["resaleValue"]
-    # owning one, the menu is (Buy1/Buy2/Buy3/Sell1/Back) = "4" sells it;
+    # owning one, the menu is (Buy1/Sell1/Buy2/Buy3/Back) = "2" sells it;
     # selling drops back to (Buy1/Buy2/Buy3/Back), so "4" backs out
-    bankInstance.userInterface.showOptions = MagicMock(side_effect=["4", "4"])
+    bankInstance.userInterface.showOptions = MagicMock(side_effect=["2", "4"])
 
     # call - sell, then back out
     bankInstance.manageInvestments()

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -5,6 +5,7 @@ from src.prompt.prompt import Prompt
 from src.stats.stats import Stats
 from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
+from src.housing import housing
 from unittest.mock import MagicMock, patch
 
 
@@ -198,12 +199,14 @@ def test_fish():
     # The active UI captures and times the reaction; mock a quick (perfect) one.
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch('src.location.docks.print'), \
-         patch('src.location.docks.sys.stdout.flush'), \
-         patch('src.location.docks.time.sleep'), \
-         patch('src.location.docks.random.randint', return_value=3):
-
-        docksInstance.timeService.increaseTime = MagicMock()
+    with patch("src.location.docks.print"), patch(
+        "src.location.docks.sys.stdout.flush"
+    ), patch("src.location.docks.time.sleep"), patch(
+        "src.location.docks.random.randint", return_value=3
+    ):
+        docksInstance.timeService.increaseTime = MagicMock(
+            return_value={"evicted": False}
+        )
 
         # call
         docksInstance.fish()
@@ -241,12 +244,14 @@ def test_fish_consumes_energy():
     docksInstance.userInterface.divider = MagicMock()
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch('src.location.docks.print'), \
-         patch('src.location.docks.sys.stdout.flush'), \
-         patch('src.location.docks.time.sleep'), \
-         patch('src.location.docks.random.randint', return_value=3):
-
-        docksInstance.timeService.increaseTime = MagicMock()
+    with patch("src.location.docks.print"), patch(
+        "src.location.docks.sys.stdout.flush"
+    ), patch("src.location.docks.time.sleep"), patch(
+        "src.location.docks.random.randint", return_value=3
+    ):
+        docksInstance.timeService.increaseTime = MagicMock(
+            return_value={"evicted": False}
+        )
 
         # call
         docksInstance.fish()
@@ -265,12 +270,14 @@ def test_fish_with_limited_energy():
     docksInstance.userInterface.divider = MagicMock()
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch('src.location.docks.print'), \
-         patch('src.location.docks.sys.stdout.flush'), \
-         patch('src.location.docks.time.sleep'), \
-         patch('src.location.docks.random.randint', return_value=5):
-
-        docksInstance.timeService.increaseTime = MagicMock()
+    with patch("src.location.docks.print"), patch(
+        "src.location.docks.sys.stdout.flush"
+    ), patch("src.location.docks.time.sleep"), patch(
+        "src.location.docks.random.randint", return_value=5
+    ):
+        docksInstance.timeService.increaseTime = MagicMock(
+            return_value={"evicted": False}
+        )
 
         # call
         docksInstance.fish()
@@ -282,6 +289,35 @@ def test_fish_with_limited_energy():
         )  # Only fished for 2 hours due to energy limit
 
 
+def test_fish_mentions_eviction_when_a_day_rolls_over_mid_trip():
+    # A multi-hour trip can cross a day boundary invisibly; make sure that's
+    # still reported in the trip's own message rather than going unnoticed.
+    docksInstance = createDocks()
+    docksInstance.userInterface.lotsOfSpace = MagicMock()
+    docksInstance.userInterface.divider = MagicMock()
+    docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
+
+    with patch("src.location.docks.print"), patch(
+        "src.location.docks.sys.stdout.flush"
+    ), patch("src.location.docks.time.sleep"), patch(
+        "src.location.docks.random.randint", side_effect=[3, 6]
+    ):
+        # the day rolls over (and evicts) partway through the trip
+        docksInstance.timeService.increaseTime = MagicMock(
+            side_effect=[
+                {"evicted": False},
+                {"evicted": True},
+                {"evicted": False},
+            ]
+        )
+
+        # call
+        docksInstance.fish()
+
+        # check
+        assert housing.EVICTION_MESSAGE in docksInstance.currentPrompt.text
+
+
 def test_fish_interactive_success():
     # Test that quick reactions result in successful catches
     docksInstance = createDocks()
@@ -290,18 +326,22 @@ def test_fish_interactive_success():
     # Quick reaction => perfect-quality catch.
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch('src.location.docks.print'), \
-         patch('src.location.docks.sys.stdout.flush'), \
-         patch('src.location.docks.time.sleep'), \
-         patch('src.location.docks.random.randint', side_effect=[3, 6]):
-
-        docksInstance.timeService.increaseTime = MagicMock()
+    with patch("src.location.docks.print"), patch(
+        "src.location.docks.sys.stdout.flush"
+    ), patch("src.location.docks.time.sleep"), patch(
+        "src.location.docks.random.randint", side_effect=[3, 6]
+    ):
+        docksInstance.timeService.increaseTime = MagicMock(
+            return_value={"evicted": False}
+        )
 
         # call
         docksInstance.fish()
 
         # check - with 100% success rate, should get full catch
-        assert docksInstance.player.fishCount >= 3  # Should get good catch with all successes
+        assert (
+            docksInstance.player.fishCount >= 3
+        )  # Should get good catch with all successes
         assert docksInstance.stats.totalFishCaught >= 3
 
 
@@ -323,7 +363,9 @@ def test_fish_slow_reaction_yields_fewer_than_fast():
         ), patch("src.location.docks.time.sleep"), patch(
             "src.location.docks.random.randint", side_effect=[3, 10]
         ):
-            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.timeService.increaseTime = MagicMock(
+                return_value={"evicted": False}
+            )
             docksInstance.fish()
         return docksInstance.player.fishCount
 
@@ -369,7 +411,9 @@ def test_fish_applies_time_of_day_modifier():
         ), patch("src.location.docks.time.sleep"), patch(
             "src.location.docks.random.randint", side_effect=[5, 10]
         ):  # 5 hours, baseFish 10
-            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.timeService.increaseTime = MagicMock(
+                return_value={"evicted": False}
+            )
             docksInstance.fish()
         results[label] = docksInstance.player.fishCount
 
@@ -397,7 +441,9 @@ def test_fish_higher_rod_widens_reaction_window():
         ), patch("src.location.docks.time.sleep"), patch(
             "src.location.docks.random.randint", side_effect=[5, 10]
         ):
-            docksInstance.timeService.increaseTime = MagicMock()
+            docksInstance.timeService.increaseTime = MagicMock(
+                return_value={"evicted": False}
+            )
             docksInstance.fish()
         results[label] = docksInstance.player.fishCount
 

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -114,7 +114,7 @@ def test_homeDescriptor_reflects_housing_status():
 def test_sleep_restores_energy_to_current_tiers_cap():
     # prepare - a fresh (homeless) player has a low energy cap
     homeInstance = createHome()
-    homeInstance.timeService.increaseDay = MagicMock()
+    homeInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
     homeInstance.player.energy = 10
 
     # call
@@ -132,7 +132,7 @@ def test_sleep_restores_energy_to_current_tiers_cap():
 def test_sleep_restores_energy_to_a_higher_owned_cap():
     # prepare - owning a nicer home raises the cap slept up to
     homeInstance = createHome()
-    homeInstance.timeService.increaseDay = MagicMock()
+    homeInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
     homeInstance.player.homeTier = 3
     homeInstance.player.energy = 10
 
@@ -141,6 +141,18 @@ def test_sleep_restores_energy_to_a_higher_owned_cap():
 
     # check
     assert homeInstance.player.energy == housing.tierInfo(3)["maxEnergy"]
+
+
+def test_sleep_mentions_eviction_when_it_happens():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.timeService.increaseDay = MagicMock(return_value={"evicted": True})
+
+    # call
+    homeInstance.sleep()
+
+    # check - the player is told, not just silently moved back to Homeless
+    assert housing.EVICTION_MESSAGE in homeInstance.currentPrompt.text
 
 
 def test_displayStats():
@@ -206,6 +218,37 @@ def test_displayStats_includes_investment_block_when_owned():
     shownText = homeInstance.userInterface.showDialogue.call_args[0][0]
     assert "Investment Properties: 2 owned" in shownText
     assert "Lifetime Rental Income: 30" in shownText
+
+
+def test_manageHome_rented_room_option_discloses_daily_rent():
+    # prepare - a homeless player deciding whether to move in
+    homeInstance = createHome()
+    homeInstance.userInterface.showOptions = MagicMock(return_value="2")
+
+    # call
+    homeInstance.manageHome()
+
+    # check - the recurring cost is visible before committing, not just
+    # "free" (which would be misleading on its own)
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    rentedRoomOption = next(o for o in optionsShown if "Rented Room" in o)
+    assert "free" in rentedRoomOption
+    assert "$%d/day" % housing.tierInfo(1)["dailyRent"] in rentedRoomOption
+
+
+def test_manageHome_downgrade_cashback_label_is_explicit():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.player.homeTier = 2
+    homeInstance.userInterface.showOptions = MagicMock(return_value="3")
+
+    # call
+    homeInstance.manageHome()
+
+    # check - "get $X back" rather than an easy-to-miss bare "+$X"
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    downOption = next(o for o in optionsShown if "down" in o.lower())
+    assert "back" in downOption
 
 
 def test_manageHome_move_up_from_homeless_to_renting_is_free():

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -159,7 +159,7 @@ def test_getDrunk():
     tavern.print = MagicMock()
     tavern.sys.stdout.flush = MagicMock()
     tavern.time.sleep = MagicMock()
-    tavernInstance.timeService.increaseDay = MagicMock()
+    tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call
     tavernInstance.getDrunk()
@@ -168,6 +168,26 @@ def test_getDrunk():
     assert tavern.print.call_count == 3
     assert tavern.sys.stdout.flush.call_count == 3
     tavernInstance.timeService.increaseDay.assert_called_once()
+
+
+def test_getDrunk_mentions_eviction_when_it_happens():
+    # prepare
+    from src.housing import housing
+
+    tavernInstance = createTavern()
+    tavernInstance.userInterface.lotsOfSpace = MagicMock()
+    tavernInstance.userInterface.divider = MagicMock()
+    tavernInstance.player.money = 10
+    tavern.print = MagicMock()
+    tavern.sys.stdout.flush = MagicMock()
+    tavern.time.sleep = MagicMock()
+    tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": True})
+
+    # call
+    tavernInstance.getDrunk()
+
+    # check - the player is told, not just silently moved back to Homeless
+    assert housing.EVICTION_MESSAGE in tavernInstance.currentPrompt.text
 
 
 def test_changeBet_no_recursive_gamble():
@@ -351,7 +371,7 @@ def test_getDrunk_updates_stats():
     tavern.print = MagicMock()
     tavern.sys.stdout.flush = MagicMock()
     tavern.time.sleep = MagicMock()
-    tavernInstance.timeService.increaseDay = MagicMock()
+    tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call - skip the random additional-loss path (>= 0.3 means no extra loss)
     # so the base $10 cost is asserted deterministically.
@@ -374,7 +394,7 @@ def test_getDrunk_can_earn_a_tip():
     tavern.print = MagicMock()
     tavern.sys.stdout.flush = MagicMock()
     tavern.time.sleep = MagicMock()
-    tavernInstance.timeService.increaseDay = MagicMock()
+    tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call - land in the "tip" outcome (>= loss chance, < loss + tip) and fix
     # the tip amount deterministically.

--- a/tests/player/test_player.py
+++ b/tests/player/test_player.py
@@ -1,3 +1,4 @@
+from src.housing import housing
 from src.player.player import Player
 
 
@@ -14,7 +15,8 @@ def test_initialization():
     assert player.money == 20
     assert player.moneyInBank == 0.01
     assert player.fishMultiplier == 1
-    assert player.energy == 100
+    # a fresh player is Homeless (tier 0), so energy starts at that tier's cap
+    assert player.energy == housing.HOUSING_TIERS[0]["maxEnergy"]
     assert player.rodLevel == 1
     assert player.fishByType == {}
     assert player.hasBoat is False

--- a/tests/player/test_playerJsonReaderWriter.py
+++ b/tests/player/test_playerJsonReaderWriter.py
@@ -55,6 +55,8 @@ def test_createPlayerFromJson():
 
 def test_createPlayerFromJson_backwards_compatibility():
     # Test that old save files without energy still work
+    from src.housing import housing
+
     playerJson = {
         "fishCount": 5,
         "fishMultiplier": 2,
@@ -71,7 +73,9 @@ def test_createPlayerFromJson_backwards_compatibility():
     assert player.fishMultiplier == playerJson["fishMultiplier"]
     assert player.money == playerJson["money"]
     assert player.moneyInBank == playerJson["moneyInBank"]
-    assert player.energy == 100  # Should default to 100
+    # a save with no homeTier field also defaults to Homeless (tier 0), so
+    # energy should default to that tier's cap
+    assert player.energy == housing.HOUSING_TIERS[0]["maxEnergy"]
 
 
 def test_writePlayerToFile():

--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -5,6 +5,7 @@ import os
 # directly; run headless under SDL_VIDEODRIVER=dummy (set by CI / the test cmd).
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
+from housing import housing
 from ui.pygameUserInterface import PygameUserInterface
 from player.player import Player
 from prompt.prompt import Prompt
@@ -18,6 +19,16 @@ def makeUI():
     timeService = TimeService(player, stats)
     prompt = Prompt("What would you like to do?")
     return PygameUserInterface(prompt, timeService, player)
+
+
+def test_statusLines_shows_energy_cap():
+    # check - the status block shows "current/cap", not just the raw value
+    ui = makeUI()
+    try:
+        expected = "Energy: %d/%d" % (ui.player.energy, housing.maxEnergy(ui.player))
+        assert expected in ui._statusLines()
+    finally:
+        ui.cleanup()
 
 
 def test_handle_resize_clamps_below_minimum():
@@ -145,7 +156,9 @@ def test_showOptions_arrow_then_enter_selects():
     ui = makeUI()
     try:
         # down moves the highlight from option 1 to option 2, Enter confirms it
-        with injected_events([keydown(key=pygame.K_DOWN), keydown(key=pygame.K_RETURN)]):
+        with injected_events(
+            [keydown(key=pygame.K_DOWN), keydown(key=pygame.K_RETURN)]
+        ):
             choice = ui.showOptions("Pick", ["A", "B", "C"])
         assert choice == "2"
     finally:

--- a/tests/ui/test_userInterface.py
+++ b/tests/ui/test_userInterface.py
@@ -1,3 +1,4 @@
+from src.housing import housing
 from src.player.player import Player
 from src.prompt.prompt import Prompt
 from src.stats.stats import Stats
@@ -67,6 +68,15 @@ def test_showOptions():
     userInterfaceInstance.lotsOfSpace.assert_called()
     assert userInterfaceInstance.divider.call_count == 3
     userInterface.input.assert_called_with("\n> ")
+
+    # check - the energy line shows the current tier's cap, not just the
+    # raw value, so the housing energy-cap benefit is always visible
+    expectedEnergyLine = " | Energy: %d/%d" % (
+        userInterfaceInstance.player.energy,
+        housing.maxEnergy(userInterfaceInstance.player),
+    )
+    printedLines = [call.args[0] for call in userInterface.print.call_args_list]
+    assert expectedEnergyLine in printedLines
 
 
 def test_showOptions_includes_location_when_set():
@@ -141,6 +151,7 @@ def test_showDialogue():
 def test_showInteractiveDialogue_with_no_options():
     # setup
     from src.npc.npc import NPC
+
     userInterfaceInstance = createUserInterface()
     userInterface.print = MagicMock()
     userInterface.input = MagicMock(return_value="")
@@ -161,16 +172,15 @@ def test_showInteractiveDialogue_with_no_options():
 def test_showInteractiveDialogue_select_option():
     # setup
     from src.npc.npc import NPC
+
     userInterfaceInstance = createUserInterface()
     userInterface.print = MagicMock()
     # First input selects option 1, second input continues, third input selects Back
     userInterface.input = MagicMock(side_effect=["1", "", "2"])
     userInterfaceInstance.lotsOfSpace = MagicMock()
     userInterfaceInstance.divider = MagicMock()
-    
-    dialogue_options = [
-        {"question": "Test question?", "response": "Test response"}
-    ]
+
+    dialogue_options = [{"question": "Test question?", "response": "Test response"}]
     npc = NPC("Test NPC", "A test character", dialogue_options)
 
     # call
@@ -184,16 +194,15 @@ def test_showInteractiveDialogue_select_option():
 def test_showInteractiveDialogue_invalid_choice():
     # setup
     from src.npc.npc import NPC
+
     userInterfaceInstance = createUserInterface()
     userInterface.print = MagicMock()
     # First input is invalid, second continues error message, third selects Back
     userInterface.input = MagicMock(side_effect=["99", "", "2"])
     userInterfaceInstance.lotsOfSpace = MagicMock()
     userInterfaceInstance.divider = MagicMock()
-    
-    dialogue_options = [
-        {"question": "Test question?", "response": "Test response"}
-    ]
+
+    dialogue_options = [{"question": "Test question?", "response": "Test response"}]
     npc = NPC("Test NPC", "A test character", dialogue_options)
 
     # call

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -9,6 +9,7 @@ import urllib.request
 # identities line up with the runtime MRO; pytest.ini exposes both `.` and `src`.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
+from housing import housing
 from ui.baseUserInterface import BaseUserInterface
 from ui.webUserInterface import WebUserInterface
 from player.player import Player
@@ -48,6 +49,15 @@ def test_web_ui_implements_interface():
     assert issubclass(WebUserInterface, BaseUserInterface)
     ui = makeWebUI()
     assert ui.get_state()["screen"]["type"] == "loading"
+
+
+def test_header_includes_max_energy():
+    # check - the header exposes the current tier's cap alongside the raw
+    # energy value, so the client can always show "X/Y" instead of just "X"
+    ui = makeWebUI()
+    header = ui._header()
+    assert header["energy"] == ui.player.energy
+    assert header["maxEnergy"] == housing.maxEnergy(ui.player)
 
 
 def test_showOptions_round_trips_a_choice():

--- a/tests/world/test_timeService.py
+++ b/tests/world/test_timeService.py
@@ -49,6 +49,32 @@ def test_increaseTimeToNextDay():
     assert timeService.time == expected_time
 
 
+def test_increaseTime_returns_not_evicted_without_a_day_rollover():
+    # prepare
+    timeService = createTimeService()
+
+    # call
+    summary = timeService.increaseTime()
+
+    # check
+    assert summary == {"evicted": False}
+
+
+def test_increaseTime_surfaces_eviction_on_day_rollover():
+    # prepare - renting but broke, one hour from the day rolling over
+    timeService = createTimeService()
+    timeService.time = 7
+    timeService.player.homeTier = 1
+    timeService.player.money = 0
+
+    # call
+    summary = timeService.increaseTime()
+
+    # check
+    assert summary == {"evicted": True}
+    assert timeService.player.homeTier == 0
+
+
 def test_increaseDay():
     # prepare
     timeService = createTimeService()


### PR DESCRIPTION
## Stacked on #105
This targets `feature/homeless-and-renting` (#105), not `main` — review it last, after #104 and #105.

## Summary
A full multi-angle review (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions, and UX) of the whole housing/investments/homeless-and-renting stack turned up real issues. All fixed here.

**Correctness**
- `Player.__init__` hardcoded `energy=100`, but a fresh player's `homeTier=0` (Homeless) caps at 60 — new players started 40 energy over their own cap. Now derived from `housing.HOUSING_TIERS[0]["maxEnergy"]`.
- `moveHome()` changed `player.homeTier` but never reclamped `player.energy` to the new (possibly lower) cap, so downgrading or being evicted left the player over-cap until their next sleep. Eviction now routes through `moveHome()` instead of duplicating the tier assignment inline, so it gets this reconciliation automatically.
- `investments.typeInfo()`/`housing.tierInfo()` silently wrapped around via Python's negative-index behavior on an out-of-range id instead of failing loudly; both now raise `ValueError`, and `schemas/player.json` gained matching `maximum` bounds.

**UX — eviction was completely silent**
- `TimeService.increaseDay()`/`increaseTime()` now return `{"evicted": bool}`. Every place a day can roll over (`Home.sleep`, `Tavern.getDrunk`, a multi-hour `Docks.fish` trip, and the main game loop as a catch-all) surfaces `housing.EVICTION_MESSAGE` when it happens.
- "Move to Rented Room (free)" was misleading — it now discloses the recurring $10/day rent up front. "+$X" cash-back downgrade label is now "get $X back".
- Energy is shown as "current/cap" (not just current) in all three front-ends (console, pygame, web).

**Cleanup**
- `netCostToMove()` simplified (the status-gated ternaries were redundant with `dict.get` defaults).
- `home.py`'s repeated adjacent-tier-move computation (built separately in `_housingStatus()` and `manageHome()`) is now computed once.
- `manageInvestments()` combined two `PROPERTY_TYPES` loops into one pass, backed by a new `investments.ownedCounts()`.

**Deliberately not changed** (flagged, not worth the churn): menu-loop duplication across `manageHome`/`manageInvestments`/`manageBusiness`, investments' 1-based vs housing's 0-based indexing, `displayStats()`'s hand-rolled optional blocks vs `achievements.py`'s data-driven pattern.

## Test plan
- [x] `python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing` — 325 passed (up from 309 on `feature/homeless-and-renting`).
- [x] Manual smoke test: fresh player energy/cap consistency, eviction via day rollover (summary + reclamp + bounds checks), all verified via direct API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_