### PR TITLE
fix(docker): install jsonschema and copy schemas/ into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 FROM python:3.12-slim
 
-# No third-party deps: the game (and its web front-end) is stdlib-only —
-# pygame is only imported lazily by the pygame front-end, which this image
-# never selects, so it's deliberately not installed here. Matches the
-# gateway-dashboard/fleet-dashboard services' "no wheel supply chain to keep
-# patched" approach.
 WORKDIR /app
+
+# jsonschema is a real runtime dependency, not a test-only one: src/fishE.py
+# imports it at module scope, so the game cannot start without it. pygame is
+# deliberately absent — it is imported lazily by the pygame front-end only,
+# which this image never selects.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
 COPY src/ ./src/
 COPY examples/ ./examples/
+# The JSON Schemas the save-file readers validate against. Their paths are
+# relative to the process cwd (see playerJsonReaderWriter.PLAYER_SCHEMA_PATH =
+# "schemas/player.json"), which is /app here — so they must be copied in, or
+# every save load/write raises FileNotFoundError.
+COPY schemas/ ./schemas/
 
 # Create the data/ directory (see saveFileManager.py's default
 # data_directory="data", resolved relative to the process cwd -> /app/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Runtime dependencies for the game itself (console and web front-ends).
+#
+# pygame is deliberately NOT listed: it is imported lazily by the pygame
+# front-end only, so the console/web front-ends run without it. Install it
+# separately if you want UIType.PYGAME.
+jsonschema>=4.0,<5.0


### PR DESCRIPTION
## The image never ran

The Dockerfile (added in #113 for containerized deployment) installs no dependencies, on the stated premise that the game is stdlib-only. That premise is false — `src/fishE.py` imports `jsonschema` at module scope, so the game cannot start without it:

- `src/fishE.py:3` — `from jsonschema.exceptions import ValidationError`
- `src/validation/schemaValidator.py:4` — `from jsonschema import validate`

This was caught when the image was deployed for real for the first time (behind `fishe.danielstephenson.dev`). The container crash-looped **638 times** before it was pulled:

```
File "/app/examples/../src/fishE.py", line 3, in <module>
  from jsonschema.exceptions import ValidationError
ModuleNotFoundError: No module named 'jsonschema'
```

The dependency was recorded in exactly one place — `.github/workflows/test.yml`'s `pip install pytest pytest-cov jsonschema pygame`. There's no `requirements.txt`, and `run.sh`'s `checkDependencies()` (which would have installed one) is commented out, so nothing propagated it to the image.

## A second, latent bug behind the first

Fixing only the import would have moved the failure rather than removed it. The save-file readers resolve their schemas **relative to the process cwd**:

```python
PLAYER_SCHEMA_PATH = "schemas/player.json"   # playerJsonReaderWriter.py:5
```

cwd is `/app` in the image, and `schemas/` was never copied in — so every save load/write would have raised `FileNotFoundError`. The app would have started, served the menu, and then broken the moment a player touched a save slot.

## Changes

- **`requirements.txt`** (new) — `jsonschema>=4.0,<5.0`. `pygame` is deliberately excluded: the pygame front-end imports it lazily, so the console and web front-ends run without it.
- **`Dockerfile`** — install from `requirements.txt`, copy `schemas/`, and drop the inaccurate "no third-party deps" comment.

## Verification

Reproduced and fixed against the exact file layout each Dockerfile produces, using a clean venv with no `jsonschema`:

| | old layout | fixed layout |
|---|---|---|
| `python3 examples/web_app.py` | `ModuleNotFoundError: No module named 'jsonschema'` | starts, serves in ~1s |
| `GET /` | — | `200`, contains `<title>FishE</title>` |
| `GET /state` | — | `200`, JSON with `screen`/`version` |
| `validate_against_schema({}, PLAYER_SCHEMA_PATH)` | `FileNotFoundError: schemas/player.json` | schema loads (raises `ValidationError`, as expected for `{}`) |

The `GET /` check is the exact command the gateway healthcheck runs.

No `src/` changes, so the existing test suite is unaffected — CI installs `jsonschema` explicitly and is independent of the new `requirements.txt`.