### PR TITLE
Wrap and scroll text in the pygame front-end, and show location/goal in its status block

### DIFF
--- a/src/ui/pygameUserInterface.py
+++ b/src/ui/pygameUserInterface.py
@@ -85,6 +85,52 @@ class PygameUserInterface(BaseUserInterface):
         # Update fonts for new screen size
         self._update_fonts()
 
+    def _textWidth(self):
+        """Pixel width available for text, inside the same 6% side margins the
+        rest of the layout uses."""
+        return int(self.width - 2 * (self.width * 0.06))
+
+    def _splitLongWord(self, word, font, maxWidth):
+        """Break a single word wider than maxWidth into chunks that fit.
+
+        Word wrapping alone can't help a word that is itself too wide, and
+        pygame clips whatever runs past the window edge, so it is split by
+        character instead of being left unreadable."""
+        chunks = []
+        while len(word) > 1 and font.size(word)[0] > maxWidth:
+            fit = 1
+            while fit < len(word) and font.size(word[: fit + 1])[0] <= maxWidth:
+                fit += 1
+            chunks.append(word[:fit])
+            word = word[fit:]
+        chunks.append(word)
+        return chunks
+
+    def _wrapText(self, text, font, maxWidth):
+        """Split text into lines that fit maxWidth pixels, keeping newlines.
+
+        pygame's Font.render draws a single row and renders "\\n" as a glyph
+        rather than a line break, so any multi-line or window-width text has to
+        be broken up here before it is drawn. Split out from the drawing code so
+        the layout can be tested (font.size works headless; mocking
+        pygame.font.Font.render doesn't)."""
+        lines = []
+        for paragraph in text.split("\n"):
+            words = []
+            for word in paragraph.split(" "):
+                words.extend(self._splitLongWord(word, font, maxWidth))
+
+            current = ""
+            for word in words:
+                candidate = "%s %s" % (current, word) if current else word
+                if current and font.size(candidate)[0] > maxWidth:
+                    lines.append(current)
+                    current = word
+                else:
+                    current = candidate
+            lines.append(current)
+        return lines
+
     def lotsOfSpace(self):
         # For pygame, this just clears the screen
         self.screen.fill(self.BLACK)
@@ -137,17 +183,83 @@ class PygameUserInterface(BaseUserInterface):
     def _statusLines(self):
         """Plain-text status rows shown on the game screen. Split out from
         _draw_game_screen so the content can be tested without a real font
-        (pygame.font.Font doesn't allow mocking its render method)."""
-        lines = [
-            f"Day {self.timeService.day}",
-            f"Time: {self.times[self.timeService.time]}",
-            f"Money: ${self.player.money}",
+        (pygame.font.Font doesn't allow mocking its render method).
+
+        Stats are grouped a few per row - the same compact header the web
+        front-end renders, rather than the console's one-per-line column - so
+        the block leaves the option list room in the default window."""
+        clock = [f"Day {self.timeService.day}", self.times[self.timeService.time]]
+        # The location and goal entries only appear once the game loop has set
+        # them, matching the console and web front-ends (empty hides the entry).
+        if self.currentLocationName:
+            clock.append(f"Location: {self.currentLocationName}")
+
+        wallet = [
+            "Money: $%.2f" % self.player.money,
             f"Fish: {self.player.fishCount}",
             f"Energy: {self.player.energy}/{housing.maxEnergy(self.player)}",
         ]
+
+        progress = []
+        if self.goalProgress:
+            progress.append(f"Goal: {self.goalProgress}")
         if self.player.operatorMode:
-            lines.append("[OPERATOR MODE]")
-        return lines
+            progress.append("[OPERATOR MODE]")
+
+        rows = [clock, wallet]
+        if progress:
+            rows.append(progress)
+        return [" | ".join(row) for row in rows]
+
+    def _gameScreenLayout(self, statusLineCount, promptLineCount, optionCount):
+        """Vertical layout of the game screen, as pixel y positions.
+
+        Split out from the drawing for the same reason as _statusLines. The
+        option rows are sized against the space actually left over, because the
+        blocks above them vary: the status block grows with the location/goal
+        entries and the prompt wraps to as many lines as it needs, which in the
+        default window would otherwise push the options off the bottom edge."""
+        lineHeight = max(self.font_medium.get_linesize(), self.height * 0.04)
+
+        descriptorY = self.height * 0.08
+        dividerY = descriptorY + self.height * 0.13
+        statusY = dividerY + self.height * 0.05
+        promptY = statusY + statusLineCount * lineHeight + self.height * 0.03
+        secondDividerY = promptY + promptLineCount * lineHeight + self.height * 0.03
+        optionsY = secondDividerY + self.height * 0.05
+
+        # Options shrink toward the font's own line height (never below it, or
+        # they would overlap) so that as many as the game offers stay on screen.
+        instructionsTop = self.height - (self.height * 0.15)
+        optionHeight = max(25, self.height * 0.06)
+        if optionCount > 0:
+            optionHeight = max(
+                self.font_medium.get_linesize(),
+                min(optionHeight, (instructionsTop - optionsY) / optionCount),
+            )
+
+        # Sits below the options, but never so low that the second instruction
+        # line (drawn one instruction_spacing further down) falls off screen.
+        instructionsY = min(
+            max(
+                optionsY + optionCount * optionHeight + self.height * 0.05,
+                instructionsTop,
+            )
+            + 30,
+            self.height - 2 * (self.height * 0.04),
+        )
+
+        return {
+            "lineHeight": lineHeight,
+            "descriptorY": descriptorY,
+            "dividerY": dividerY,
+            "statusY": statusY,
+            "promptY": promptY,
+            "secondDividerY": secondDividerY,
+            "optionsY": optionsY,
+            "optionHeight": optionHeight,
+            "instructionsY": instructionsY,
+        }
 
     def _draw_game_screen(self, descriptor, optionList):
         """Draw the main game screen with responsive layout"""
@@ -156,64 +268,58 @@ class PygameUserInterface(BaseUserInterface):
 
         # Use proportional positioning based on screen dimensions
         margin_x = self.width * 0.06  # 6% margin from left/right
-        margin_y = self.height * 0.08  # 8% margin from top
-        y_offset = margin_y
+        status_x = margin_x + (self.width * 0.06)  # Indent status lines
+        text_width = int(self.width - margin_x - status_x)
+
+        status_lines = self._statusLines()
+        # The prompt carries appended milestone/goal announcements, which easily
+        # outrun the window width on a single line.
+        prompt_lines = self._wrapText(
+            self.currentPrompt.text, self.font_medium, text_width
+        )
+        layout = self._gameScreenLayout(
+            len(status_lines), len(prompt_lines), len(optionList)
+        )
+        line_height = layout["lineHeight"]
 
         # Draw descriptor - centered and scaled
         desc_surface = self.font_large.render(descriptor, True, self.WHITE)
-        desc_rect = desc_surface.get_rect(center=(self.width // 2, y_offset))
+        desc_rect = desc_surface.get_rect(
+            center=(self.width // 2, layout["descriptorY"])
+        )
         self.screen.blit(desc_surface, desc_rect)
-        y_offset += self.height * 0.13  # 13% of screen height
 
-        # Draw divider - proportional margins
+        # Draw dividers - proportional margins
         divider_start = margin_x
         divider_end = self.width - margin_x
-        pygame.draw.line(
-            self.screen,
-            self.GRAY,
-            (divider_start, y_offset),
-            (divider_end, y_offset),
-            2,
-        )
-        y_offset += self.height * 0.05  # 5% spacing
+        for divider_y in (layout["dividerY"], layout["secondDividerY"]):
+            pygame.draw.line(
+                self.screen,
+                self.GRAY,
+                (divider_start, divider_y),
+                (divider_end, divider_y),
+                2,
+            )
 
         # Draw game status
-        status_lines = self._statusLines()
-
-        status_x = margin_x + (self.width * 0.06)  # Indent status lines
-        line_height = self.height * 0.05  # 5% of screen height per line
-
+        y_offset = layout["statusY"]
         for line in status_lines:
             text_surface = self.font_medium.render(line, True, self.WHITE)
             self.screen.blit(text_surface, (status_x, y_offset))
             y_offset += line_height
 
-        y_offset += self.height * 0.03  # 3% extra spacing
-
         # Draw current prompt
-        prompt_surface = self.font_medium.render(
-            self.currentPrompt.text, True, self.LIGHT_BLUE
-        )
-        self.screen.blit(prompt_surface, (status_x, y_offset))
-        y_offset += self.height * 0.08  # 8% spacing
-
-        # Draw another divider
-        pygame.draw.line(
-            self.screen,
-            self.GRAY,
-            (divider_start, y_offset),
-            (divider_end, y_offset),
-            2,
-        )
-        y_offset += self.height * 0.05  # 5% spacing
+        y_offset = layout["promptY"]
+        for line in prompt_lines:
+            prompt_surface = self.font_medium.render(line, True, self.LIGHT_BLUE)
+            self.screen.blit(prompt_surface, (status_x, y_offset))
+            y_offset += line_height
 
         # Draw options with responsive sizing
-        option_height = max(
-            25, self.height * 0.06
-        )  # At least 25px, or 6% of screen height
+        option_height = layout["optionHeight"]
         highlight_margin = self.width * 0.02  # 2% margin for highlight
+        y_offset = layout["optionsY"]
 
-        # Draw options
         for i, option in enumerate(optionList):
             color = self.LIGHT_BLUE if i == self.selected_option else self.WHITE
             option_text = f"[{i + 1}] {option}"
@@ -232,13 +338,7 @@ class PygameUserInterface(BaseUserInterface):
             y_offset += option_height
 
         # Draw instructions at bottom with proportional spacing
-        instructions_start_y = self.height - (self.height * 0.15)  # 15% from bottom
-        y_offset = max(
-            y_offset + self.height * 0.05, instructions_start_y
-        )  # Ensure minimum spacing
-
-        # Draw instructions
-        y_offset += 30
+        y_offset = layout["instructionsY"]
         instructions = [
             "Use UP/DOWN arrows or number keys to select",
             "Press ENTER or SPACE to choose",
@@ -252,8 +352,54 @@ class PygameUserInterface(BaseUserInterface):
             self.screen.blit(inst_surface, inst_rect)
             y_offset += instruction_spacing
 
+    def _dialogueScrollBounds(self, lineCount):
+        """(visible line count, maximum scroll offset) for the dialogue area."""
+        lineHeight = max(self.font_medium.get_linesize(), 1)
+        top = self.height * 0.2
+        bottom = self.height - self.height * 0.15  # room for the hint line
+        visible = max(1, int((bottom - top) // lineHeight))
+        return visible, max(0, lineCount - visible)
+
+    def _draw_dialogue(self, lines, scroll, visible):
+        """Draw the visible window of a wrapped dialogue plus its hint line."""
+        self.screen.fill(self.BLACK)
+        margin_x = self.width * 0.06
+        lineHeight = max(self.font_medium.get_linesize(), 1)
+        y_offset = self.height * 0.2
+
+        for line in lines[scroll : scroll + visible]:
+            self.screen.blit(
+                self.font_medium.render(line, True, self.WHITE), (margin_x, y_offset)
+            )
+            y_offset += lineHeight
+
+        hint = self._dialogueHint(len(lines), scroll, visible)
+        hint_surface = self.font_small.render(hint, True, self.GRAY)
+        hint_rect = hint_surface.get_rect(
+            center=(self.width // 2, self.height - self.height * 0.1)
+        )
+        self.screen.blit(hint_surface, hint_rect)
+
+    def _dialogueHint(self, lineCount, scroll, visible):
+        """The footer hint for a dialogue - it only mentions scrolling when
+        there is something off screen to scroll to."""
+        if lineCount <= visible:
+            return "Press any key to continue"
+        return "UP/DOWN to scroll (%d-%d of %d) - any other key to continue" % (
+            scroll + 1,
+            min(scroll + visible, lineCount),
+            lineCount,
+        )
+
     def showDialogue(self, text):
-        """Render a block of text and wait for the player to press a key."""
+        """Render a block of text and wait for the player to press a key.
+
+        The text is wrapped first (see _wrapText) and, when it is taller than the
+        window, scrolled with UP/DOWN - the stats and retirement screens are long
+        enough to need it. Any other key continues."""
+        lines = self._wrapText(text, self.font_medium, self._textWidth())
+        visible, maxScroll = self._dialogueScrollBounds(len(lines))
+        scroll = 0
         waiting = True
         while waiting:
             for event in pygame.event.get():
@@ -262,20 +408,20 @@ class PygameUserInterface(BaseUserInterface):
                     sys.exit()
                 elif event.type == pygame.VIDEORESIZE:
                     self._handle_resize(event.w, event.h)
+                    # The wrap depends on the window width and the visible line
+                    # count on its height, so both are redone after a resize.
+                    lines = self._wrapText(text, self.font_medium, self._textWidth())
+                    visible, maxScroll = self._dialogueScrollBounds(len(lines))
+                    scroll = min(scroll, maxScroll)
                 elif event.type == pygame.KEYDOWN:
-                    waiting = False
+                    if event.key == pygame.K_UP:
+                        scroll = max(0, scroll - 1)
+                    elif event.key == pygame.K_DOWN:
+                        scroll = min(maxScroll, scroll + 1)
+                    else:
+                        waiting = False
 
-            self.screen.fill(self.BLACK)
-            margin_x = self.width * 0.06
-            text_surface = self.font_medium.render(text, True, self.WHITE)
-            self.screen.blit(text_surface, (margin_x, self.height * 0.2))
-            prompt_surface = self.font_small.render(
-                "Press any key to continue", True, self.GRAY
-            )
-            prompt_rect = prompt_surface.get_rect(
-                center=(self.width // 2, self.height - self.height * 0.1)
-            )
-            self.screen.blit(prompt_surface, prompt_rect)
+            self._draw_dialogue(lines, scroll, visible)
             pygame.display.flip()
             pygame.time.Clock().tick(60)
 
@@ -302,16 +448,31 @@ class PygameUserInterface(BaseUserInterface):
 
             self.screen.fill(self.BLACK)
             margin_x = self.width * 0.06
-            prompt_surface = self.font_medium.render(promptText, True, self.WHITE)
-            self.screen.blit(prompt_surface, (margin_x, self.height * 0.3))
-            entry_surface = self.font_medium.render(
-                "> " + entered, True, self.LIGHT_BLUE
-            )
-            self.screen.blit(entry_surface, (margin_x, self.height * 0.45))
+            lineHeight = max(self.font_medium.get_linesize(), 1)
+            # The prompt is the game's current prompt text, which can carry
+            # appended announcements - wrap it rather than let it run off screen.
+            y_offset = self.height * 0.3
+            for line in self._wrapText(promptText, self.font_medium, self._textWidth()):
+                prompt_surface = self.font_medium.render(line, True, self.WHITE)
+                self.screen.blit(prompt_surface, (margin_x, y_offset))
+                y_offset += lineHeight
+
+            # Wrapped too - a long answer (a business name, say) would otherwise
+            # type its way off the right edge of the window.
+            y_offset = max(y_offset + lineHeight, self.height * 0.45)
+            for line in self._wrapText(
+                "> " + entered, self.font_medium, self._textWidth()
+            ):
+                entry_surface = self.font_medium.render(line, True, self.LIGHT_BLUE)
+                self.screen.blit(entry_surface, (margin_x, y_offset))
+                y_offset += lineHeight
+
             hint_surface = self.font_small.render(
                 "Type your answer and press ENTER", True, self.GRAY
             )
-            self.screen.blit(hint_surface, (margin_x, self.height * 0.6))
+            self.screen.blit(
+                hint_surface, (margin_x, max(y_offset + lineHeight, self.height * 0.6))
+            )
             pygame.display.flip()
             pygame.time.Clock().tick(60)
 
@@ -333,8 +494,12 @@ class PygameUserInterface(BaseUserInterface):
 
             self.screen.fill(self.BLACK)
             margin_x = self.width * 0.06
-            message_surface = self.font_medium.render(message, True, self.WHITE)
-            self.screen.blit(message_surface, (margin_x, self.height * 0.4))
+            lineHeight = max(self.font_medium.get_linesize(), 1)
+            y_offset = self.height * 0.4
+            for line in self._wrapText(message, self.font_medium, self._textWidth()):
+                message_surface = self.font_medium.render(line, True, self.WHITE)
+                self.screen.blit(message_surface, (margin_x, y_offset))
+                y_offset += lineHeight
             pygame.display.flip()
             pygame.time.Clock().tick(60)
 

--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -21,12 +21,185 @@ def makeUI():
     return PygameUserInterface(prompt, timeService, player)
 
 
+def statusText(ui):
+    # the status block groups several stats per row, so assertions look for an
+    # entry anywhere in the block rather than as a row of its own
+    return " | ".join(ui._statusLines())
+
+
 def test_statusLines_shows_energy_cap():
     # check - the status block shows "current/cap", not just the raw value
     ui = makeUI()
     try:
         expected = "Energy: %d/%d" % (ui.player.energy, housing.maxEnergy(ui.player))
-        assert expected in ui._statusLines()
+        assert expected in statusText(ui)
+    finally:
+        ui.cleanup()
+
+
+def test_statusLines_shows_location_and_goal_when_set():
+    # parity with the console/web front-ends: both header fields the game loop
+    # sets appear in the status block
+    ui = makeUI()
+    try:
+        ui.currentLocationName = "Docks"
+        ui.goalProgress = "$20 / $10000"
+        assert "Location: Docks" in statusText(ui)
+        assert "Goal: $20 / $10000" in statusText(ui)
+    finally:
+        ui.cleanup()
+
+
+def test_statusLines_hides_location_and_goal_when_unset():
+    # empty header fields hide their entry, same as the other two front-ends
+    ui = makeUI()
+    try:
+        assert "Location:" not in statusText(ui)
+        assert "Goal:" not in statusText(ui)
+    finally:
+        ui.cleanup()
+
+
+def test_statusLines_stays_compact_when_everything_is_shown():
+    # the whole header fits in a few rows, leaving the option list room
+    ui = makeUI()
+    try:
+        ui.currentLocationName = "Docks"
+        ui.goalProgress = "$20 / $10000"
+        ui.player.operatorMode = True
+        lines = ui._statusLines()
+        assert len(lines) == 3
+        assert "[OPERATOR MODE]" in statusText(ui)
+        for line in lines:
+            assert ui.font_medium.size(line)[0] <= ui._textWidth()
+    finally:
+        ui.cleanup()
+
+
+def test_statusLines_formats_money_to_two_decimals():
+    # a fractional balance (a small bank withdrawal, say) is rounded for display
+    # rather than shown as a raw float
+    ui = makeUI()
+    try:
+        ui.player.money = 20 + 0.01 + 0.02
+        assert "Money: $20.03" in statusText(ui)
+    finally:
+        ui.cleanup()
+
+
+def test_gameScreenLayout_keeps_a_full_menu_on_screen():
+    # the docks menu (7 options) with every header row and a wrapped prompt is
+    # the busiest screen the game builds - all of it has to fit the window
+    ui = makeUI()
+    try:
+        layout = ui._gameScreenLayout(3, 2, 7)
+        assert layout["optionsY"] + 7 * layout["optionHeight"] <= ui.height
+        # both instruction lines sit below the options and inside the window
+        assert layout["instructionsY"] >= layout["optionsY"]
+        assert layout["instructionsY"] + ui.height * 0.04 <= ui.height
+    finally:
+        ui.cleanup()
+
+
+def test_gameScreenLayout_keeps_roomy_option_rows_when_there_is_space():
+    # a short menu is unaffected: rows keep the full 6%-of-height size
+    ui = makeUI()
+    try:
+        layout = ui._gameScreenLayout(3, 1, 3)
+        assert layout["optionHeight"] == max(25, ui.height * 0.06)
+    finally:
+        ui.cleanup()
+
+
+def test_gameScreenLayout_never_shrinks_options_below_the_font():
+    # rows shrink to make room, but not so far that they overlap each other
+    ui = makeUI()
+    try:
+        layout = ui._gameScreenLayout(3, 6, 20)
+        assert layout["optionHeight"] >= ui.font_medium.get_linesize()
+    finally:
+        ui.cleanup()
+
+
+def test_gameScreenLayout_shifts_blocks_down_as_the_prompt_wraps():
+    # every block below the prompt moves down by exactly the added lines
+    ui = makeUI()
+    try:
+        oneLine = ui._gameScreenLayout(3, 1, 5)
+        threeLines = ui._gameScreenLayout(3, 3, 5)
+        assert threeLines["promptY"] == oneLine["promptY"]
+        assert threeLines["optionsY"] - oneLine["optionsY"] == 2 * oneLine["lineHeight"]
+    finally:
+        ui.cleanup()
+
+
+def test_wrapText_keeps_every_line_within_the_width():
+    # a line too wide for the window is broken into lines that each fit
+    ui = makeUI()
+    try:
+        maxWidth = ui._textWidth()
+        text = "You reel in a fish and the whole village hears about it. " * 5
+        lines = ui._wrapText(text, ui.font_medium, maxWidth)
+        assert len(lines) > 1
+        for line in lines:
+            assert ui.font_medium.size(line)[0] <= maxWidth
+    finally:
+        ui.cleanup()
+
+
+def test_wrapText_preserves_newlines_and_blank_lines():
+    # pygame's render ignores "\n", so the wrap has to turn them into real lines
+    ui = makeUI()
+    try:
+        lines = ui._wrapText("Total Fish Caught: 3\n\nMilestones:", ui.font_medium, 700)
+        assert lines == ["Total Fish Caught: 3", "", "Milestones:"]
+    finally:
+        ui.cleanup()
+
+
+def test_wrapText_breaks_a_word_wider_than_the_window():
+    # word wrapping can't help a single over-wide word, so it is split by
+    # character instead of being clipped at the window edge
+    ui = makeUI()
+    try:
+        lines = ui._wrapText("x" * 200, ui.font_medium, 200)
+        assert len(lines) > 1
+        assert "".join(lines) == "x" * 200
+        for line in lines:
+            assert ui.font_medium.size(line)[0] <= 200
+    finally:
+        ui.cleanup()
+
+
+def test_wrapText_leaves_short_text_alone():
+    ui = makeUI()
+    try:
+        assert ui._wrapText("Slot 1 deleted.", ui.font_medium, ui._textWidth()) == [
+            "Slot 1 deleted."
+        ]
+    finally:
+        ui.cleanup()
+
+
+def test_dialogueScrollBounds_reports_scrollable_overflow():
+    # more lines than fit leaves room to scroll; a short block does not
+    ui = makeUI()
+    try:
+        visible, maxScroll = ui._dialogueScrollBounds(500)
+        assert visible >= 1
+        assert maxScroll == 500 - visible
+        assert ui._dialogueScrollBounds(1)[1] == 0
+    finally:
+        ui.cleanup()
+
+
+def test_dialogueHint_mentions_scrolling_only_when_needed():
+    ui = makeUI()
+    try:
+        assert ui._dialogueHint(3, 0, 20) == "Press any key to continue"
+        hint = ui._dialogueHint(60, 5, 20)
+        assert "UP/DOWN" in hint
+        assert "(6-25 of 60)" in hint
     finally:
         ui.cleanup()
 
@@ -89,6 +262,16 @@ def injected_events(events):
         yield
 
 
+@contextlib.contextmanager
+def injected_event_frames(frames):
+    # Like injected_events, but each frame of the loop gets its own event list -
+    # needed for keys that don't end the loop (scrolling a dialogue).
+    with patch("ui.pygameUserInterface.pygame.event.get", side_effect=frames), patch(
+        "ui.pygameUserInterface.pygame.display.flip"
+    ), patch("ui.pygameUserInterface.pygame.time.Clock"):
+        yield
+
+
 def test_showDialogue_returns_on_keypress():
     ui = makeUI()
     try:
@@ -96,6 +279,45 @@ def test_showDialogue_returns_on_keypress():
         with injected_events([keydown()]):
             ui.showDialogue("some text")
         assert ui.currentPrompt.text == "What would you like to do?"
+    finally:
+        ui.cleanup()
+
+
+def test_showDialogue_scrolls_a_block_taller_than_the_window():
+    # DOWN scrolls a too-tall block instead of dismissing it; any other key
+    # dismisses it, so the drawn window moves down a line before continuing
+    ui = makeUI()
+    try:
+        text = "\n".join("Line %d" % i for i in range(100))
+        drawn = []
+        with patch.object(ui, "_draw_dialogue", lambda *args: drawn.append(args)):
+            with injected_event_frames(
+                [
+                    [keydown(key=pygame.K_DOWN)],
+                    [keydown(key=pygame.K_DOWN)],
+                    [keydown()],
+                ]
+            ):
+                ui.showDialogue(text)
+        scrollOffsets = [args[1] for args in drawn]
+        assert scrollOffsets == [1, 2, 2]
+    finally:
+        ui.cleanup()
+
+
+def test_showDialogue_does_not_scroll_past_the_last_line():
+    # UP at the top and DOWN at the bottom are both clamped
+    ui = makeUI()
+    try:
+        text = "\n".join("Line %d" % i for i in range(3))
+        drawn = []
+        with patch.object(ui, "_draw_dialogue", lambda *args: drawn.append(args)):
+            with injected_event_frames(
+                [[keydown(key=pygame.K_UP)], [keydown(key=pygame.K_DOWN)], [keydown()]]
+            ):
+                ui.showDialogue(text)
+        # the whole block fits, so there is nowhere to scroll to
+        assert [args[1] for args in drawn] == [0, 0, 0]
     finally:
         ui.cleanup()
 
@@ -138,6 +360,26 @@ def test_promptForText_handles_backspace():
         with injected_events(events):
             result = ui.promptForText("Name?")
         assert result == "a"
+    finally:
+        ui.cleanup()
+
+
+def test_draw_game_screen_handles_a_prompt_that_needs_wrapping():
+    # the goal announcement is appended to the prompt and is wider than the
+    # window on one line - drawing it wraps rather than raising or clipping
+    ui = makeUI()
+    try:
+        ui.currentLocationName = "Docks"
+        ui.goalProgress = "$10000 / $10000"
+        ui.currentPrompt.text = (
+            "What would you like to do?  [GOAL REACHED! You've built your fortune "
+            "of $10000! Keep fishing, or retire from the Home menu.]"
+        )
+        assert (
+            len(ui._wrapText(ui.currentPrompt.text, ui.font_medium, ui._textWidth()))
+            > 1
+        )
+        ui._draw_game_screen("The Docks", ["Cast a line", "Go home"])
     finally:
         ui.cleanup()
 


### PR DESCRIPTION
## Summary

Two pygame front-end defects, both about text the other two front-ends render correctly for free.

- **Wrap and scroll text (#118).** `pygame.font.Font.render()` draws a single row and renders `"\n"` as a glyph, so the pygame front-end was clipping or mangling anything that wasn't short and single-line. Measured on pygame 2.6.1 / SDL 2.28.4 at the default 800x600 window: a 25-line stats block rendered as one `(4288, 17)` surface, and the prompt with the goal announcement appended came to 983px wide. `_wrapText` now splits on newlines and word-wraps to the window (breaking a single over-wide word by character rather than clipping it), and it is applied to `showDialogue`, the prompt row of `_draw_game_screen`, `promptForText` (prompt and typed answer) and `timedKeyPress`. `showDialogue` scrolls with UP/DOWN when the block is taller than the window — the real stats screen wraps to ~30 lines against 21 visible — and any other key still continues, so nothing else changes.
- **Status block parity (#119).** `FishE.play` sets `currentLocationName` and `goalProgress` before every render and the console and web front-ends both show them; pygame showed neither. Both now appear (empty still hides the entry, same as the other two), and money is formatted `$%.2f` instead of printing a raw float such as `$20.010000000000002`.

## Why the status block is now grouped rows

Issue #119 proposed one row per stat, in the console's order. That doesn't fit: adding two rows to a one-per-row column, plus a prompt that can wrap, pushes the option list off the bottom edge. The docks menu (7 options) already overflowed the default window by 54px before this change:

```
options start: 402.0  end: 654.0  window height: 600
```

So the header instead groups stats a few per row — the same compact layout the web front-end's flex header already uses — and the vertical layout moved into `_gameScreenLayout`, which sizes the option rows against the space actually left over (never below the font's own line height). The busiest screen the game builds (3 header rows, a 2-line prompt, 7 options) now ends at 510px with both instruction lines on screen, and short menus keep their original 36px rows.

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `python3 -m pytest -q --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — 368 passed; `src/ui/pygameUserInterface.py` coverage 67% → 92%
- [x] `black` + `autoflake` per `format.sh` (limited to the two files this PR touches — the formatter also rewrites several unrelated files on this repo, left alone here)
- [x] Front-ends touched: **pygame only**. `BaseUserInterface` and its abstract primitives are unchanged, so the console and web front-ends are untouched; this PR brings pygame up to what those two already did.
- [x] Rendered the game screen, the stats dialogue and a scrolled dialogue headless (`SDL_VIDEODRIVER=dummy`) and checked the images: all 7 docks options visible, prompt wrapped to 2 lines, stats block readable, scroll hint reading `UP/DOWN to scroll (8-28 of 40) - any other key to continue`.

Closes #118
Closes #119

<!-- gardener-tend-dispatch -->



---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._