### PR TITLE
Remove stale bait-price GOALS entry from PLANNING.md

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -2,9 +2,6 @@ General Idea
 You are a fisherman living in a home by the docks. There’s a store nearby that you can walk to and you sell your fish there. You’re able to buy better fishing gear and deposit your money in the bank. Every day is a new opportunity to collect fish.
 
 
-GOALS
-- FISH LOADING BAIT PRICE BUG
-
 Maybes
 - Maybe make the fishMultiplier a chance thing
 - Aesthetic upgrades?


### PR DESCRIPTION
## Summary
- `PLANNING.md`'s only GOALS entry ("FISH LOADING BAIT PRICE BUG") is stale: `Player.priceForBait` round-trips correctly through `PlayerJsonReaderWriter`, is declared in `schemas/player.json`, and its 1.25x escalation on purchase (`src/location/shop.py`) is covered by tests. No reproducible bug exists against current code.
- Removed the GOALS section since it no longer describes an actionable/reproducible issue.

## Test plan
- [x] `python3 -m compileall -q src`
- [x] `python3 -m pytest -q` — 370 passed locally; the 32 failures are pre-existing pygame-display tests that need the `SDL_VIDEODRIVER=dummy`/`SDL_AUDIODRIVER=dummy` env vars this sandbox couldn't set (env-var-prefixed commands require approval not available in this run). This PR only touches `PLANNING.md`, so these are unrelated to the change; CI sets those env vars itself and is the real anchor here.

Closes #122

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._