### PR TITLE
Rebind TimeService to the loaded player and stats after save load

### DIFF
--- a/src/fishE.py
+++ b/src/fishE.py
@@ -64,6 +64,15 @@ class FishE:
         if os.path.exists(time_path) and os.path.getsize(time_path) > 0:
             self.loadTimeService()
 
+        # loadPlayer()/loadStats() rebind self.player/self.stats to brand-new
+        # objects, but only loadTimeService() rebuilds the TimeService around
+        # them. When a slot has player.json/stats.json but no timeService.json,
+        # the TimeService built from the defaults above would keep pointing at
+        # the discarded objects, so every daily tick (interest, crew catch,
+        # investment income, rent) would apply to a player nobody reads.
+        self.timeService.player = self.player
+        self.timeService.stats = self.stats
+
         # Point the UI at the (possibly reloaded) game state.
         self.userInterface.player = self.player
         self.userInterface.timeService = self.timeService

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -110,6 +110,91 @@ def createGameForPersistence(data_directory):
     return game
 
 
+def createGameThroughInit(data_directory, saveFiles):
+    # Run the real FishE.__init__ against a temp save slot holding exactly
+    # saveFiles ({filename: json-serializable}), with only the save-slot menu
+    # and the front-end stubbed out - everything else is the real wiring, so
+    # the load block and the state it hands to TimeService are exercised.
+    fishE.Player = Player
+    fishE.Stats = Stats
+    fishE.TimeService = TimeService
+    fishE.Prompt = Prompt
+    fishE.PlayerJsonReaderWriter = PlayerJsonReaderWriter
+    fishE.StatsJsonReaderWriter = StatsJsonReaderWriter
+    fishE.TimeServiceJsonReaderWriter = TimeServiceJsonReaderWriter
+    fishE.SaveFileManager = SaveFileManager
+
+    slot = os.path.join(data_directory, "slot_1")
+    os.makedirs(slot, exist_ok=True)
+    for filename, contents in saveFiles.items():
+        with open(os.path.join(slot, filename), "w") as f:
+            json.dump(contents, f)
+
+    config = Config()
+    config.dataDirectory = data_directory
+
+    def selectSlotOne(self):
+        self.saveFileManager.select_save_slot(1)
+
+    with patch.object(fishE, "Config", return_value=config), patch.object(
+        fishE, "UserInterfaceFactory", MagicMock()
+    ), patch.object(fishE.FishE, "_selectSaveFile", selectSlotOne):
+        return fishE.FishE()
+
+
+def test_init_rebinds_timeService_to_loaded_player_without_timeService_file():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - a slot holding player.json and stats.json but no
+        # timeService.json, which is the shape migrate_old_save_files() produces
+        # from an old save that never had one
+        game = createGameThroughInit(
+            data_directory,
+            {
+                "player.json": PlayerJsonReaderWriter().createJsonFromPlayer(Player()),
+                "stats.json": StatsJsonReaderWriter().createJsonFromStats(Stats()),
+            },
+        )
+
+        # check - the TimeService drives the same objects the rest of the game
+        # uses, so daily interest/income/rent land on the loaded player
+        assert game.timeService.player is game.player
+        assert game.timeService.stats is game.stats
+
+
+def test_init_rebinds_timeService_when_only_player_file_present():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - the shape left behind by a save interrupted after
+        # player.json was written but before stats.json/timeService.json
+        game = createGameThroughInit(
+            data_directory,
+            {"player.json": PlayerJsonReaderWriter().createJsonFromPlayer(Player())},
+        )
+
+        # check
+        assert game.timeService.player is game.player
+        assert game.timeService.stats is game.stats
+
+
+def test_init_daily_tick_credits_the_loaded_player():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - a saved player with money in the bank, in a slot with no
+        # timeService.json
+        savedPlayer = Player()
+        savedPlayer.moneyInBank = 100
+        game = createGameThroughInit(
+            data_directory,
+            {"player.json": PlayerJsonReaderWriter().createJsonFromPlayer(savedPlayer)},
+        )
+        moneyInBankBefore = game.player.moneyInBank
+
+        # call
+        game.timeService.increaseDay()
+
+        # check - bank interest reaches the player the game actually reads
+        assert game.player.moneyInBank > moneyInBankBefore
+        assert game.stats.moneyMadeFromInterest > 0
+
+
 def test_save_then_load_roundtrip():
     # restore real classes in case an earlier test mocked the module globals
     fishE.Player = Player


### PR DESCRIPTION
## Summary

- `FishE.__init__` builds `TimeService(self.player, self.stats)` from the new-game defaults, then loads each save file only if it exists and is non-empty. `loadPlayer()`/`loadStats()` rebind `self.player`/`self.stats` to brand-new objects, but only `loadTimeService()` rebuilds the `TimeService` around them — so a slot holding `player.json` but no `timeService.json` left `self.timeService.player`/`.stats` pointing at the discarded defaults.
- Everything on the daily tick runs off those references: `TimeService.increaseDay` credits bank interest to `self.player`, then hands `self.player, self.stats` to `business.runDailyProduction`, `investments.runDailyIncome` and `housing.runDailyRent`. With a stale reference, a day rollover silently credited interest, crew catch and rental income to an object nobody reads, and charged rent against it too.
- Fixed by rebinding `self.timeService.player`/`.stats` once after the load block, alongside the existing `self.userInterface.player`/`.timeService` repointing.

That slot shape is reachable in practice: `SaveFileManager.migrate_old_save_files` gates on `player.json` only and moves whichever of the three files exist; the same shape also results from a save interrupted partway through `FishE.save()` (which writes `player.json` first), or from a zero-byte `timeService.json` that the `getsize(...) > 0` guard skips.

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `python3 -m pytest --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — 371 passed (368 before), coverage 94%
- [x] All three new tests were confirmed to fail against `main` (stashing only the `src/fishE.py` change) and pass with it
- [x] No front-end change — this is game-state wiring in `FishE.__init__`, below the `BaseUserInterface` contract, so console/pygame/web are all unaffected
- [x] No `Player`/`Stats`/`TimeService` field added, renamed or retyped, so `schemas/*.json` and the `*JsonReaderWriter` classes are unchanged (re-verified all three still match their reader-writer field-for-field)

New tests in `tests/test_fishE.py`, driving the real `FishE.__init__` against a temp save slot with only the save-slot menu and front-end stubbed:

- `test_init_rebinds_timeService_to_loaded_player_without_timeService_file` — slot with `player.json` + `stats.json`, no `timeService.json`
- `test_init_rebinds_timeService_when_only_player_file_present` — interrupted-save shape
- `test_init_daily_tick_credits_the_loaded_player` — behavioural: `increaseDay()` reaches the player the game actually reads

Closes #120

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._