### PR TITLE
Fix tavern money prompts truncating cents

### DIFF
--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -228,7 +228,7 @@ class Tavern:
                     continue
             elif input == 7:
                 self.changeBet(
-                    "How much money would you like to bet? Money: $%d"
+                    "How much money would you like to bet? Money: $%.2f"
                     % self.player.money
                 )
                 continue
@@ -242,7 +242,7 @@ class Tavern:
     def changeBet(self, prompt):
         amount = self.userInterface.promptForNumber(prompt)
         if amount is None:
-            self.currentPrompt.text = "Try again. Money: $%d" % self.player.money
+            self.currentPrompt.text = "Try again. Money: $%.2f" % self.player.money
             return
         self.amount = int(amount)
 
@@ -255,7 +255,8 @@ class Tavern:
             # Don't call self.gamble() recursively - let the main loop continue
         else:
             self.currentPrompt.text = (
-                "You don't have that much money on you! Money: $%d" % self.player.money
+                "You don't have that much money on you! Money: $%.2f"
+                % self.player.money
             )
 
     def talkToNPC(self):

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -361,6 +361,51 @@ def test_changeBet_invalid_input():
         builtins.input = original_input
 
 
+def test_changeBet_invalid_input_shows_cents():
+    # prepare - money picks up cents via bank withdrawals (see bank.py), so
+    # the retry prompt must not silently truncate them
+    tavernInstance = createTavern()
+    tavernInstance.player.money = 42.7
+    tavernInstance.userInterface.promptForNumber = MagicMock(return_value=None)
+
+    # call
+    tavernInstance.changeBet("How much money would you like to bet?")
+
+    # check
+    assert "$42.70" in tavernInstance.currentPrompt.text
+
+
+def test_changeBet_insufficient_money_shows_cents():
+    # prepare
+    tavernInstance = createTavern()
+    tavernInstance.player.money = 12.3
+    tavernInstance.userInterface.promptForNumber = MagicMock(return_value=100)
+
+    # call
+    tavernInstance.changeBet("How much money would you like to bet?")
+
+    # check
+    assert tavernInstance.currentBet == 0
+    assert "$12.30" in tavernInstance.currentPrompt.text
+
+
+def test_gamble_change_bet_prompt_shows_cents():
+    # prepare - the "Change Bet" option (7) rebuilds its prompt from
+    # player.money each time; a fractional balance must not lose its cents
+    tavernInstance = createTavern()
+    tavernInstance.player.money = 100.5
+    tavernInstance.changeBet = MagicMock()
+    tavernInstance.userInterface.showOptions = MagicMock(side_effect=["7", "8"])
+
+    # call
+    tavernInstance.gamble()
+
+    # check
+    tavernInstance.changeBet.assert_called_once()
+    promptArg = tavernInstance.changeBet.call_args[0][0]
+    assert "$100.50" in promptArg
+
+
 def test_getDrunk_updates_stats():
     # prepare
     tavernInstance = createTavern()


### PR DESCRIPTION
## Summary
- `player.money` can hold a fractional value after a bank withdrawal (`bank.py` already parses withdraw/deposit amounts with `float(input())`), but three "Change Bet" prompts in `tavern.py` formatted `self.player.money` with `%d`, silently dropping the cents.
- Switched those three prompts (in `gamble()`'s "Change Bet" branch and `changeBet()`'s two outcome branches) to `%.2f`, matching the convention `bank.py` already uses for the same field.
- `currentBet`/`winAmount`/`diceThrow` displays were left as `%d` — those are always whole dollars by design (`changeBet` does `self.amount = int(amount)`), so no change needed there.

## Test plan
- [x] Added `test_changeBet_invalid_input_shows_cents`, `test_changeBet_insufficient_money_shows_cents`, and `test_gamble_change_bet_prompt_shows_cents` to `tests/location/test_tavern.py`, each asserting the generated prompt text retains cents (e.g. `$42.70`).
- [x] Verified regression coverage: stashed the `tavern.py` fix, confirmed all three new tests fail against the old `%d` code, then restored the fix and confirmed they pass.
- [x] `python3 -m compileall -q src tests`
- [x] Full suite: 374 passed (`SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest`)

## Triage notes
- The repo's only open issue (#122, PLANNING.md's stale-looking bait-price GOALS entry) explicitly requires the repo owner's memory of the original bug symptom to resolve safely — left open, not picked for this cycle.

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._