### PR TITLE
Add the promised Retire option to the Home menu

### DIFF
--- a/src/achievements/achievements.py
+++ b/src/achievements/achievements.py
@@ -6,6 +6,13 @@
 # reaches its threshold; the set of already-announced milestone names lives on
 # Stats (stats.earnedMilestones) so each is announced only once across saves.
 
+# Total wealth (cash + bank) the player is working toward. Reaching it triggers
+# a one-time victory message and unlocks the Retire option in the Home menu.
+# Lives here (rather than in fishE.py, where it's announced) so both fishE.py
+# and location/home.py can read it without a circular import between them.
+GOAL_AMOUNT = 10000
+GOAL_MILESTONE_NAME = "Reached Goal"
+
 MILESTONES = [
     {
         "name": "First Catch",

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -13,13 +13,8 @@ from ui.userInterfaceFactory import UserInterfaceFactory
 from ui.enum.uiType import UIType
 from saveFileManager import SaveFileManager
 from achievements import achievements
+from achievements.achievements import GOAL_AMOUNT, GOAL_MILESTONE_NAME
 from housing import housing
-
-
-# Total wealth (cash + bank) the player is working toward. Reaching it triggers
-# a one-time victory message; the game then continues until the player retires.
-GOAL_AMOUNT = 10000
-GOAL_MILESTONE_NAME = "Reached Goal"
 
 # Which front-end the game runs. Swap to UIType.PYGAME (or a future web type)
 # here to change the interface — the rest of the game is front-end agnostic.

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -25,7 +25,13 @@ class Home:
         self.timeService = timeService
 
     def run(self):
-        li = ["Sleep", "See Stats", "Manage Home", "Go to Docks", "Quit"]
+        retireAvailable = (
+            achievements.GOAL_MILESTONE_NAME in self.stats.earnedMilestones
+        )
+        li = ["Sleep", "See Stats", "Manage Home", "Go to Docks"]
+        if retireAvailable:
+            li.append("Retire")
+        li.append("Quit")
         self.input = self.userInterface.showOptions(self._homeDescriptor(), li)
 
         if self.input == "1":
@@ -41,7 +47,10 @@ class Home:
         elif self.input == "4":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
-        elif self.input == "5":
+        elif retireAvailable and self.input == "5":
+            self.retire()
+            return LocationType.NONE
+        elif self.input == str(len(li)):
             return LocationType.NONE
 
     def _homeDescriptor(self):
@@ -147,7 +156,7 @@ class Home:
                 self.currentPrompt.text = "What would you like to do?"
                 return
 
-    def displayStats(self):
+    def _statsLines(self):
         lines = [
             "Total Fish Caught: %d" % self.stats.totalFishCaught,
             "Total Money Made: %d" % self.stats.totalMoneyMade,
@@ -188,6 +197,18 @@ class Home:
             lines.append(
                 " [%s] %s - %s" % (mark, milestone["name"], milestone["description"])
             )
+        return lines
+
+    def displayStats(self):
         # Render through the active front-end (and wait for acknowledgement) so the
         # stats screen works in any UI rather than only the console.
+        self.userInterface.showDialogue("\n".join(self._statsLines()))
+
+    def retire(self):
+        """Show a closing summary and end the run, reusing displayStats()'s lines."""
+        lines = [
+            "You retire from fishing, your fortune secured for good.",
+            "Here's how your career adds up:",
+            "",
+        ] + self._statsLines()
         self.userInterface.showDialogue("\n".join(lines))

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -97,6 +97,69 @@ def test_run_quit_action():
     assert nextLocation == LocationType.NONE
 
 
+def test_run_no_retire_option_before_goal_reached():
+    # prepare - a fresh player has not earned the goal milestone
+    homeInstance = createHome()
+    homeInstance.userInterface.showOptions = MagicMock(return_value="5")
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check - "5" is still Quit, and Retire is not offered at all
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    assert "Retire" not in optionsShown
+    assert optionsShown[-1] == "Quit"
+    assert nextLocation == LocationType.NONE
+
+
+def test_run_retire_option_appears_after_goal_reached():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.stats.earnedMilestones.append(achievements.GOAL_MILESTONE_NAME)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="5")
+    homeInstance.retire = MagicMock()
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check - Retire is offered right before Quit, and choosing it ends the run
+    optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
+    assert optionsShown[-2:] == ["Retire", "Quit"]
+    homeInstance.retire.assert_called_once()
+    assert nextLocation == LocationType.NONE
+
+
+def test_run_quit_still_works_after_goal_reached():
+    # prepare - Quit shifts to option "6" once Retire is offered
+    homeInstance = createHome()
+    homeInstance.stats.earnedMilestones.append(achievements.GOAL_MILESTONE_NAME)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="6")
+    homeInstance.retire = MagicMock()
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check
+    homeInstance.retire.assert_not_called()
+    assert nextLocation == LocationType.NONE
+
+
+def test_retire_shows_summary_with_stats():
+    # prepare
+    homeInstance = createHome()
+    homeInstance.userInterface.showDialogue = MagicMock()
+
+    # call
+    homeInstance.retire()
+
+    # check - reuses the same stat lines displayStats() shows
+    homeInstance.userInterface.showDialogue.assert_called_once()
+    shownText = homeInstance.userInterface.showDialogue.call_args[0][0]
+    assert "retire" in shownText.lower()
+    assert "Total Fish Caught" in shownText
+    assert "Milestones:" in shownText
+
+
 def test_homeDescriptor_reflects_housing_status():
     # prepare
     homeInstance = createHome()


### PR DESCRIPTION
## Summary
- The README and the in-game victory message both promise a "retire from the Home menu" flow once the $10,000 wealth goal is reached, but no such option existed anywhere in the code.
- `Home.run()` now offers a `Retire` option, inserted before `Quit`, once `achievements.GOAL_MILESTONE_NAME` is present in `stats.earnedMilestones` (the same flag `FishE.announceGoalIfReached` already sets).
- Selecting `Retire` shows a closing career summary (reusing the same stat lines `displayStats()` already assembles, factored into a shared `_statsLines()` helper) and ends the run the same way `Quit` does.
- Moved the `GOAL_AMOUNT`/`GOAL_MILESTONE_NAME` constants from `fishE.py` into `achievements/achievements.py` so `home.py` can read them without a circular import (`fishE.py` already imports `location.home`); `fishE.py` re-imports them so `fishE.GOAL_AMOUNT`/`fishE.GOAL_MILESTONE_NAME` still resolve for existing callers/tests.

## Test plan
- [x] `python3 -m compileall -q src tests`
- [x] `python3 -m pytest -q --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — 329 passed, `home.py` at 99% coverage
- [x] Added tests in `tests/location/test_home.py`: Retire hidden before the goal is reached, Retire appears and is selectable right before Quit after the goal is reached, Quit still works once the option list has shifted, and the retire summary includes the stat lines
- [x] Manually drove the flow end-to-end (mocked UI) to confirm the option list and dialogue content before/after the goal
- Front-end parity: `Home` only calls the generic `showOptions`/`showDialogue` primitives (no per-frontend helper methods), which all three front-ends (console, pygame, web) already implement generically for any option list/dialogue text — no per-frontend changes were needed
- No `schemas/*.json` changes needed — no new persisted fields were added, this only reuses the existing `earnedMilestones` list already covered by `schemas/stats.json`

Closes #107

---

_drafted by Claude on behalf of Daniel Stephenson_