### PR TITLE
Show short game pauses through the front-end

### DIFF
--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -1,6 +1,4 @@
 import random
-import sys
-import time
 
 from location.enum.locationType import LocationType
 from player.player import Player
@@ -332,12 +330,7 @@ class Docks:
         return 1.0, ""
 
     def fish(self):
-        self.userInterface.lotsOfSpace()
-        self.userInterface.divider()
-
-        print("Fishing... "),
-        sys.stdout.flush()
-        time.sleep(1)
+        self.userInterface.showBusy("Fishing...", 1)
 
         # Capture the time of day at the start of the trip (the loop advances it).
         timeFactor, timeLabel = self.getTimeOfDayModifier(self.timeService.time)

--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -1,6 +1,4 @@
 import random
-import sys
-import time
 
 from location.enum.locationType import LocationType
 
@@ -68,7 +66,8 @@ class Tavern:
                     "response": "Ah, the tavern! This is the place to unwind after a long day. "
                     "You can get yourself drunk for $10 - though you'll wake up at home with a headache the next day! "
                     "Or if you're feeling lucky, you can gamble with the dice. Place a bet, pick a number from 1 to 6, "
-                    "and if the dice matches your choice, you'll win %dx your money!" % DICE_WIN_MULTIPLIER,
+                    "and if the dice matches your choice, you'll win %dx your money!"
+                    % DICE_WIN_MULTIPLIER,
                 },
                 {
                     "question": "Tell me about the other villagers.",
@@ -151,15 +150,9 @@ class Tavern:
             return LocationType.DOCKS
 
     def getDrunk(self):
-        self.userInterface.lotsOfSpace()
-        self.userInterface.divider()
-
         self.player.spendMoney(10)
 
-        for i in range(3):
-            print("... ")
-            sys.stdout.flush()
-            time.sleep(1)
+        self.userInterface.showBusy("You drink your way into the evening...", 3)
 
         self.stats.timesGottenDrunk += 1
 

--- a/src/ui/baseUserInterface.py
+++ b/src/ui/baseUserInterface.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 from prompt.prompt import Prompt
 from player.player import Player
@@ -88,6 +89,16 @@ class BaseUserInterface(ABC):
     def cleanup(self):
         """Release any resources held by the front-end."""
         pass
+
+    def showBusy(self, message, seconds=1.0):
+        """Show a message while the game pauses, without waiting for input.
+
+        Used by the short "Fishing..." style beats, which otherwise have no way
+        to say anything: showDialogue would demand a keypress the game never
+        asked for. Concrete (not abstract) so a front-end that has nothing to
+        draw still gets the pause; every front-end in this repo overrides it to
+        actually show the message."""
+        time.sleep(seconds)
 
     def promptForNumber(self, promptText):
         """Prompt for a number via promptForText; return a float or None if the

--- a/src/ui/pygameUserInterface.py
+++ b/src/ui/pygameUserInterface.py
@@ -478,6 +478,37 @@ class PygameUserInterface(BaseUserInterface):
 
         return entered
 
+    def showBusy(self, message, seconds=1.0):
+        """Draw a message and hold it for `seconds`, taking no input.
+
+        The window keeps being redrawn and its events pumped throughout, so the
+        pause looks like the game working rather than the window hanging."""
+        endTime = time.time() + seconds
+        while time.time() < endTime:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.cleanup()
+                    sys.exit()
+                elif event.type == pygame.VIDEORESIZE:
+                    self._handle_resize(event.w, event.h)
+
+            self._draw_busy(message)
+            pygame.display.flip()
+            pygame.time.Clock().tick(60)
+
+    def _draw_busy(self, message):
+        """Draw the wrapped busy message. Split out from showBusy so the layout
+        can be tested without driving the wait loop."""
+        self.screen.fill(self.BLACK)
+        margin_x = self.width * 0.06
+        lineHeight = max(self.font_medium.get_linesize(), 1)
+        y_offset = self.height * 0.4
+        for line in self._wrapText(message, self.font_medium, self._textWidth()):
+            self.screen.blit(
+                self.font_medium.render(line, True, self.WHITE), (margin_x, y_offset)
+            )
+            y_offset += lineHeight
+
     def timedKeyPress(self, message):
         """Show a message and return the seconds until the player presses a key."""
         startTime = time.time()

--- a/src/ui/userInterface.py
+++ b/src/ui/userInterface.py
@@ -130,6 +130,20 @@ class UserInterface(BaseUserInterface):
         self.divider()
         return input("> ")
 
+    def showBusy(self, message, seconds=1.0):
+        """Print the message, then a dot row per second spent waiting."""
+        self.lotsOfSpace()
+        self.divider()
+        print(message)
+        sys.stdout.flush()
+        remaining = seconds
+        while remaining > 0:
+            step = min(1.0, remaining)
+            time.sleep(step)
+            remaining -= step
+            print("... ")
+            sys.stdout.flush()
+
     def timedKeyPress(self, message):
         print(message)
         sys.stdout.flush()

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -157,6 +157,10 @@ function render(screen) {
     inp.onkeydown = (e) => { if (e.key === "Enter") submit(); };
     b.onclick = submit;
     app.append(inp); app.append(b); inp.focus();
+  } else if (screen.type === "busy") {
+    // A pause the game takes on its own — shown, but with nothing to click;
+    // the next screen replaces it when the pause is over.
+    app.append(el("div", { className: "descriptor", textContent: screen.message }));
   } else if (screen.type === "timed") {
     app.append(el("div", { className: "descriptor", textContent: screen.message }));
     const b = el("button", { textContent: "React!", className: "action" });
@@ -331,6 +335,13 @@ class WebUserInterface(BaseUserInterface):
             return float(self._inputQueue.get())
         except (ValueError, TypeError):
             return None
+
+    def showBusy(self, message, seconds=1.0):
+        # Published as its own screen type so the browser shows the message
+        # instead of sitting on the previous screen. No input is consumed —
+        # whatever the game presents next supersedes it.
+        self._present({"type": "busy", "message": message})
+        time.sleep(seconds)
 
     def timedKeyPress(self, message):
         self._present({"type": "timed", "message": message})

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -15,6 +15,9 @@ def createDocks():
     stats = Stats()
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
+    # fish() opens with a one-second "Fishing..." pause on the real front-end;
+    # stub it so the tests neither print to the console nor wait it out.
+    userInterface.showBusy = MagicMock()
     return docks.Docks(userInterface, currentPrompt, player, stats, timeService)
 
 
@@ -192,16 +195,10 @@ def test_run_go_to_bank_action():
 def test_fish():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.lotsOfSpace = MagicMock()
-    docksInstance.userInterface.divider = MagicMock()
     # The active UI captures and times the reaction; mock a quick (perfect) one.
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", return_value=3
-    ):
+    with patch("src.location.docks.random.randint", return_value=3):
         docksInstance.timeService.increaseTime = MagicMock(
             return_value={"evicted": False}
         )
@@ -209,9 +206,10 @@ def test_fish():
         # call
         docksInstance.fish()
 
-        # check
-        docksInstance.userInterface.lotsOfSpace.assert_called_once()
-        docksInstance.userInterface.divider.assert_called_once()
+        # check - the trip announces itself through the front-end, so every UI
+        # shows it rather than only the console seeing a print()
+        docksInstance.userInterface.showBusy.assert_called_once()
+        assert "Fishing" in docksInstance.userInterface.showBusy.call_args[0][0]
         # Player should catch fish based on success rate
         assert docksInstance.player.fishCount >= 1
         assert docksInstance.stats.totalFishCaught >= 1
@@ -242,11 +240,7 @@ def test_fish_consumes_energy():
     docksInstance.userInterface.divider = MagicMock()
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", return_value=3
-    ):
+    with patch("src.location.docks.random.randint", return_value=3):
         docksInstance.timeService.increaseTime = MagicMock(
             return_value={"evicted": False}
         )
@@ -268,11 +262,7 @@ def test_fish_with_limited_energy():
     docksInstance.userInterface.divider = MagicMock()
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", return_value=5
-    ):
+    with patch("src.location.docks.random.randint", return_value=5):
         docksInstance.timeService.increaseTime = MagicMock(
             return_value={"evicted": False}
         )
@@ -295,11 +285,7 @@ def test_fish_mentions_eviction_when_a_day_rolls_over_mid_trip():
     docksInstance.userInterface.divider = MagicMock()
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", side_effect=[3, 6]
-    ):
+    with patch("src.location.docks.random.randint", side_effect=[3, 6]):
         # the day rolls over (and evicts) partway through the trip
         docksInstance.timeService.increaseTime = MagicMock(
             side_effect=[
@@ -324,11 +310,7 @@ def test_fish_interactive_success():
     # Quick reaction => perfect-quality catch.
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", side_effect=[3, 6]
-    ):
+    with patch("src.location.docks.random.randint", side_effect=[3, 6]):
         docksInstance.timeService.increaseTime = MagicMock(
             return_value={"evicted": False}
         )
@@ -356,11 +338,7 @@ def test_fish_slow_reaction_yields_fewer_than_fast():
         docksInstance = make_docks()
         docksInstance.userInterface.timedKeyPress = MagicMock(return_value=reactionTime)
 
-        with patch("src.location.docks.print"), patch(
-            "src.location.docks.sys.stdout.flush"
-        ), patch("src.location.docks.time.sleep"), patch(
-            "src.location.docks.random.randint", side_effect=[3, 10]
-        ):
+        with patch("src.location.docks.random.randint", side_effect=[3, 10]):
             docksInstance.timeService.increaseTime = MagicMock(
                 return_value={"evicted": False}
             )
@@ -418,9 +396,7 @@ def test_fish_applies_weather_modifier():
     for weather in ("stormy", "rainy"):
         docksInstance = make_docks_in(weather)
         docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
-        with patch("src.location.docks.print"), patch(
-            "src.location.docks.sys.stdout.flush"
-        ), patch("src.location.docks.time.sleep"), patch(
+        with patch(
             "src.location.docks.random.randint", side_effect=[5, 10]
         ):  # 5 hours, baseFish 10
             docksInstance.timeService.increaseTime = MagicMock(
@@ -441,11 +417,7 @@ def test_fish_mentions_weather_label():
     docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
     docksInstance.timeService.weather = "rainy"
 
-    with patch("src.location.docks.print"), patch(
-        "src.location.docks.sys.stdout.flush"
-    ), patch("src.location.docks.time.sleep"), patch(
-        "src.location.docks.random.randint", side_effect=[3, 6]
-    ):
+    with patch("src.location.docks.random.randint", side_effect=[3, 6]):
         docksInstance.timeService.increaseTime = MagicMock(
             return_value={"evicted": False}
         )
@@ -484,9 +456,7 @@ def test_fish_applies_time_of_day_modifier():
     for label, hour in (("midday", 12), ("dawn", 6)):
         docksInstance = make_docks_at(hour)
         docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
-        with patch("src.location.docks.print"), patch(
-            "src.location.docks.sys.stdout.flush"
-        ), patch("src.location.docks.time.sleep"), patch(
+        with patch(
             "src.location.docks.random.randint", side_effect=[5, 10]
         ):  # 5 hours, baseFish 10
             docksInstance.timeService.increaseTime = MagicMock(
@@ -514,11 +484,7 @@ def test_fish_higher_rod_widens_reaction_window():
         docksInstance = make_docks_with_rod(rod)
         # A 2.5s reaction is too slow at rod level 1 but within a high rod's window.
         docksInstance.userInterface.timedKeyPress = MagicMock(return_value=2.5)
-        with patch("src.location.docks.print"), patch(
-            "src.location.docks.sys.stdout.flush"
-        ), patch("src.location.docks.time.sleep"), patch(
-            "src.location.docks.random.randint", side_effect=[5, 10]
-        ):
+        with patch("src.location.docks.random.randint", side_effect=[5, 10]):
             docksInstance.timeService.increaseTime = MagicMock(
                 return_value={"evicted": False}
             )

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -14,6 +14,9 @@ def createTavern():
     stats = Stats()
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
+    # getDrunk() opens with a three-second pause on the real front-end; stub it
+    # so the tests neither print to the console nor wait it out.
+    userInterface.showBusy = MagicMock()
     return tavern.Tavern(userInterface, currentPrompt, player, stats, timeService)
 
 
@@ -168,20 +171,15 @@ def test_npc_business_dialogue_mentions_business_name():
 def test_getDrunk():
     # prepare
     tavernInstance = createTavern()
-    tavernInstance.userInterface.lotsOfSpace = MagicMock()
-    tavernInstance.userInterface.divider = MagicMock()
     tavernInstance.player.money = 10
-    tavern.print = MagicMock()
-    tavern.sys.stdout.flush = MagicMock()
-    tavern.time.sleep = MagicMock()
     tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call
     tavernInstance.getDrunk()
 
-    # check
-    assert tavern.print.call_count == 3
-    assert tavern.sys.stdout.flush.call_count == 3
+    # check - the night out is announced through the front-end, so every UI
+    # shows it rather than only the console seeing a print()
+    tavernInstance.userInterface.showBusy.assert_called_once()
     tavernInstance.timeService.increaseDay.assert_called_once()
 
 
@@ -190,12 +188,7 @@ def test_getDrunk_mentions_eviction_when_it_happens():
     from src.housing import housing
 
     tavernInstance = createTavern()
-    tavernInstance.userInterface.lotsOfSpace = MagicMock()
-    tavernInstance.userInterface.divider = MagicMock()
     tavernInstance.player.money = 10
-    tavern.print = MagicMock()
-    tavern.sys.stdout.flush = MagicMock()
-    tavern.time.sleep = MagicMock()
     tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": True})
 
     # call
@@ -455,13 +448,8 @@ def test_gamble_change_bet_prompt_shows_cents():
 def test_getDrunk_updates_stats():
     # prepare
     tavernInstance = createTavern()
-    tavernInstance.userInterface.lotsOfSpace = MagicMock()
-    tavernInstance.userInterface.divider = MagicMock()
     tavernInstance.player.money = 20
     tavernInstance.stats.timesGottenDrunk = 0
-    tavern.print = MagicMock()
-    tavern.sys.stdout.flush = MagicMock()
-    tavern.time.sleep = MagicMock()
     tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call - skip the random additional-loss path (>= 0.3 means no extra loss)
@@ -478,13 +466,8 @@ def test_getDrunk_updates_stats():
 def test_getDrunk_can_earn_a_tip():
     # prepare
     tavernInstance = createTavern()
-    tavernInstance.userInterface.lotsOfSpace = MagicMock()
-    tavernInstance.userInterface.divider = MagicMock()
     tavernInstance.player.money = 20
     tavernInstance.stats.totalMoneyMade = 0
-    tavern.print = MagicMock()
-    tavern.sys.stdout.flush = MagicMock()
-    tavern.time.sleep = MagicMock()
     tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call - land in the "tip" outcome (>= loss chance, < loss + tip) and fix
@@ -585,13 +568,8 @@ def test_getDrunk_loses_money_in_drunken_stupor():
     # prepare - land in the money-loss branch (roll < DRUNK_LOSS_CHANCE) with
     # a fixed loss percentage so the amount lost is deterministic.
     tavernInstance = createTavern()
-    tavernInstance.userInterface.lotsOfSpace = MagicMock()
-    tavernInstance.userInterface.divider = MagicMock()
     tavernInstance.player.money = 100
     tavernInstance.stats.moneyLostWhileDrunk = 0
-    tavern.print = MagicMock()
-    tavern.sys.stdout.flush = MagicMock()
-    tavern.time.sleep = MagicMock()
     tavernInstance.timeService.increaseDay = MagicMock(return_value={"evicted": False})
 
     # call - $10 drink cost leaves $90, then a 20% stupor loss of that $90

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -522,7 +522,9 @@ def test_gamble_loss_via_real_loop():
         textAfterLoss.append(tavernInstance.currentPrompt.text)
         return "8"
 
-    tavernInstance.userInterface.showOptions = MagicMock(side_effect=showOptionsSideEffect)
+    tavernInstance.userInterface.showOptions = MagicMock(
+        side_effect=showOptionsSideEffect
+    )
 
     # call
     with patch("src.location.tavern.random.randint", return_value=4):
@@ -553,7 +555,9 @@ def test_gamble_no_bet_placed():
         textAfterAttempt.append(tavernInstance.currentPrompt.text)
         return "8"
 
-    tavernInstance.userInterface.showOptions = MagicMock(side_effect=showOptionsSideEffect)
+    tavernInstance.userInterface.showOptions = MagicMock(
+        side_effect=showOptionsSideEffect
+    )
 
     # call
     with patch("src.location.tavern.random.randint") as mockRandint:

--- a/tests/ui/test_baseUserInterface.py
+++ b/tests/ui/test_baseUserInterface.py
@@ -7,6 +7,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 import pytest
+from unittest.mock import patch
 
 from ui.baseUserInterface import BaseUserInterface
 from ui.userInterface import UserInterface
@@ -80,6 +81,22 @@ class FakeNPC:
 
     def introduce(self):
         return "Hello"
+
+
+def test_showBusy_is_inherited_and_only_waits():
+    # prepare - RecordingUserInterface implements the abstract primitives only,
+    # so it exercises the default a new front-end would get for free
+    prompt, timeService, player = makeArgs()
+    ui = RecordingUserInterface(prompt, timeService, player, choices=[])
+
+    # call
+    with patch("ui.baseUserInterface.time.sleep") as sleep:
+        ui.showBusy("Fishing...", 2)
+
+    # check - the pause happens and nothing is shown or acknowledged
+    sleep.assert_called_once_with(2)
+    assert ui.shownDialogues == []
+    assert ui.currentPrompt.text == "What would you like to do?"
 
 
 def test_promptForNumber_parses_or_returns_none():

--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -436,16 +436,24 @@ def test_showBusy_draws_the_message_until_the_wait_is_over():
         ui.cleanup()
 
 
-def test_showBusy_takes_no_input_and_leaves_the_prompt_alone():
-    # Unlike showDialogue, a busy pause isn't the player acknowledging anything,
-    # so it must not rewrite the current prompt out from under the game.
+def test_showBusy_ignores_keypresses_and_leaves_the_prompt_alone():
+    # Unlike showDialogue, a busy pause isn't the player acknowledging anything:
+    # a keypress must neither cut it short nor rewrite the current prompt.
     ui = makeUI()
     try:
         ui.currentPrompt.text = "before"
+        drawn = []
+        # t=0 on entry, then two checks inside the 1 second wait and one past it
         with patch(
-            "ui.pygameUserInterface.time.time", side_effect=[0.0, 5.0]
-        ), injected_events([keydown()]):
+            "ui.pygameUserInterface.time.time", side_effect=[0.0, 0.1, 0.2, 5.0]
+        ), patch.object(
+            ui, "_draw_busy", lambda message: drawn.append(message)
+        ), injected_event_frames(
+            [[keydown()], []]
+        ):
             ui.showBusy("Fishing...", 1)
+        # a second frame was drawn after the keypress, so it wasn't taken as input
+        assert len(drawn) == 2
         assert ui.currentPrompt.text == "before"
     finally:
         ui.cleanup()

--- a/tests/ui/test_pygameUserInterface.py
+++ b/tests/ui/test_pygameUserInterface.py
@@ -243,7 +243,7 @@ def test_update_fonts_keeps_fonts_usable_when_tiny():
 # --- interactive input primitives (events injected via patched pygame.event.get) ---
 import contextlib  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
-from unittest.mock import patch  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pygame  # noqa: E402
 
@@ -414,5 +414,51 @@ def test_showOptions_ignores_out_of_range_number():
         with injected_events([keydown(key=pygame.K_9), keydown(key=pygame.K_1)]):
             choice = ui.showOptions("Pick", ["A", "B"])
         assert choice == "1"
+    finally:
+        ui.cleanup()
+
+
+def test_showBusy_draws_the_message_until_the_wait_is_over():
+    # The pause has to be drawn in the window - before showBusy existed the
+    # message went to the terminal and the player just saw a frozen screen.
+    ui = makeUI()
+    try:
+        drawn = []
+        # t=0 (loop entry), then 0.0 and 1.5 as the two loop-condition checks:
+        # the first is inside the 1 second wait, the second past its end.
+        with patch(
+            "ui.pygameUserInterface.time.time", side_effect=[0.0, 0.0, 1.5]
+        ), patch.object(ui, "_draw_busy", lambda message: drawn.append(message)):
+            with injected_events([]):
+                ui.showBusy("Fishing...", 1)
+        assert drawn == ["Fishing..."]
+    finally:
+        ui.cleanup()
+
+
+def test_showBusy_takes_no_input_and_leaves_the_prompt_alone():
+    # Unlike showDialogue, a busy pause isn't the player acknowledging anything,
+    # so it must not rewrite the current prompt out from under the game.
+    ui = makeUI()
+    try:
+        ui.currentPrompt.text = "before"
+        with patch(
+            "ui.pygameUserInterface.time.time", side_effect=[0.0, 5.0]
+        ), injected_events([keydown()]):
+            ui.showBusy("Fishing...", 1)
+        assert ui.currentPrompt.text == "before"
+    finally:
+        ui.cleanup()
+
+
+def test_drawBusy_wraps_a_message_wider_than_the_window():
+    ui = makeUI()
+    try:
+        # A Surface's blit can't be patched (it's read-only), so the whole
+        # target surface is swapped out to count the drawn lines.
+        ui.screen = MagicMock()
+        ui._draw_busy("Fishing... " * 40)
+        # more than one line means the long message was wrapped, not clipped
+        assert ui.screen.blit.call_count > 1
     finally:
         ui.cleanup()

--- a/tests/ui/test_userInterface.py
+++ b/tests/ui/test_userInterface.py
@@ -259,3 +259,36 @@ def test_timedKeyPress_returns_reaction_seconds():
 
     # check
     assert reaction == 1.5
+
+
+def test_showBusy_prints_the_message_and_waits():
+    # setup
+    userInterfaceInstance = createUserInterface()
+    userInterfaceInstance.lotsOfSpace = MagicMock()
+    userInterfaceInstance.divider = MagicMock()
+    printed = []
+    userInterface.print = MagicMock(side_effect=lambda text: printed.append(text))
+
+    # call - a 3 second pause, without actually spending 3 seconds
+    with patch("src.ui.userInterface.time.sleep") as sleep:
+        userInterfaceInstance.showBusy("Fishing...", 3)
+
+    # check - the message is shown, then one dot row per second waited
+    assert printed[0] == "Fishing..."
+    assert printed[1:] == ["... "] * 3
+    assert [call.args[0] for call in sleep.call_args_list] == [1.0, 1.0, 1.0]
+
+
+def test_showBusy_waits_a_fractional_second_in_one_step():
+    # setup
+    userInterfaceInstance = createUserInterface()
+    userInterfaceInstance.lotsOfSpace = MagicMock()
+    userInterfaceInstance.divider = MagicMock()
+    userInterface.print = MagicMock()
+
+    # call
+    with patch("src.ui.userInterface.time.sleep") as sleep:
+        userInterfaceInstance.showBusy("Fishing...", 0.5)
+
+    # check - a sub-second wait isn't rounded up into a full second
+    assert [call.args[0] for call in sleep.call_args_list] == [0.5]

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -10,6 +10,7 @@ import urllib.request
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from housing import housing
+from ui import webUserInterface
 from ui.baseUserInterface import BaseUserInterface
 from ui.webUserInterface import WebUserInterface
 from player.player import Player
@@ -128,6 +129,27 @@ def test_timedKeyPress_returns_elapsed_seconds():
     ui.submit_input("")
     thread.join(timeout=2)
     assert box["result"] >= 0.0
+
+
+def test_showBusy_presents_the_message_without_consuming_input():
+    # The pause has to reach the browser - before showBusy existed the message
+    # went to the server's terminal and the page sat on the previous screen.
+    ui = makeWebUI()
+    thread, box = runInThread(lambda: ui.showBusy("Fishing...", 0.05))
+    waitForScreen(ui, "busy")
+    assert ui.get_state()["screen"]["message"] == "Fishing..."
+
+    thread.join(timeout=2)
+    # A stray submission during the pause is left in the queue for whatever the
+    # game asks next, rather than being swallowed by the pause.
+    ui.submit_input("1")
+    assert ui._inputQueue.get(timeout=1) == "1"
+
+
+def test_busy_screen_is_rendered_by_the_client():
+    # The client only renders screen types it knows about, so a new type on the
+    # server needs its branch on the page too.
+    assert 'screen.type === "busy"' in webUserInterface.HTML_PAGE
 
 
 def test_http_server_serves_and_accepts_input():


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Adds a **`showBusy(message, seconds)` primitive to `BaseUserInterface`** and routes the game's two short pauses through it.

`Docks.fish` and `Tavern.getDrunk` used to `print()` their flavour text and `time.sleep()` directly, bypassing the UI contract. On the console that read fine; on the other two front-ends the text went to the terminal and the player just saw the previous screen frozen for 1-3 seconds. (`getDrunk` also called `lotsOfSpace()`/`divider()` first, which on pygame fills the surface without ever flipping the display, and on web are documented no-ops — so nothing was drawn either.)

Implemented in all three front-ends:

- **console** — prints the message, then a dot row per second waited (the old "... " animation).
- **pygame** — draws the wrapped message and flips every frame, pumping events (including QUIT and resize) so the window stays responsive rather than looking hung.
- **web** — publishes a `busy` screen the client renders, and consumes no input; the next screen supersedes it.
- The base implementation is concrete (just the pause), so a future front-end still works without changing it — the abstract primitive list is unchanged, and `README.md`'s "implement `BaseUserInterface` + a `UIType` + a factory branch" instruction still holds as written.

Closes #125

> **Note:** this branch originally also carried fixes for #126 and #127, which landed independently in #128 while it was in review. It has been rebased onto that work, taking main's version of both; what remains is only the `showBusy` change.

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — **388 passed**, coverage 95%
- [x] **All three front-ends touched and covered:** new tests for the console (`test_userInterface.py`), pygame (`test_pygameUserInterface.py` — the message is drawn, a keypress neither ends the pause nor rewrites the prompt, and an over-wide message wraps), web (`test_webUserInterface.py` — the `busy` screen is presented, no input is consumed, and the client page has a matching render branch), and the inherited default (`test_baseUserInterface.py`).
- [x] Call-site tests updated: `test_docks.py`/`test_tavern.py` stub `showBusy` instead of patching `print`/`sys.stdout.flush`/`time.sleep`, and assert the pause is announced through the UI.
- [x] No `Player`/`Stats`/`TimeService` field changed, so `schemas/*.json` and the `*JsonReaderWriter`s are correctly untouched; `README.md`/`PLANNING.md` describe nothing that changed here.


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._