### PR TITLE
Add test for showInteractiveDialogue's no-options fallback

### DIFF
--- a/tests/ui/test_baseUserInterface.py
+++ b/tests/ui/test_baseUserInterface.py
@@ -149,6 +149,36 @@ class ConditionalNPC:
         return "Hello"
 
 
+class NoOptionsNPC:
+    """An NPC with zero available dialogue options - e.g. every option's
+    condition is currently false. showInteractiveDialogue falls back to a
+    plain introduction instead of showing an empty question menu."""
+
+    name = "Tester"
+
+    def get_dialogue_options(self):
+        return []
+
+    def get_dialogue_response(self, index):
+        return ""
+
+    def introduce(self):
+        return "Tester: Not much to say."
+
+
+def test_inherited_interactive_dialogue_falls_back_to_introduction_when_no_options():
+    # prepare - no choices are consumed since showOptions is never reached
+    prompt, timeService, player = makeArgs()
+    ui = RecordingUserInterface(prompt, timeService, player, choices=[])
+
+    # call
+    ui.showInteractiveDialogue(NoOptionsNPC())
+
+    # check - the introduction was shown via showDialogue, not a question menu
+    assert ui.shownDialogues == ["Tester: Not much to say."]
+    assert ui.currentPrompt.text == "What would you like to do?"
+
+
 def test_inherited_interactive_dialogue_reflects_unlocked_options():
     # prepare - the flow every front-end without an override inherits (pygame
     # and web both use it), so conditional options have to work here


### PR DESCRIPTION
## Summary
- Full-repo triage this cycle found no open issues/PRs and no drift: schemas match their models and `*JsonReaderWriter`s, README/PLANNING.md/Dockerfile/requirements.txt/install scripts all match actual behavior, money/price displays are correctly `%.2f` (or legitimately always-integer, using `%d`), no test relies on unseeded `random`, and no test hits a real filesystem/display.
- Coverage review (`pytest --cov=src`) showed `src/ui/baseUserInterface.py` at 82%, the lowest of any module. The uncovered non-abstract lines were `showInteractiveDialogue`'s fallback branch for an NPC with zero currently-available dialogue options (e.g. every option's `condition` is false) — this is shared logic both the pygame and web front-ends inherit without override, so it's real production behavior, just never exercised by a test.
- Added `test_inherited_interactive_dialogue_falls_back_to_introduction_when_no_options`, characterizing the current (correct) behavior: the NPC's `introduce()` text is shown via `showDialogue` instead of an empty question menu.

Per the entire-untouched-backlog note: there was no backlog to defer — zero open issues and zero open PRs at triage time, and no functional bugs were found during the review, so this cycle's only outcome is the test-expansion work above (Phase 2 Stage B).

## Test plan
- [x] `python3 -m compileall -q src`
- [x] Full suite (`pytest`, headless SDL) — 464 passed, up from 463
- [x] Coverage on `src/ui/baseUserInterface.py` rose from 82% → 88%; all remaining uncovered lines are unreachable `@abstractmethod` `pass` stub bodies

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._