### PR TITLE
Add coverage for Bank deposit/withdraw invalid-amount retry

### DIFF
--- a/tests/location/test_bank.py
+++ b/tests/location/test_bank.py
@@ -290,6 +290,43 @@ def test_withdraw_with_decimal():
     assert bankInstance.player.money == 10.50
 
 
+def test_deposit_invalid_input_retries_then_succeeds():
+    # prepare - the player types something non-numeric first (promptForNumber
+    # returns None), then a valid amount
+    bankInstance = createBank()
+    bankInstance.userInterface.lotsOfSpace = MagicMock()
+    bankInstance.userInterface.divider = MagicMock()
+    bankInstance.player.money = 100
+    bankInstance.player.moneyInBank = 0
+    bankInstance.userInterface.promptForNumber = MagicMock(side_effect=[None, 10.0])
+
+    # call
+    bankInstance.deposit()
+
+    # check - prompted twice, and the valid second attempt went through
+    assert bankInstance.userInterface.promptForNumber.call_count == 2
+    assert bankInstance.player.moneyInBank == 10
+    assert bankInstance.player.money == 90
+
+
+def test_withdraw_invalid_input_retries_then_succeeds():
+    # prepare - same invalid-then-valid input sequence as deposit, on withdraw
+    bankInstance = createBank()
+    bankInstance.userInterface.lotsOfSpace = MagicMock()
+    bankInstance.userInterface.divider = MagicMock()
+    bankInstance.player.moneyInBank = 100
+    bankInstance.player.money = 0
+    bankInstance.userInterface.promptForNumber = MagicMock(side_effect=[None, 10.0])
+
+    # call
+    bankInstance.withdraw()
+
+    # check - prompted twice, and the valid second attempt went through
+    assert bankInstance.userInterface.promptForNumber.call_count == 2
+    assert bankInstance.player.moneyInBank == 90
+    assert bankInstance.player.money == 10
+
+
 def test_manageInvestments_buy_when_affordable():
     # prepare
     from src.investments import investments


### PR DESCRIPTION
## Summary
- Full triage found no open issues/PRs and no documentation drift (README, PLANNING.md, and all three `schemas/*.json` match their models). No backlog work was skipped/deferred this cycle since the backlog was empty.
- This cycle is a Stage B unit-test-expansion cycle: `src/location/bank.py` was the only source file with a coverage gap that represents a real, player-reachable behavior — `Bank.deposit()`/`Bank.withdraw()` each loop back and re-prompt when `promptForNumber` returns `None` (i.e. the player typed something non-numeric), but neither retry branch had a test.
- Added `test_deposit_invalid_input_retries_then_succeeds` and `test_withdraw_invalid_input_retries_then_succeeds`, mirroring the sibling test structure already in `tests/location/test_bank.py`, using `side_effect=[None, 10.0]` to exercise the retry-then-succeed path deterministically.
- `src/location/bank.py` is now at 100% line coverage (was 96%, missing exactly these two branches).

## Test plan
- [x] `python3 -m compileall -q src`
- [x] Full suite (headless SDL): 404 passed, 0 failed
- [x] `tests/location/test_bank.py` alone: 25 passed
- [x] Coverage check confirms `src/location/bank.py` at 100%, no other file regressed

Closes: none — no tracking issue existed; this is a proactive Stage B test-expansion cycle per the dev-loop's tiebreaker (documentation/coverage work preferred when the issue backlog is empty).

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._