### PR TITLE
Document the fishing minigame and milestone system in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ You start **Homeless** — no home, and a low energy cap to show for it. From th
 ### Investment Properties
 Separately from where you live, you can build a real-estate portfolio. At the bank, choose **Manage Investment Properties** to buy rental units around the village — Dockside Cottage, Fisherman's Rowhouse, Harborview Flat — that you don't live in yourself. Every unit you own pays out its own daily rental income automatically each new day, alongside bank interest and any crew wages, and any unit can be sold back for a portion of its price.
 
+### Fishing
+Cast a line at the docks to spend a random 1-10 hours fishing (10 energy per hour, so you need at least 10 energy to start). When a fish bites, react as fast as you can to set the hook — the faster you react, the better the catch quality, and a better rod (bought at the shop) gives you more time to react. What you reel in also depends on the day: fish feed best at dawn and dusk and go quiet under the midday sun, and the weather — rolled fresh each morning and shown in the docks description — can help (rain) or hurt (storms) your haul on top of that. Which species you land is random and weighted by rarity, from common Minnows to rare, high-value Golden Koi.
+
+### Milestones
+Lifetime stats — fish caught, money earned, hours spent fishing, crew hired, homes owned, and more — unlock milestones as you reach their thresholds, from your very first catch up to owning the finest home in the village. Each milestone is announced once, the first time you reach it, even across save reloads.
+
 ### Selling Fish
 Sell your catch at the shop. The shop has a limited amount of money each day that refills overnight, so a very large haul may sell out the shop and need to be finished the next day — sell regularly, and park your earnings in the bank or reinvest them in gear and your crew.
 


### PR DESCRIPTION
## Summary
- No open issues or PRs existed at triage time, and a full source sweep found no untested code, schema drift, or `%d`-on-float formatting bugs — the repo is in a clean, well-covered state (351 tests passing).
- This cycle is a Stage A documentation accuracy sweep (per the dev-loop skill's fallback work mode): the README's *Features* section documents selling fish, housing, and investment properties, but never described the fishing minigame itself (reaction timing, rod-level window, time-of-day and weather yield modifiers, weighted species rarity) or the milestone/achievement system (`src/achievements/achievements.py`) — both fully implemented and tested, but entirely absent from player-facing docs.
- Added two new Features subsections, `Fishing` and `Milestones`, matching the doc's existing tone and em-dash style. Every claim was verified against `src/location/docks.py`, `src/fish/fish.py`, and `src/achievements/achievements.py` before writing (e.g. the 10-energy-per-hour cost and 10-energy minimum to start match `fish()`'s `hasEnergy`/`spendEnergy` calls; the "announced once, even across reloads" claim matches `getNewlyEarned`'s use of the persisted `stats.earnedMilestones`).
- `PLANNING.md`'s `FISH LOADING BAIT PRICE BUG` goal note was investigated but left untouched — no corresponding bug was found in `priceForBait` load/save/display code (schema, `PlayerJsonReaderWriter`, and shop display all use `%.2f` correctly), and the note isn't specific enough to act on without guessing; left as-is rather than fabricating a fix under a docs-only cycle.

## Test plan
- [x] `python3 -m compileall -q src`
- [x] Full pytest suite (headless SDL drivers): 351 passed, 0 failed
- [x] Docs-only change — no code paths modified, so no regression risk

No tracking issue — gap found during this cycle's documentation sweep (Phase 2, Stage A).

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._