### PR TITLE
Reveal the village one option at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,24 @@ python3 examples/web_app.py
 
 The entire game — save-file manager, fishing, shop, bank, tavern, and NPC dialogue — plays in the browser, with no extra dependencies (it uses only the Python standard library). Adding a new front-end means implementing `BaseUserInterface` and adding a `UIType` + factory branch.
 
+### One Thing at a Time
+A new game opens on the docks with a rod, a bucket, and exactly one thing to do: **fish**. Everything else in the village arrives later, one option at a time, as you earn it — and each arrival tells you why it's there:
+
+```
+ You caught 7 Minnow over 6 hours! A perfect hook!  [Milestone unlocked: First Catch!]
+ [Your basket is heavy with fish. Gilbert buys them at the shop - better go sell them.]
+
+ [1] Fish
+ [2] Go to Shop
+ [3] Quit
+```
+
+Sell that basket and you're shown where you sleep; put in a few days and the villagers start talking to you; save up and the bank, the boats and the property market open up in turn. New entries are appended to the bottom of the menu, so an option you already know keeps its number. Only ever one new thing per screen, even when you earned two at once — so there's never a wall of choices to read.
+
+Nothing is made harder by this; it's pacing, not difficulty. A save file from a player who already owns half the village opens with all of it available, exactly as before.
+
 ### Your Goal
-Build a fortune of **$10,000** in total wealth (cash on hand plus savings in the bank). Your progress toward the goal is shown in the status header, and reaching it earns a one-time victory — after which you're free to keep fishing or retire from the Home menu.
+Build a fortune of **$10,000** in total wealth (cash on hand plus savings in the bank). You're told about it once you've got your first $1,000 to your name, after which your progress toward the goal is shown in the status header. Reaching it earns a one-time victory — after which you're free to keep fishing or retire from the Home menu.
 
 ### Your Fleet
 Once you can afford it, buy a **boat** at the docks ("Manage Fleet") — and then another, and another. Every boat is dedicated to one of four **roles**, and you can re-dedicate her whenever you like:

--- a/schemas/stats.json
+++ b/schemas/stats.json
@@ -36,6 +36,13 @@
             },
             "description": "Names of milestones the player has already been awarded."
         },
+        "unlockedFeatures": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Ids of the features that have been revealed to the player so far."
+        },
         "totalWorkersHired": {
             "type": "integer",
             "description": "The lifetime number of workers hired for the fishing business."

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -16,6 +16,7 @@ from saveFileManager import SaveFileManager
 from achievements import achievements
 from achievements.achievements import GOAL_AMOUNT, GOAL_MILESTONE_NAME
 from housing import housing
+from progression import progression
 from config.config import Config
 
 # Which front-end the game runs. Swap to UIType.PYGAME (or a future web type)
@@ -115,7 +116,18 @@ class FishE:
             ),
         }
 
-        self.currentLocation = LocationType.HOME
+        # A loaded save may predate the progression module entirely, or may
+        # have earned unlocks between the last save and now; grant those
+        # quietly so the village is never re-locked around an established
+        # player (see progression.catchUp).
+        progression.catchUp(self.player, self.stats)
+
+        # The game opens on the docks, with fishing as the only thing on the
+        # menu. Everywhere else in the village is revealed as it is earned -
+        # see src/progression.
+        self.currentLocation = LocationType.DOCKS
+        if progression.isFreshStart(self.stats):
+            self.prompt.text = progression.OPENING_PROMPT
 
     def _selectSaveFile(self):
         """Display the save-file menu through the UI and let the player choose.
@@ -195,10 +207,16 @@ class FishE:
         while self.running:
             # show the current location and goal progress in the UI header
             self.userInterface.currentLocationName = self.currentLocation.capitalize()
-            self.userInterface.goalProgress = "$%d / $%d" % (
-                self.getTotalWealth(),
-                GOAL_AMOUNT,
-            )
+            # The fortune the run is ultimately about is itself a late reveal:
+            # a player on their first cast is working toward filling a bucket,
+            # not toward $10,000, and an empty string hides the line.
+            if progression.isUnlocked(self.stats, progression.GOAL):
+                self.userInterface.goalProgress = "$%d / $%d" % (
+                    self.getTotalWealth(),
+                    GOAL_AMOUNT,
+                )
+            else:
+                self.userInterface.goalProgress = ""
 
             # change location
             nextLocation = self.locations[self.currentLocation].run()
@@ -213,6 +231,14 @@ class FishE:
             newlyEarned = achievements.getNewlyEarned(self.stats)
             for milestone in newlyEarned:
                 self.prompt.text += "  [Milestone unlocked: %s!]" % milestone["name"]
+
+            # announce the one thing the player has just opened up, with the
+            # reason they opened it, so the newly-appeared menu entry is
+            # explained on the same screen it first shows up on (appended for
+            # the same reason as milestones above)
+            unlock = progression.getNextUnlock(self.player, self.stats)
+            if unlock is not None:
+                self.prompt.text += "  [%s]" % unlock["announcement"]
 
             # announce reaching the wealth goal once (the run continues)
             self.announceGoalIfReached()

--- a/src/location/bank.py
+++ b/src/location/bank.py
@@ -7,6 +7,7 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 from business import business
 from investments import investments
+from progression import progression
 
 
 # @author Daniel McCoy Stephenson
@@ -103,19 +104,28 @@ class Bank:
         )
 
     def run(self):
-        li = [
-            "Make a Deposit",
-            "Make a Withdrawal",
-            "Talk to %s" % self.npc.name,
-            "Manage Investment Properties",
-            "Go to docks",
-        ]
+        # Saving is what the bank is for on the day it opens up; the property
+        # business behind the counter is revealed later (see src/progression),
+        # so options and actions are built as a pair rather than dispatched on
+        # a fixed number.
+        li = ["Make a Deposit", "Make a Withdrawal"]
+        actions = ["deposit", "withdraw"]
+        if progression.isUnlocked(self.stats, progression.TALK):
+            li.append("Talk to %s" % self.npc.name)
+            actions.append("talk")
+        if progression.isUnlocked(self.stats, progression.INVESTMENTS):
+            li.append("Manage Investment Properties")
+            actions.append("investments")
+        li.append("Go to docks")
+        actions.append("docks")
+
         input = self.userInterface.showOptions(
             "You're at the front of the line and the teller asks you what you want to do.",
             li,
         )
+        action = actions[int(input) - 1]
 
-        if input == "1":
+        if action == "deposit":
             if self.player.operatorMode or self.player.money > 0:
                 self.currentPrompt.text = (
                     "How much would you like to deposit? Money: $%.2f"
@@ -126,7 +136,7 @@ class Bank:
                 self.currentPrompt.text = "You don't have any money on you!"
             return LocationType.BANK
 
-        elif input == "2":
+        elif action == "withdraw":
             if self.player.moneyInBank > 0:
                 self.currentPrompt.text = (
                     "How much would you like to withdraw? Money In Bank: $%.2f"
@@ -137,15 +147,15 @@ class Bank:
                 self.currentPrompt.text = "You don't have any money in the bank!"
             return LocationType.BANK
 
-        elif input == "3":
+        elif action == "talk":
             self.talkToNPC()
             return LocationType.BANK
 
-        elif input == "4":
+        elif action == "investments":
             self.manageInvestments()
             return LocationType.BANK
 
-        elif input == "5":
+        elif action == "docks":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
 

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -14,6 +14,7 @@ from business import boats
 from business import export
 from business import adventures
 from housing import housing
+from progression import progression
 
 
 # The catch reaction window widens with the player's rod level, so a better rod
@@ -62,11 +63,7 @@ class Docks:
                 },
                 {
                     "question": "What other locations can I visit?",
-                    "response": "From the docks, you can get to anywhere in the village! "
-                    "There's your home - that's where you sleep to restore energy. "
-                    "Gilbert's shop is where you sell fish and buy better bait. "
-                    "The tavern is run by Old Tom - gambling and drinks there. "
-                    "And the bank, where Margaret will keep your money safe and even give you interest!",
+                    "response": self._locationsDialogue,
                 },
                 {
                     "question": "Tell me about energy and rest.",
@@ -100,28 +97,27 @@ class Docks:
 
     def run(self):
         # Options and actions are built as a pair - rather than dispatching on
-        # a hardcoded number - because the last two entries only appear once
-        # the player has earned them, and the menu positions below them would
-        # otherwise shift depending on game state. New conditional entries are
-        # appended at the end so the fixed ones keep their familiar numbers.
-        li = [
-            "Fish",
-            "Talk to %s" % self.npc.name,
-            "Go Home",
-            "Go to Shop",
-            "Go to Tavern",
-            "Go to Bank",
-            "Manage Fleet",
-        ]
-        actions = [
-            "fish",
-            "talk",
-            "home",
-            "shop",
-            "tavern",
-            "bank",
-            "manage",
-        ]
+        # a hardcoded number - because almost every entry only appears once the
+        # player has earned it, and the menu positions below it would otherwise
+        # shift depending on game state.
+        #
+        # Fishing is the one thing a brand new player can do, and everything
+        # else arrives in the order src/progression reveals it, appended at the
+        # bottom - so an option the player already knows keeps its number when
+        # a new one shows up. Quit stays last.
+        li = ["Fish"]
+        actions = ["fish"]
+        for feature, label, action in (
+            (progression.SHOP, "Go to Shop", "shop"),
+            (progression.HOME, "Go Home", "home"),
+            (progression.TALK, "Talk to %s" % self.npc.name, "talk"),
+            (progression.BANK, "Go to Bank", "bank"),
+            (progression.FLEET, "Manage Fleet", "manage"),
+            (progression.TAVERN, "Go to Tavern", "tavern"),
+        ):
+            if progression.isUnlocked(self.stats, feature):
+                li.append(label)
+                actions.append(action)
         if self.player.hiredWorkers:
             li.append("Talk to Your Crew")
             actions.append("talk_crew")
@@ -131,6 +127,12 @@ class Docks:
         if self.readyToSail():
             li.append("Take the Helm")
             actions.append("voyage")
+        # The docks are where the game starts and where a player with nothing
+        # unlocked yet spends their first few casts, so the way out of the game
+        # lives here as well as at home - otherwise a new player would have no
+        # way to stop before they've earned one.
+        li.append("Quit")
+        actions.append("quit")
         if self.player.hasBoat and self.player.businessName:
             descriptor = (
                 "%s is docked and ready for the day." % self.player.businessName
@@ -195,6 +197,40 @@ class Docks:
         elif action == "voyage":
             self.takeTheHelm()
             return LocationType.DOCKS
+
+        elif action == "quit":
+            return LocationType.NONE
+
+    def _locationsDialogue(self):
+        """Sam's tour of the village - only the parts of it the player has
+        found so far (see src/progression). Listing the bank to someone who
+        has never sold a fish would hand back exactly the wall of options the
+        staged reveal exists to avoid, and Sam pointing at a door that isn't
+        on the menu yet would just be confusing."""
+        places = []
+        if progression.isUnlocked(self.stats, progression.HOME):
+            places.append("there's your home, where you sleep to restore energy")
+        if progression.isUnlocked(self.stats, progression.SHOP):
+            places.append("Gilbert's shop is where you sell fish and buy better gear")
+        if progression.isUnlocked(self.stats, progression.TAVERN):
+            places.append("the tavern is run by Old Tom - gambling and drinks there")
+        if progression.isUnlocked(self.stats, progression.BANK):
+            places.append(
+                "the bank is where Margaret keeps your money safe, and even "
+                "pays you interest"
+            )
+        if not places:
+            return (
+                "Nowhere yet, far as you're concerned! Wet your line first - "
+                "the village opens up to a fisherman who's actually fishing."
+            )
+        text = "Well, %s." % villagers.joinNames(places)
+        if len(places) < 4:
+            text += (
+                " There's more to this village besides, but you'll come to it "
+                "in your own time."
+            )
+        return text
 
     def _businessDialogue(self):
         """Sam's take on the player's fishing business, staged by boat tier and

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -6,6 +6,7 @@ from stats.stats import Stats
 from ui.userInterface import UserInterface
 from achievements import achievements
 from housing import housing
+from progression import progression
 
 
 # @author Daniel McCoy Stephenson
@@ -25,32 +26,46 @@ class Home:
         self.timeService = timeService
 
     def run(self):
-        retireAvailable = (
-            achievements.GOAL_MILESTONE_NAME in self.stats.earnedMilestones
-        )
-        li = ["Sleep", "See Stats", "Manage Home", "Go to Docks"]
-        if retireAvailable:
+        # Sleeping is all home is for at first; the ledger and the housing
+        # ladder are revealed later (see src/progression), and retiring only
+        # once the wealth goal has been reached - so options and actions are
+        # built as a pair rather than dispatched on a fixed number.
+        li = ["Sleep"]
+        actions = ["sleep"]
+        if progression.isUnlocked(self.stats, progression.JOURNAL):
+            li.append("See Stats")
+            actions.append("stats")
+        if progression.isUnlocked(self.stats, progression.HOUSING):
+            li.append("Manage Home")
+            actions.append("housing")
+        li.append("Go to Docks")
+        actions.append("docks")
+        if achievements.GOAL_MILESTONE_NAME in self.stats.earnedMilestones:
             li.append("Retire")
+            actions.append("retire")
         li.append("Quit")
-        self.input = self.userInterface.showOptions(self._homeDescriptor(), li)
+        actions.append("quit")
 
-        if self.input == "1":
+        self.input = self.userInterface.showOptions(self._homeDescriptor(), li)
+        action = actions[int(self.input) - 1]
+
+        if action == "sleep":
             self.sleep()
             return LocationType.HOME
-        elif self.input == "2":
+        elif action == "stats":
             self.displayStats()
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.HOME
-        elif self.input == "3":
+        elif action == "housing":
             self.manageHome()
             return LocationType.HOME
-        elif self.input == "4":
+        elif action == "docks":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
-        elif retireAvailable and self.input == "5":
+        elif action == "retire":
             self.retire()
             return LocationType.NONE
-        elif self.input == str(len(li)):
+        elif action == "quit":
             return LocationType.NONE
 
     def _homeDescriptor(self):

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -9,6 +9,7 @@ from npc import villagers
 from fish import fish
 from business import business
 from business import export
+from progression import progression
 
 
 # Upper bound on fishMultiplier so bait upgrades stop being an infinite power
@@ -161,31 +162,42 @@ class Shop:
         )
 
     def run(self):
-        li = [
-            "Sell Fish",
-            "Buy Better Bait ( $%.2f )" % self.player.priceForBait,
-            "Buy Better Rod ( $%.2f )" % rodUpgradeCost(self.player.rodLevel),
-            "Talk to %s" % self.npc.name,
-            "Go to Docks",
-        ]
+        # Selling is the whole reason a new player walks up the hill; the gear
+        # on the walls is revealed later (see src/progression), so options and
+        # actions are built as a pair rather than dispatched on a fixed number.
+        li = ["Sell Fish"]
+        actions = ["sell"]
+        if progression.isUnlocked(self.stats, progression.BAIT):
+            li.append("Buy Better Bait ( $%.2f )" % self.player.priceForBait)
+            actions.append("bait")
+        if progression.isUnlocked(self.stats, progression.ROD):
+            li.append("Buy Better Rod ( $%.2f )" % rodUpgradeCost(self.player.rodLevel))
+            actions.append("rod")
+        if progression.isUnlocked(self.stats, progression.TALK):
+            li.append("Talk to %s" % self.npc.name)
+            actions.append("talk")
+        li.append("Go to Docks")
+        actions.append("docks")
+
         input = self.userInterface.showOptions(
             "The shopkeeper winks at you as you behold his collection of fishing poles.",
             li,
         )
+        action = actions[int(input) - 1]
 
-        if input == "1":
+        if action == "sell":
             self.sellFish()
             return LocationType.SHOP
-        elif input == "2":
+        elif action == "bait":
             self.buyBetterBait()
             return LocationType.SHOP
-        elif input == "3":
+        elif action == "rod":
             self.buyBetterRod()
             return LocationType.SHOP
-        elif input == "4":
+        elif action == "talk":
             self.talkToNPC()
             return LocationType.SHOP
-        elif input == "5":
+        elif action == "docks":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
 

--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -11,6 +11,7 @@ from npc.npc import NPC
 from npc import villagers
 from business import business
 from housing import housing
+from progression import progression
 
 
 # Dice has 6 equally likely faces, so a correct guess pays 5x the bet to make
@@ -141,17 +142,23 @@ class Tavern:
         )
 
     def run(self):
-        li = [
-            "Get drunk ( $10 )",
-            "Gamble",
-            "Talk to %s" % self.npc.name,
-            "Go to Docks",
-        ]
+        # Options and actions are built as a pair rather than dispatched on a
+        # fixed number, because talking to Old Tom is revealed separately from
+        # the tavern itself (see src/progression).
+        li = ["Get drunk ( $10 )", "Gamble"]
+        actions = ["drink", "gamble"]
+        if progression.isUnlocked(self.stats, progression.TALK):
+            li.append("Talk to %s" % self.npc.name)
+            actions.append("talk")
+        li.append("Go to Docks")
+        actions.append("docks")
+
         input = self.userInterface.showOptions(
             "You sit at the bar, watching the barkeep clean a mug with a dirty rag.", li
         )
+        action = actions[int(input) - 1]
 
-        if input == "1":
+        if action == "drink":
             if self.player.canAfford(10):
                 self.getDrunk()
                 return LocationType.HOME
@@ -159,18 +166,18 @@ class Tavern:
                 self.currentPrompt.text = "You don't have enough money."
                 return LocationType.TAVERN
 
-        elif input == "2":
+        elif action == "gamble":
             self.currentPrompt.text = (
                 "What will the dice land on? Current Bet: $%d" % self.currentBet
             )
             self.gamble()
             return LocationType.TAVERN
 
-        elif input == "3":
+        elif action == "talk":
             self.talkToNPC()
             return LocationType.TAVERN
 
-        elif input == "4":
+        elif action == "docks":
             self.currentPrompt.text = "What would you like to do?"
             return LocationType.DOCKS
 

--- a/src/progression/progression.py
+++ b/src/progression/progression.py
@@ -1,0 +1,197 @@
+# @author Daniel McCoy Stephenson
+#
+# Progressive disclosure: which parts of the village the player has been shown
+# yet. A new game opens on the docks with a rod and a single thing to do -
+# fish - and every other option in the game arrives later, one at a time, as
+# the player earns it.
+#
+# The point is pacing rather than difficulty. Nothing here makes an action
+# harder or more expensive; it only decides whether the option is on the menu
+# yet, so a first-time player is never handed eleven choices they have no
+# context for. Each unlock fires on a state the player has just created
+# themselves (a full basket, a first sale, a heavy purse), and announces itself
+# with the reason - "your basket is heavy, go sell them" - so the next thing to
+# do is always the thing that just became possible.
+#
+# Data-driven the same way src/achievements is: add a row to UNLOCKS and it is
+# tracked, gated and announced automatically. Conditions read only the Player
+# and the Stats, deliberately - both are already threaded through every
+# location, so gating a menu entry never needs a new constructor argument.
+#
+# Unlocks are permanent. The set of already-granted ids lives on
+# Stats (stats.unlockedFeatures) so it is saved, and a feature is announced
+# exactly once across the whole run.
+
+# Feature ids. Each is referenced by the location that owns the menu entry.
+SHOP = "shop"
+HOME = "home"
+TALK = "talk"
+BAIT = "bait"
+ROD = "rod"
+HOUSING = "housing"
+BANK = "bank"
+JOURNAL = "journal"
+TAVERN = "tavern"
+FLEET = "fleet"
+INVESTMENTS = "investments"
+GOAL = "goal"
+
+# The opening line of a brand new game, in place of the standing "What would
+# you like to do?" - which is a strange thing to ask someone whose menu has one
+# entry on it.
+OPENING_PROMPT = "You've got a rod, a bucket, and the whole sea in front of you."
+
+
+def _wealth(player):
+    return player.money + player.moneyInBank
+
+
+# Ordered roughly by when they fire, though nothing depends on the order - each
+# condition is checked independently every time the game loop comes around.
+UNLOCKS = [
+    {
+        "id": SHOP,
+        "name": "the shop",
+        "announcement": "Your basket is heavy with fish. Gilbert buys them at "
+        "the shop - better go sell them.",
+        "condition": lambda player, stats: stats.totalFishCaught >= 1,
+    },
+    {
+        "id": HOME,
+        "name": "home",
+        # Either half of this is enough on its own: the first sale is the
+        # natural moment to be shown where you sleep, and running the tank dry
+        # before selling anything must not leave a player with no way to
+        # recover their energy.
+        "announcement": "You're worn out, and there's a bunk waiting. You can "
+        "head home to sleep.",
+        "condition": lambda player, stats: stats.totalMoneyMade > 0
+        or player.energy < 10,
+    },
+    {
+        "id": BAIT,
+        "name": "better bait",
+        "announcement": "You've coin enough for the good bait. Gilbert keeps "
+        "it behind the counter.",
+        "condition": lambda player, stats: player.money >= player.priceForBait,
+    },
+    {
+        "id": TALK,
+        "name": "conversation",
+        "announcement": "You've been around the village long enough that folk "
+        "will stop and talk to you now.",
+        "condition": lambda player, stats: stats.hoursSpentFishing >= 20,
+    },
+    {
+        "id": ROD,
+        "name": "better rods",
+        "announcement": "Better bait fills the basket; a better rod makes the "
+        "fish easier to hook. Gilbert has some on the wall.",
+        "condition": lambda player, stats: player.fishMultiplier > 1,
+    },
+    {
+        "id": HOUSING,
+        "name": "somewhere to live",
+        "announcement": "You've earned enough to keep a roof over your head. "
+        "See about a room from home.",
+        "condition": lambda player, stats: stats.totalMoneyMade >= 100,
+    },
+    {
+        "id": BANK,
+        "name": "the bank",
+        "announcement": "That's more coin than you want in your pocket. "
+        "Margaret at the bank will keep it safe, and pay you interest.",
+        "condition": lambda player, stats: _wealth(player) >= 150,
+    },
+    {
+        "id": JOURNAL,
+        "name": "your journal",
+        "announcement": "You've put in enough hours to wonder how they add "
+        "up. There's a ledger at home.",
+        "condition": lambda player, stats: stats.hoursSpentFishing >= 15,
+    },
+    {
+        "id": FLEET,
+        "name": "a boat of your own",
+        "announcement": "Sam says there's a rowboat for sale. A boat means a "
+        "crew, and a crew fishes while you sleep.",
+        "condition": lambda player, stats: _wealth(player) >= 250,
+    },
+    {
+        "id": TAVERN,
+        "name": "the tavern",
+        "announcement": "Word of the new fisherman has reached Old Tom. The "
+        "tavern door is open to you.",
+        "condition": lambda player, stats: stats.totalMoneyMade >= 250,
+    },
+    {
+        "id": INVESTMENTS,
+        "name": "investment properties",
+        "announcement": "Margaret mentions the cottages that come up for sale "
+        "now and then. A property pays every day, whether you fish or not.",
+        "condition": lambda player, stats: _wealth(player) >= 600,
+    },
+    {
+        "id": GOAL,
+        "name": "a fortune worth counting",
+        "announcement": "A thousand dollars to your name. They say ten "
+        "thousand is enough to retire on - you're on your way.",
+        "condition": lambda player, stats: _wealth(player) >= 1000,
+    },
+]
+
+ALL_FEATURE_IDS = [unlock["id"] for unlock in UNLOCKS]
+
+
+def isUnlocked(stats, featureId):
+    """Whether the player has been shown the given feature yet."""
+    return featureId in stats.unlockedFeatures
+
+
+def getNextUnlock(player, stats):
+    """Grant and return the next feature the player has earned, or None.
+
+    One per call, deliberately, even when several conditions came true at once.
+    A single long cast can land a first catch, empty the energy bar and put
+    hours on the clock all at the same time - announcing all of that on one
+    screen would hand the player the wall of new options this module exists to
+    avoid. The rest are still earned and arrive on the following screens, one
+    per action, so the game always unfolds a button at a time.
+
+    The granted id is appended to stats.unlockedFeatures (which is saved), so a
+    feature is announced once and then stays available for good - the same "the
+    persisted list doubles as the already-announced flag" approach used for
+    milestones in src/achievements."""
+    for unlock in UNLOCKS:
+        if unlock["id"] in stats.unlockedFeatures:
+            continue
+        if unlock["condition"](player, stats):
+            stats.unlockedFeatures.append(unlock["id"])
+            return unlock
+    return None
+
+
+def catchUp(player, stats):
+    """Grant every already-earned unlock at once, without announcing anything.
+
+    Called when a game is loaded, where the drip above would be wrong. A save
+    file written before this module existed has no unlockedFeatures at all, and
+    its player may already own a fleet and a manor - re-locking the village
+    around them would be a bug, and handing it back one button per action would
+    be worse. A save that does have the list is unaffected, and a brand new
+    game meets no conditions, so this grants nothing there either."""
+    while getNextUnlock(player, stats) is not None:
+        pass
+
+
+def unlockAll(stats):
+    """Grant every feature at once. For tests and for anything that needs the
+    full menu without playing through to it."""
+    stats.unlockedFeatures = list(ALL_FEATURE_IDS)
+
+
+def isFreshStart(stats):
+    """True for a player who hasn't done anything yet - nothing unlocked and
+    no fish caught. Used to open the game on something more inviting than the
+    standing "What would you like to do?" prompt."""
+    return not stats.unlockedFeatures and stats.totalFishCaught == 0

--- a/src/stats/stats.py
+++ b/src/stats/stats.py
@@ -9,6 +9,10 @@ class Stats:
         self.moneyLostFromGambling = 0
         self.moneyLostWhileDrunk = 0
         self.earnedMilestones = []
+        # Ids of the features the player has been shown so far (see
+        # src/progression). Empty for a new game: everything but fishing is
+        # revealed as it is earned.
+        self.unlockedFeatures = []
         # Lifetime fishing-business totals, tracked so players can see the
         # impact of the business they've built (see src/business).
         self.totalWorkersHired = 0

--- a/src/stats/statsJsonReaderWriter.py
+++ b/src/stats/statsJsonReaderWriter.py
@@ -16,6 +16,7 @@ class StatsJsonReaderWriter:
             "moneyLostFromGambling": stats.moneyLostFromGambling,
             "moneyLostWhileDrunk": stats.moneyLostWhileDrunk,
             "earnedMilestones": stats.earnedMilestones,
+            "unlockedFeatures": stats.unlockedFeatures,
             "totalWorkersHired": stats.totalWorkersHired,
             "totalFishCaughtByCrew": stats.totalFishCaughtByCrew,
             "totalWagesPaid": stats.totalWagesPaid,
@@ -62,6 +63,9 @@ class StatsJsonReaderWriter:
         )
         stats.earnedMilestones = statsJson.get(
             "earnedMilestones", stats.earnedMilestones
+        )
+        stats.unlockedFeatures = statsJson.get(
+            "unlockedFeatures", stats.unlockedFeatures
         )
         stats.totalWorkersHired = statsJson.get(
             "totalWorkersHired", stats.totalWorkersHired

--- a/tests/location/test_bank.py
+++ b/tests/location/test_bank.py
@@ -6,13 +6,19 @@ from src.prompt.prompt import Prompt
 from src.stats.stats import Stats
 from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
+from src.progression import progression
 from unittest.mock import MagicMock
 
 
-def createBank():
+def createBank(unlocked=True):
     currentPrompt = Prompt("What would you like to do?")
     player = Player()
     stats = Stats()
+    if unlocked:
+        # These tests are about what the bank does, not about what a brand
+        # new player can see of it (see src/progression); the staged reveal has
+        # its own tests below.
+        progression.unlockAll(stats)
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
     return bank.Bank(userInterface, currentPrompt, player, stats, timeService)
@@ -390,3 +396,57 @@ def test_manageInvestments_status_reflects_no_holdings():
 
     # check
     assert "don't own any yet" in bankInstance._investmentsStatus()
+
+
+def test_run_shows_only_saving_to_a_player_who_just_found_the_bank():
+    # prepare - the property business behind the counter is revealed later
+    # (see src/progression)
+    bankInstance = createBank(unlocked=False)
+    bankInstance.userInterface.showOptions = MagicMock(return_value="3")
+
+    # call
+    nextLocation = bankInstance.run()
+
+    # check
+    options = bankInstance.userInterface.showOptions.call_args[0][1]
+    assert options == ["Make a Deposit", "Make a Withdrawal", "Go to docks"]
+    assert nextLocation == LocationType.DOCKS
+
+
+def test_run_reveals_investments_and_the_teller_as_they_are_unlocked():
+    # prepare
+    bankInstance = createBank(unlocked=False)
+    bankInstance.userInterface.showOptions = MagicMock(return_value="1")
+    bankInstance.deposit = MagicMock()
+
+    for feature, label in (
+        (progression.TALK, "Talk to Margaret the Teller"),
+        (progression.INVESTMENTS, "Manage Investment Properties"),
+    ):
+        # call - before the unlock
+        bankInstance.run()
+
+        # check
+        assert label not in bankInstance.userInterface.showOptions.call_args[0][1]
+
+        # prepare/call - and after it
+        bankInstance.stats.unlockedFeatures.append(feature)
+        bankInstance.run()
+
+        # check
+        assert label in bankInstance.userInterface.showOptions.call_args[0][1]
+
+
+def test_run_withdrawal_fires_from_its_position_with_a_short_menu():
+    # prepare
+    bankInstance = createBank(unlocked=False)
+    bankInstance.player.moneyInBank = 50
+    bankInstance.userInterface.showOptions = MagicMock(return_value="2")
+    bankInstance.withdraw = MagicMock()
+
+    # call
+    nextLocation = bankInstance.run()
+
+    # check
+    assert nextLocation == LocationType.BANK
+    bankInstance.withdraw.assert_called_once()

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -11,19 +11,40 @@ from src.business import boats
 from src.business import export
 from src.housing import housing
 from src.npc import villagers
+from src.progression import progression
 from unittest.mock import MagicMock, patch
 
 
-def createDocks():
+def createDocks(unlocked=True):
     currentPrompt = Prompt("What would you like to do?")
     player = Player()
     stats = Stats()
+    if unlocked:
+        # Most of these tests are about what the docks do, not about what a
+        # brand new player can see, so start with the whole menu revealed (see
+        # src/progression). The staged reveal has its own tests below.
+        progression.unlockAll(stats)
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
     # fish() opens with a one-second "Fishing..." pause on the real front-end;
     # stub it so the tests neither print to the console nor wait it out.
     userInterface.showBusy = MagicMock()
     return docks.Docks(userInterface, currentPrompt, player, stats, timeService)
+
+
+def dockChooser(label):
+    """Pick the docks menu entry with this label, rather than a fixed number.
+
+    Which options are on the menu (and so what each one is numbered) depends on
+    how much of the game the player has unlocked, so tests say what they mean."""
+
+    def chooser(descriptor, optionList):
+        for index, option in enumerate(optionList, start=1):
+            if option == label or option.startswith(label):
+                return str(index)
+        raise AssertionError("no %r option in %r" % (label, optionList))
+
+    return chooser
 
 
 def test_initialization():
@@ -57,7 +78,9 @@ def test_run_fish_action():
 def test_run_go_home_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="3")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go Home")
+    )
 
     # call
     nextLocation = docksInstance.run()
@@ -69,7 +92,9 @@ def test_run_go_home_action():
 def test_run_talk_to_npc_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="2")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Talk to Sam")
+    )
     docksInstance.talkToNPC = MagicMock()
 
     # call
@@ -163,7 +188,9 @@ def test_npc_dialogue_response_reflects_business_via_callable():
 def test_run_go_to_shop_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="4")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go to Shop")
+    )
 
     # call
     nextLocation = docksInstance.run()
@@ -175,7 +202,9 @@ def test_run_go_to_shop_action():
 def test_run_go_to_tavern_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="5")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go to Tavern")
+    )
 
     # call
     nextLocation = docksInstance.run()
@@ -187,7 +216,9 @@ def test_run_go_to_tavern_action():
 def test_run_go_to_bank_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="6")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go to Bank")
+    )
 
     # call
     nextLocation = docksInstance.run()
@@ -437,7 +468,9 @@ def test_run_descriptor_mentions_current_weather():
     # prepare
     docksInstance = createDocks()
     docksInstance.timeService.weather = "stormy"
-    docksInstance.userInterface.showOptions = MagicMock(return_value="3")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go Home")
+    )
 
     # call
     docksInstance.run()
@@ -502,7 +535,9 @@ def test_fish_higher_rod_widens_reaction_window():
 def test_run_manage_fleet_action():
     # prepare
     docksInstance = createDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="7")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Manage Fleet")
+    )
     docksInstance.manageFleet = MagicMock()
 
     # call
@@ -881,7 +916,9 @@ def test_run_talk_to_crew_action():
     docksInstance = createDocks()
     boats.addBoat(docksInstance.player, 1)
     boats.hireWorker(docksInstance.player, "Marta Kell")
-    docksInstance.userInterface.showOptions = MagicMock(return_value="8")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Talk to Your Crew")
+    )
     docksInstance.talkToCrew = MagicMock()
 
     # call
@@ -1062,7 +1099,9 @@ def createExportingDocks(tier=2, money=1000, fishCount=100):
 def test_run_export_option_appears_only_with_a_big_enough_boat():
     # prepare - a Rowboat, which can't make the crossing
     docksInstance = createExportingDocks(tier=1)
-    docksInstance.userInterface.showOptions = MagicMock(return_value="3")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go Home")
+    )
 
     # call
     docksInstance.run()
@@ -1083,9 +1122,11 @@ def test_run_export_option_appears_only_with_a_big_enough_boat():
 
 
 def test_run_export_action():
-    # prepare - the export entry is last, after Manage Boat & Crew
+    # prepare
     docksInstance = createExportingDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="8")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Export Fish to Other Villages")
+    )
     docksInstance.exportFish = MagicMock()
 
     # call
@@ -1101,7 +1142,9 @@ def test_run_menu_positions_hold_when_both_extras_are_present():
     # conditional entries are on the menu at once
     docksInstance = createExportingDocks()
     boats.hireWorker(docksInstance.player, "Marta Kell")
-    docksInstance.userInterface.showOptions = MagicMock(return_value="9")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Export Fish to Other Villages")
+    )
     docksInstance.exportFish = MagicMock()
     docksInstance.talkToCrew = MagicMock()
 
@@ -1111,8 +1154,10 @@ def test_run_menu_positions_hold_when_both_extras_are_present():
     # check - export sits after the crew entry, and each action still lines up
     # with its own option rather than the one beside it
     options = docksInstance.userInterface.showOptions.call_args[0][1]
-    assert options[7] == "Talk to Your Crew"
-    assert options[8] == "Export Fish to Other Villages"
+    assert (
+        options.index("Export Fish to Other Villages")
+        == options.index("Talk to Your Crew") + 1
+    )
     docksInstance.exportFish.assert_called_once()
     docksInstance.talkToCrew.assert_not_called()
 
@@ -1122,7 +1167,9 @@ def test_run_crew_action_still_fires_without_the_export_entry():
     docksInstance = createDocks()
     boats.addBoat(docksInstance.player, 1)
     boats.hireWorker(docksInstance.player, "Marta Kell")
-    docksInstance.userInterface.showOptions = MagicMock(return_value="8")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Talk to Your Crew")
+    )
     docksInstance.talkToCrew = MagicMock()
 
     # call
@@ -1336,7 +1383,9 @@ def test_run_take_the_helm_appears_only_with_a_boat_that_can_sail():
     # prepare - a boat with nobody aboard can't be taken out
     docksInstance = createDocks()
     boats.addBoat(docksInstance.player, 2, boats.ROLE_PIRACY)
-    docksInstance.userInterface.showOptions = MagicMock(return_value="3")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go Home")
+    )
     docksInstance.run()
 
     # check
@@ -1355,13 +1404,8 @@ def test_run_take_the_helm_appears_only_with_a_boat_that_can_sail():
 def test_run_take_the_helm_action():
     # prepare - find the entry by label, since crew/export entries also appear
     docksInstance, _ = createSailingDocks()
-    docksInstance.userInterface.showOptions = MagicMock(return_value="1")
-    docksInstance.fish = MagicMock()
-    docksInstance.run()
-    menu = docksInstance.userInterface.showOptions.call_args[0][1]
-
     docksInstance.userInterface.showOptions = MagicMock(
-        return_value=str(menu.index("Take the Helm") + 1)
+        side_effect=dockChooser("Take the Helm")
     )
     docksInstance.takeTheHelm = MagicMock()
 
@@ -1781,7 +1825,9 @@ def test_the_docks_screen_flags_a_fleet_that_needs_attention():
     boats.hireWorker(docksInstance.player, "Marta Kell")
     boats.hireWorker(docksInstance.player, "Owen Brackish")
     boats.unassignCrew(docksInstance.player, crewed["id"], "Owen Brackish")
-    docksInstance.userInterface.showOptions = MagicMock(return_value="3")
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=dockChooser("Go Home")
+    )
 
     # call
     docksInstance.run()
@@ -1807,3 +1853,112 @@ def test_the_docks_screen_stays_quiet_when_nothing_is_wrong():
     assert (
         "Needs attention" not in docksInstance.userInterface.showOptions.call_args[0][0]
     )
+
+
+def test_run_shows_only_fishing_to_a_brand_new_player():
+    # prepare - nothing unlocked yet (see src/progression)
+    docksInstance = createDocks(unlocked=False)
+    docksInstance.userInterface.showOptions = MagicMock(side_effect=dockChooser("Fish"))
+    docksInstance.fish = MagicMock()
+
+    # call
+    docksInstance.run()
+
+    # check - one thing to do, plus a way out of the game
+    options = docksInstance.userInterface.showOptions.call_args[0][1]
+    assert options == ["Fish", "Quit"]
+
+
+def test_run_reveals_each_docks_entry_as_it_is_unlocked():
+    # prepare
+    docksInstance = createDocks(unlocked=False)
+    docksInstance.userInterface.showOptions = MagicMock(side_effect=dockChooser("Fish"))
+    docksInstance.fish = MagicMock()
+
+    for feature, label in (
+        (progression.SHOP, "Go to Shop"),
+        (progression.HOME, "Go Home"),
+        (progression.TALK, "Talk to Sam the Dock Worker"),
+        (progression.BANK, "Go to Bank"),
+        (progression.FLEET, "Manage Fleet"),
+        (progression.TAVERN, "Go to Tavern"),
+    ):
+        # call - before the unlock
+        docksInstance.run()
+
+        # check
+        assert label not in docksInstance.userInterface.showOptions.call_args[0][1]
+
+        # prepare/call - and after it
+        docksInstance.stats.unlockedFeatures.append(feature)
+        docksInstance.run()
+
+        # check
+        assert label in docksInstance.userInterface.showOptions.call_args[0][1]
+
+
+def test_run_new_entries_are_appended_below_the_familiar_ones():
+    # prepare - the menu grows downward, so an option the player already knows
+    # keeps its number when a new one shows up
+    docksInstance = createDocks(unlocked=False)
+    docksInstance.userInterface.showOptions = MagicMock(side_effect=dockChooser("Fish"))
+    docksInstance.fish = MagicMock()
+    docksInstance.stats.unlockedFeatures.append(progression.SHOP)
+    docksInstance.run()
+    before = docksInstance.userInterface.showOptions.call_args[0][1]
+
+    # call
+    docksInstance.stats.unlockedFeatures.append(progression.HOME)
+    docksInstance.run()
+
+    # check
+    after = docksInstance.userInterface.showOptions.call_args[0][1]
+    assert after[: len(before) - 1] == before[:-1]  # everything above Quit holds
+    assert after.index("Go Home") == len(before) - 1
+
+
+def test_run_quit_action_ends_the_run():
+    # prepare - the docks are where a new player starts, so quitting has to be
+    # possible before the home menu has been unlocked
+    docksInstance = createDocks(unlocked=False)
+    docksInstance.userInterface.showOptions = MagicMock(side_effect=dockChooser("Quit"))
+
+    # call
+    nextLocation = docksInstance.run()
+
+    # check
+    assert nextLocation == LocationType.NONE
+
+
+def test_locations_dialogue_only_describes_places_the_player_has_found():
+    # prepare
+    docksInstance = createDocks(unlocked=False)
+
+    # check - Sam has nothing to point at before the player has done anything
+    text = docksInstance._locationsDialogue()
+    assert "bank" not in text
+    assert "Wet your line" in text
+
+    # prepare - the shop opens up
+    docksInstance.stats.unlockedFeatures.append(progression.SHOP)
+
+    # check
+    text = docksInstance._locationsDialogue()
+    assert "Gilbert's shop" in text
+    assert "Old Tom" not in text
+    assert "in your own time" in text
+
+
+def test_locations_dialogue_covers_the_whole_village_once_it_is_open():
+    # prepare
+    docksInstance = createDocks()
+
+    # call
+    text = docksInstance._locationsDialogue()
+
+    # check
+    assert "your home" in text
+    assert "Gilbert's shop" in text
+    assert "Old Tom" in text
+    assert "the bank" in text
+    assert "in your own time" not in text

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -7,13 +7,19 @@ from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
 from src.achievements import achievements
 from src.housing import housing
+from src.progression import progression
 from unittest.mock import MagicMock
 
 
-def createHome():
+def createHome(unlocked=True):
     currentPrompt = Prompt("What would you like to do?")
     player = Player()
     stats = Stats()
+    if unlocked:
+        # These tests are about what the home menu does, not about what a brand
+        # new player can see of it (see src/progression); the staged reveal has
+        # its own tests below.
+        progression.unlockAll(stats)
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
     return home.Home(userInterface, currentPrompt, player, stats, timeService)
@@ -430,3 +436,56 @@ def test_manageHome_at_top_tier_has_no_move_up_option():
     optionsShown = homeInstance.userInterface.showOptions.call_args[0][1]
     assert not any("move to" in option.lower() for option in optionsShown)
     assert any("down" in option.lower() for option in optionsShown)
+
+
+def test_run_shows_only_sleeping_to_a_player_who_just_found_home():
+    # prepare - the ledger and the housing ladder are revealed later (see
+    # src/progression)
+    homeInstance = createHome(unlocked=False)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="1")
+    homeInstance.sleep = MagicMock()
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check
+    options = homeInstance.userInterface.showOptions.call_args[0][1]
+    assert options == ["Sleep", "Go to Docks", "Quit"]
+    assert nextLocation == LocationType.HOME
+    homeInstance.sleep.assert_called_once()
+
+
+def test_run_quit_still_works_on_the_short_menu():
+    # prepare
+    homeInstance = createHome(unlocked=False)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="3")
+
+    # call
+    nextLocation = homeInstance.run()
+
+    # check
+    assert nextLocation == LocationType.NONE
+
+
+def test_run_reveals_the_ledger_and_the_housing_ladder_as_they_unlock():
+    # prepare
+    homeInstance = createHome(unlocked=False)
+    homeInstance.userInterface.showOptions = MagicMock(return_value="1")
+    homeInstance.sleep = MagicMock()
+
+    for feature, label in (
+        (progression.JOURNAL, "See Stats"),
+        (progression.HOUSING, "Manage Home"),
+    ):
+        # call - before the unlock
+        homeInstance.run()
+
+        # check
+        assert label not in homeInstance.userInterface.showOptions.call_args[0][1]
+
+        # prepare/call - and after it
+        homeInstance.stats.unlockedFeatures.append(feature)
+        homeInstance.run()
+
+        # check
+        assert label in homeInstance.userInterface.showOptions.call_args[0][1]

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -7,13 +7,19 @@ from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
 from src.business import boats
 from src.business import export
+from src.progression import progression
 from unittest.mock import MagicMock
 
 
-def createShop():
+def createShop(unlocked=True):
     currentPrompt = Prompt("What would you like to do?")
     player = Player()
     stats = Stats()
+    if unlocked:
+        # These tests are about what the shop does, not about what a brand new
+        # player can see of it (see src/progression); the staged reveal has its
+        # own tests below.
+        progression.unlockAll(stats)
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
     return shop.Shop(userInterface, currentPrompt, player, stats, timeService)
@@ -420,3 +426,74 @@ def test_sellFish_leftover_advice_without_an_export_boat():
     assert shopInstance.player.fishCount > 0
     assert "Come back tomorrow for the rest." in shopInstance.currentPrompt.text
     assert "docks" not in shopInstance.currentPrompt.text
+
+
+def test_run_shows_only_selling_to_a_player_who_just_found_the_shop():
+    # prepare - the shop opens up the moment there are fish to sell, and
+    # nothing on the walls has been revealed yet (see src/progression)
+    shopInstance = createShop(unlocked=False)
+    shopInstance.userInterface.showOptions = MagicMock(return_value="1")
+    shopInstance.sellFish = MagicMock()
+
+    # call
+    nextLocation = shopInstance.run()
+
+    # check
+    options = shopInstance.userInterface.showOptions.call_args[0][1]
+    assert options == ["Sell Fish", "Go to Docks"]
+    assert nextLocation == LocationType.SHOP
+    shopInstance.sellFish.assert_called_once()
+
+
+def test_run_go_to_docks_is_always_the_last_entry():
+    # prepare - the way back can't depend on what has been unlocked
+    shopInstance = createShop(unlocked=False)
+    shopInstance.userInterface.showOptions = MagicMock(return_value="2")
+
+    # call
+    nextLocation = shopInstance.run()
+
+    # check
+    assert nextLocation == LocationType.DOCKS
+
+
+def test_run_reveals_the_gear_as_it_is_unlocked():
+    # prepare
+    shopInstance = createShop(unlocked=False)
+    shopInstance.userInterface.showOptions = MagicMock(return_value="1")
+    shopInstance.sellFish = MagicMock()
+
+    for feature, label in (
+        (progression.BAIT, "Buy Better Bait"),
+        (progression.ROD, "Buy Better Rod"),
+        (progression.TALK, "Talk to Gilbert the Shopkeeper"),
+    ):
+        # call - before the unlock
+        shopInstance.run()
+
+        # check
+        options = shopInstance.userInterface.showOptions.call_args[0][1]
+        assert not any(option.startswith(label) for option in options)
+
+        # prepare/call - and after it
+        shopInstance.stats.unlockedFeatures.append(feature)
+        shopInstance.run()
+
+        # check
+        options = shopInstance.userInterface.showOptions.call_args[0][1]
+        assert any(option.startswith(label) for option in options)
+
+
+def test_run_buying_bait_fires_from_its_actual_position():
+    # prepare - bait unlocked but the rod not, so "Buy Better Bait" is entry 2
+    shopInstance = createShop(unlocked=False)
+    shopInstance.stats.unlockedFeatures.append(progression.BAIT)
+    shopInstance.userInterface.showOptions = MagicMock(return_value="2")
+    shopInstance.buyBetterBait = MagicMock()
+
+    # call
+    nextLocation = shopInstance.run()
+
+    # check
+    assert nextLocation == LocationType.SHOP
+    shopInstance.buyBetterBait.assert_called_once()

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -7,13 +7,19 @@ from src.ui.userInterface import UserInterface
 from src.world.timeService import TimeService
 from src.business import business
 from src.business import boats
+from src.progression import progression
 from unittest.mock import MagicMock, patch
 
 
-def createTavern():
+def createTavern(unlocked=True):
     currentPrompt = Prompt("What would you like to do?")
     player = Player()
     stats = Stats()
+    if unlocked:
+        # These tests are about what the tavern does, not about what a brand
+        # new player can see of it (see src/progression); the staged reveal has
+        # its own tests below.
+        progression.unlockAll(stats)
     timeService = TimeService(player, stats)
     userInterface = UserInterface(currentPrompt, timeService, player)
     # getDrunk() opens with a three-second pause on the real front-end; stub it
@@ -631,3 +637,30 @@ def test_old_tom_crew_dialogue_warns_about_unpaid_wages():
     # check - Old Tom passes on what the crew are saying at the bar
     assert "payday" in response
     assert "$%d a day" % (2 * business.WORKER_DAILY_WAGE) in response
+
+
+def test_run_hides_old_tom_until_conversation_is_unlocked():
+    # prepare - the tavern can open up before the player is on talking terms
+    # with the village (see src/progression)
+    tavernInstance = createTavern(unlocked=False)
+    tavernInstance.userInterface.showOptions = MagicMock(return_value="3")
+
+    # call
+    nextLocation = tavernInstance.run()
+
+    # check
+    options = tavernInstance.userInterface.showOptions.call_args[0][1]
+    assert options == ["Get drunk ( $10 )", "Gamble", "Go to Docks"]
+    assert nextLocation == LocationType.DOCKS
+
+    # prepare - conversation unlocks
+    tavernInstance.stats.unlockedFeatures.append(progression.TALK)
+    tavernInstance.userInterface.showOptions = MagicMock(return_value="3")
+    tavernInstance.talkToNPC = MagicMock()
+
+    # call
+    nextLocation = tavernInstance.run()
+
+    # check
+    assert nextLocation == LocationType.TAVERN
+    tavernInstance.talkToNPC.assert_called_once()

--- a/tests/progression/test_progression.py
+++ b/tests/progression/test_progression.py
@@ -1,0 +1,210 @@
+from src.player.player import Player
+from src.progression import progression
+from src.stats.stats import Stats
+
+
+def createState():
+    return Player(), Stats()
+
+
+def test_a_brand_new_player_has_unlocked_nothing():
+    # prepare
+    player, stats = createState()
+
+    # call
+    unlock = progression.getNextUnlock(player, stats)
+
+    # check - the opening screen is fishing and nothing else
+    assert unlock is None
+    assert stats.unlockedFeatures == []
+
+
+def test_first_catch_unlocks_the_shop_and_says_why():
+    # prepare
+    player, stats = createState()
+    stats.totalFishCaught = 1
+
+    # call
+    unlock = progression.getNextUnlock(player, stats)
+
+    # check
+    assert unlock["id"] == progression.SHOP
+    assert "sell" in unlock["announcement"]
+    assert progression.isUnlocked(stats, progression.SHOP)
+
+
+def test_an_unlock_is_only_announced_once():
+    # prepare
+    player, stats = createState()
+    stats.totalFishCaught = 1
+    progression.getNextUnlock(player, stats)
+
+    # call - the condition still holds on the next pass
+    unlock = progression.getNextUnlock(player, stats)
+
+    # check
+    assert unlock is None
+    assert stats.unlockedFeatures.count(progression.SHOP) == 1
+
+
+def test_selling_fish_unlocks_home():
+    # prepare
+    player, stats = createState()
+    stats.totalMoneyMade = 12
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert progression.isUnlocked(stats, progression.HOME)
+
+
+def test_running_out_of_energy_unlocks_home_even_without_a_sale():
+    # prepare - a player who fished themselves flat before selling anything.
+    # Without this they would have no way to get their energy back.
+    player, stats = createState()
+    player.energy = 0
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert progression.isUnlocked(stats, progression.HOME)
+
+
+def test_bait_unlocks_once_it_is_affordable():
+    # prepare
+    player, stats = createState()
+    player.money = player.priceForBait - 1
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert not progression.isUnlocked(stats, progression.BAIT)
+
+    # prepare - one more sale covers it
+    player.money = player.priceForBait
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert progression.isUnlocked(stats, progression.BAIT)
+
+
+def test_rod_unlocks_after_the_first_bait_upgrade():
+    # prepare
+    player, stats = createState()
+    player.fishMultiplier = 2
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert progression.isUnlocked(stats, progression.ROD)
+
+
+def test_banked_money_counts_toward_the_wealth_unlocks():
+    # prepare - the same wealth, all of it in the bank
+    player, stats = createState()
+    player.money = 0
+    player.moneyInBank = 700
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert progression.isUnlocked(stats, progression.BANK)
+    assert progression.isUnlocked(stats, progression.FLEET)
+    assert progression.isUnlocked(stats, progression.INVESTMENTS)
+    assert not progression.isUnlocked(stats, progression.GOAL)
+
+
+def test_every_unlock_is_reachable_and_has_its_pieces():
+    # check - a row with no id/announcement/condition would be silently
+    # un-gateable, and a duplicate id would announce twice
+    ids = [unlock["id"] for unlock in progression.UNLOCKS]
+    assert len(ids) == len(set(ids))
+    assert ids == progression.ALL_FEATURE_IDS
+    for unlock in progression.UNLOCKS:
+        assert unlock["id"]
+        assert unlock["name"]
+        assert unlock["announcement"].endswith(".")
+        assert callable(unlock["condition"])
+
+
+def test_unlockAll_grants_the_whole_village():
+    # prepare
+    _, stats = createState()
+
+    # call
+    progression.unlockAll(stats)
+
+    # check
+    for featureId in progression.ALL_FEATURE_IDS:
+        assert progression.isUnlocked(stats, featureId)
+
+
+def test_catchUp_grants_an_established_player_without_announcing():
+    # prepare - the state of a save written before progression existed: a rich
+    # player with an empty unlockedFeatures list
+    player, stats = createState()
+    player.money = 20000
+    player.fishMultiplier = 5
+    stats.totalFishCaught = 4000
+    stats.totalMoneyMade = 30000
+    stats.hoursSpentFishing = 900
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check - the whole village is open, and nothing is left to announce on
+    # the first screen they see
+    assert sorted(stats.unlockedFeatures) == sorted(progression.ALL_FEATURE_IDS)
+    assert progression.getNextUnlock(player, stats) is None
+
+
+def test_catchUp_grants_nothing_to_a_new_game():
+    # prepare
+    player, stats = createState()
+
+    # call
+    progression.catchUp(player, stats)
+
+    # check
+    assert stats.unlockedFeatures == []
+
+
+def test_isFreshStart():
+    # prepare
+    player, stats = createState()
+
+    # check
+    assert progression.isFreshStart(stats)
+
+    # prepare - one cast in
+    stats.totalFishCaught = 3
+    progression.getNextUnlock(player, stats)
+
+    # check
+    assert not progression.isFreshStart(stats)
+
+
+def test_only_one_feature_is_granted_per_call():
+    # prepare - a single long cast can land a first catch and empty the energy
+    # bar at the same time, meeting two conditions at once
+    player, stats = createState()
+    stats.totalFishCaught = 8
+    player.energy = 0
+
+    # call
+    first = progression.getNextUnlock(player, stats)
+
+    # check - the player is told one thing, not two
+    assert first["id"] == progression.SHOP
+    assert stats.unlockedFeatures == [progression.SHOP]
+
+    # call - the other arrives on the following screen
+    assert progression.getNextUnlock(player, stats)["id"] == progression.HOME
+    assert progression.getNextUnlock(player, stats) is None

--- a/tests/stats/test_statsJsonReaderWriter.py
+++ b/tests/stats/test_statsJsonReaderWriter.py
@@ -342,3 +342,35 @@ def test_save_without_exportStats_loads_with_zeroes():
     assert loaded.totalFishExported == 0
     assert loaded.totalMoneyFromExports == 0
     assert loaded.totalShippingPaid == 0
+
+
+def test_unlockedFeatures_round_trips():
+    # prepare
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    stats = createStats()
+    stats.unlockedFeatures = ["shop", "home"]
+
+    # call - serialize then deserialize
+    statsJson = statsJsonReaderWriter.createJsonFromStats(stats)
+    restored = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check - which parts of the village have been revealed has to survive a
+    # save, or a returning player would be shown the whole menu again
+    assert statsJson["unlockedFeatures"] == ["shop", "home"]
+    assert restored.unlockedFeatures == ["shop", "home"]
+
+
+def test_createStatsFromJson_missingUnlockedFeatures_defaultsToEmpty():
+    # prepare - a save written before progression existed
+    statsJsonReaderWriter = createStatsJsonReaderWriter()
+    statsJson = {
+        "totalFishCaught": 1,
+        "totalMoneyMade": 1,
+    }
+
+    # call
+    stats = statsJsonReaderWriter.createStatsFromJson(statsJson)
+
+    # check - backward compatible default; FishE.__init__ then grants whatever
+    # the player has already earned (see progression.catchUp)
+    assert stats.unlockedFeatures == []

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -13,6 +13,7 @@ from src.world.timeServiceJsonReaderWriter import TimeServiceJsonReaderWriter
 from src.saveFileManager import SaveFileManager
 from src.location.enum.locationType import LocationType
 from src.housing import housing
+from src.progression import progression
 
 # Imported the same way fishE.py imports it (bare, not "src."-prefixed) so
 # isinstance checks against fishE.FishE's real self.config compare the same
@@ -22,8 +23,12 @@ from config.config import Config
 
 
 def createFishE():
-    fishE.Player = MagicMock()
-    fishE.Stats = MagicMock()
+    # Player and Stats hand back real objects: __init__ runs the progression
+    # catch-up over them (see src/progression), and its unlock conditions
+    # compare real numbers. These are still mocks, so the call-count assertions
+    # below hold either way.
+    fishE.Player = MagicMock(return_value=Player())
+    fishE.Stats = MagicMock(return_value=Stats())
     fishE.TimeService = MagicMock()
     fishE.Prompt = MagicMock()
     fishE.UserInterfaceFactory = MagicMock()
@@ -36,6 +41,11 @@ def createFishE():
     fishE.TimeServiceJsonReaderWriter = MagicMock()
     fishE.StatsJsonReaderWriter = MagicMock()
     fishE.SaveFileManager = MagicMock()
+    # Same reason as Player/Stats above: whether __init__ takes the load path
+    # depends on whether a save file happens to exist, and the progression
+    # catch-up runs over whatever it ends up holding.
+    fishE.PlayerJsonReaderWriter.return_value.readPlayerFromFile.return_value = Player()
+    fishE.StatsJsonReaderWriter.return_value.readStatsFromFile.return_value = Stats()
     fishE.loadPlayer = MagicMock()
     fishE.loadStats = MagicMock()
     fishE.loadTimeService = MagicMock()
@@ -425,9 +435,7 @@ def test_save_creates_missing_data_directory():
         game.save()
 
         # check - save() created the directory tree itself
-        assert os.path.exists(
-            os.path.join(data_directory, "slot_1", "player.json")
-        )
+        assert os.path.exists(os.path.join(data_directory, "slot_1", "player.json"))
 
 
 def test_save_handles_write_failure_without_raising():
@@ -661,6 +669,119 @@ def test_play_updates_ui_header_before_running_location():
     # call
     game.play()
 
-    # check - header fields are set from the location/wealth before run() is called
+    # check - header fields are set from the location/wealth before run() is
+    # called; the goal line stays hidden until the player has been shown it
     assert game.userInterface.currentLocationName == LocationType.HOME.capitalize()
+    assert game.userInterface.goalProgress == ""
+
+
+def test_play_shows_the_goal_line_once_it_is_unlocked():
+    # prepare - a player who has already been shown the goal
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.player.money = 10
+    game.player.moneyInBank = 5
+    progression.unlockAll(game.stats)
+
+    # call
+    game.play()
+
+    # check
     assert game.userInterface.goalProgress == "$15 / $%d" % fishE.GOAL_AMOUNT
+
+
+def test_play_announces_a_newly_unlocked_feature_with_its_reason():
+    # prepare - the player lands their first catch this iteration
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.stats.totalFishCaught = 1
+
+    # call
+    game.play()
+
+    # check - the newly-appeared menu entry is explained on the same screen it
+    # first shows up on
+    shop = next(u for u in progression.UNLOCKS if u["id"] == progression.SHOP)
+    assert shop["announcement"] in game.prompt.text
+    assert progression.isUnlocked(game.stats, progression.SHOP)
+
+
+def test_play_does_not_repeat_an_unlock_announcement():
+    # prepare
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.stats.totalFishCaught = 1
+    progression.catchUp(game.player, game.stats)
+
+    # call
+    game.play()
+
+    # check
+    shop = next(u for u in progression.UNLOCKS if u["id"] == progression.SHOP)
+    assert shop["announcement"] not in game.prompt.text
+
+
+def test_init_starts_a_new_game_on_the_docks_with_nothing_unlocked():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - an empty slot, i.e. a brand new game
+        game = createGameThroughInit(data_directory, {})
+
+        # check - the player opens on the docks, where fishing is the only
+        # thing on the menu, and is greeted with something better than the
+        # standing "What would you like to do?"
+        assert game.currentLocation == LocationType.DOCKS
+        assert game.stats.unlockedFeatures == []
+        assert game.prompt.text == progression.OPENING_PROMPT
+
+
+def test_init_catches_up_a_save_written_before_progression_existed():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - an established player whose stats.json has no
+        # unlockedFeatures at all
+        player = Player()
+        player.money = 8000
+        player.fishMultiplier = 4
+        stats = Stats()
+        stats.totalFishCaught = 900
+        stats.totalMoneyMade = 12000
+        stats.hoursSpentFishing = 400
+        statsJson = StatsJsonReaderWriter().createJsonFromStats(stats)
+        del statsJson["unlockedFeatures"]
+
+        # call
+        game = createGameThroughInit(
+            data_directory,
+            {
+                "player.json": PlayerJsonReaderWriter().createJsonFromPlayer(player),
+                "stats.json": statsJson,
+            },
+        )
+
+        # check - the village they already built is not re-locked around them,
+        # and none of it is announced as news
+        assert sorted(game.stats.unlockedFeatures) == sorted(
+            progression.ALL_FEATURE_IDS
+        )
+        assert game.prompt.text != progression.OPENING_PROMPT
+
+
+def test_play_announces_one_unlock_per_screen():
+    # prepare - a first catch that also emptied the energy bar, so two unlocks
+    # are earned on the same action
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.stats.totalFishCaught = 1
+    game.player.energy = 0
+
+    # call - one iteration of the game loop
+    game.play()
+
+    # check - the player is handed one new button with its reason, not two;
+    # the other is still earned and arrives on the next screen
+    announcements = [
+        unlock["announcement"]
+        for unlock in progression.UNLOCKS
+        if unlock["announcement"] in game.prompt.text
+    ]
+    assert len(announcements) == 1
+    assert game.stats.unlockedFeatures == [progression.SHOP]


### PR DESCRIPTION
## Summary

A new game now opens **on the docks with a single thing to do — fish**. Every other option in the village arrives later, one per screen, as the player earns it, and each arrival is announced with the reason it appeared:

```
 You caught 7 Minnow over 6 hours! A perfect hook!  [Milestone unlocked: First Catch!]
 [Your basket is heavy with fish. Gilbert buys them at the shop - better go sell them.]

 [1] Fish
 [2] Go to Shop
 [3] Quit
```

This is pacing, not difficulty — nothing is made harder or more expensive, and an established save opens with the whole village available exactly as before.

- Adds `src/progression`, a data-driven unlock table (id, announcement, condition over `Player`/`Stats`) built the same way as `src/achievements`' milestones — add a row and it is tracked, gated and announced automatically.
- Persists the granted ids on `Stats.unlockedFeatures`, with the matching `schemas/stats.json` entry and `StatsJsonReaderWriter` field.
- Starts the game at the docks, and grants already-earned unlocks silently on load, so a save written before this existed is never re-locked around its player.
- Gates the docks, shop, bank, tavern and home menus on the unlocks. The docks grow **downward**, so an option the player already knows keeps its number when a new one shows up.
- Adds **Quit** to the docks: that is now where a new player starts, and they would otherwise have no way to stop before earning the home menu.
- Hides the `$10,000` goal line from the status header until the player's first `$1,000` — "$20 / $10,000" on cast one gives away the whole arc.
- Stages Sam's "What other locations can I visit?" answer to the places the player has actually found.

## Design notes

**One reveal per screen, always.** A single long cast can land a first catch *and* empty the energy bar at once. Announcing both would produce exactly the wall of new options this exists to avoid, so `getNextUnlock` grants one; the rest are still earned and arrive on the following screens.

**No deadlocks.** *Go Home* unlocks on the first sale **or** on energy dropping below the 10 needed to fish, so a player who fishes themselves flat before selling anything can always still get their energy back.

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — 676 passed (was 638); `src/progression` at 100% coverage
- [x] `black src tests` + `autoflake` per `format.sh`
- [x] **Front-end parity**: this is entirely game-layer, so all three front-ends get it through `showOptions`. Verified live on the **console** front-end (opening menu, first-catch reveal, save/reload) and on the **web** front-end over HTTP (`GET /state` / `POST /input`) — both show the staged menus and the empty goal line. The **pygame** front-end renders the same `optionList` and already hides an empty `goalProgress`.
- [x] Scripted 1,500-action playthrough to check pacing: all 12 unlocks land across ~83 actions / 9 in-game days, no dead zones.
- [x] Save/reload round-trip: `unlockedFeatures` persists, and a legacy `stats.json` with no such field catches up on load.

---

_drafted by Claude on behalf of Daniel Stephenson_