### PR TITLE
Improve the web UI's mobile experience

### DIFF
--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -18,20 +18,30 @@ HTML_PAGE = """<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>FishE</title>
 <style>
+  /* text-size-adjust keeps Safari from inflating text of its own accord once
+     the viewport is device-width (most visible in landscape). */
+  html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
   body { font-family: monospace; background: #0b1d2a; color: #e0f0ff;
-         max-width: 680px; margin: 2rem auto; padding: 0 1rem; }
+         max-width: 680px; margin: 2rem auto; padding: 0 1rem;
+         /* The game can emit long unbroken strings; break them rather than
+            letting them scroll the page sideways. Inherited by the screens. */
+         overflow-wrap: break-word; }
   .header { color: #7fb0d0; border-bottom: 1px solid #2a4a5a;
             padding-bottom: .5rem; margin-bottom: 1rem;
             display: flex; flex-wrap: wrap; gap: .15rem 1.1rem; }
   .descriptor { margin: 1rem 0; font-size: 1.1rem; }
   .prompt { color: #9fd0ff; margin: 1rem 0; }
-  .dialogue { white-space: pre-wrap; margin: 1rem 0; line-height: 1.5; }
+  .dialogue { white-space: pre-wrap; overflow-wrap: break-word;
+              margin: 1rem 0; line-height: 1.5; }
   button { display: block; width: 100%; text-align: left; margin: .3rem 0;
            padding: .6rem; background: #163345; color: #e0f0ff;
            border: 1px solid #2a4a5a; border-radius: 4px; cursor: pointer;
-           font-family: monospace; font-size: 1rem; }
+           font-family: monospace; font-size: 1rem;
+           overflow-wrap: break-word;
+           touch-action: manipulation; }  /* no double-tap-to-zoom delay */
   button:hover { background: #1f4a63; }
   button.danger { background: #4a1620; border-color: #7a2a35; }
   button.danger:hover { background: #63202c; }
@@ -50,6 +60,21 @@ HTML_PAGE = """<!DOCTYPE html>
   .operator { color: #ffcf8f; font-weight: bold; }
   .notice { color: #9fd0ff; margin-top: 1rem; }
   .notice.warning { color: #ffcf8f; border-left: 3px solid #c77b2a; padding-left: .6rem; }
+  /* Phone-sized screens only: the desktop layout above is left as-is. Note that
+     font sizes are deliberately not reduced here — 1rem inputs (16px) are what
+     keeps iOS Safari from zooming the page in when a field is focused. */
+  @media (max-width: 600px) {
+    /* 2rem of vertical margin is a lot of a short screen to spend on nothing. */
+    body { margin: 1rem auto; padding: 0 .75rem; }
+    /* A wrapped header was stacking its rows almost on top of each other. */
+    .header { gap: .35rem 1rem; }
+    /* .6rem padding puts a button at ~40px tall, under the ~44px that is
+       comfortable to tap; .75rem clears it. Wider gaps between them, too. */
+    button { padding: .75rem .6rem; margin: .45rem 0; }
+    /* Continue/Submit/React! are the only thing to press on their screens —
+       give them the full width instead of a small target off to one side. */
+    button.action { width: 100%; padding: .75rem .6rem; }
+  }
 </style>
 </head>
 <body>

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -153,6 +153,31 @@ def test_busy_screen_is_rendered_by_the_client():
     assert 'screen.type === "busy"' in webUserInterface.HTML_PAGE
 
 
+def test_page_declares_a_mobile_viewport():
+    # Without this, phone browsers lay the page out at ~980px wide and scale it
+    # down, which renders every control too small to read or tap.
+    assert (
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        in webUserInterface.HTML_PAGE
+    )
+
+
+def test_page_has_narrow_screen_styles():
+    # Narrow-screen adjustments live in their own media query so the desktop
+    # layout is untouched; the action buttons go full-width for easier tapping.
+    page = webUserInterface.HTML_PAGE
+    assert "@media (max-width: 600px)" in page
+    narrow = page.split("@media (max-width: 600px)", 1)[1].split("</style>", 1)[0]
+    assert "button.action { width: 100%" in narrow
+
+
+def test_input_font_size_stays_at_least_16px():
+    # iOS Safari zooms the page in when focusing an input smaller than 16px;
+    # 1rem is 16px at the default root size, so it must not shrink.
+    rule = webUserInterface.HTML_PAGE.split("\n  input {", 1)[1].split("}", 1)[0]
+    assert "font-size: 1rem" in rule
+
+
 def test_http_server_serves_and_accepts_input():
     # Integration smoke test against a real ephemeral-port server.
     ui = makeWebUI(start_server=True, port=0)


### PR DESCRIPTION
## Problem

`HTML_PAGE` in `src/ui/webUserInterface.py` had no viewport meta tag. Mobile browsers therefore laid the page out at their ~980px virtual viewport and scaled it down, so all text and controls rendered tiny. Everything else here is a targeted narrow-screen pass over the same stylesheet — no redesign, no color changes, no new dependencies (still zero external assets).

## Changes

**The defect**
- Added `<meta name="viewport" content="width=device-width, initial-scale=1">`.

**Narrow-screen adjustments, isolated in `@media (max-width: 600px)`** so the desktop layout is untouched:
- `body` margin `2rem` -> `1rem` and padding `1rem` -> `.75rem`. 2rem of vertical margin is a large share of a short phone screen spent on nothing.
- `button` padding `.6rem` -> `.75rem`. At `.6rem` with a 1rem font a button is roughly 40px tall, under the ~44px comfortable tap target; `.75rem` clears it. Margin `.3rem` -> `.45rem` to reduce mis-taps between stacked options.
- `button.action` (Continue / Submit / React!) goes full width. It is the only control on those screens, so an auto-width button off to one side is a needlessly small target.
- `.header` row gap `.15rem` -> `.35rem`. The status chips genuinely wrap onto several rows on a phone, and at `.15rem` the rows sat almost on top of each other.

**Horizontal overflow**
- `overflow-wrap: break-word` on `body` (inherited), `.dialogue`, and `button`, so a long unbroken string from the game can never make the page scroll sideways — `.dialogue` uses `white-space: pre-wrap`, which otherwise would.

**Touch/text handling**
- `touch-action: manipulation` on buttons, dropping the double-tap-to-zoom delay.
- `text-size-adjust: 100%` on `html`, so Safari doesn't inflate text of its own accord now that the viewport is device-width (most visible in landscape).

## Deliberately left alone

- **Font sizes.** `input` stays at `font-size: 1rem`, which resolves to 16px at the default root size — exactly the threshold that keeps iOS Safari from zooming the page in on focus. Nothing in the media query shrinks any font.
- **The base desktop layout.** `max-width: 680px`, full-width block buttons, and the color scheme were already fine and are unchanged.
- **`.header { flex-wrap: wrap }`** itself — wrapping is the right behavior; only the row gap needed attention.

## Verification

- `python3 -m pytest`: **410 passed**.
- Ran the real app (`FISHE_WEB_HOST=0.0.0.0 FISHE_WEB_PORT=8234 python3 examples/web_app.py`) and fetched it: `GET /` -> 200 with the viewport meta and the media query present in the served HTML; `GET /state` -> 200 JSON.
- Added three tests in `tests/ui/test_webUserInterface.py`, in the style of the existing web-handler tests: the viewport tag is present, the narrow-screen block exists and makes action buttons full width, and the input font size never drops below 16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_