### PR TITLE
Run the web game in the player's browser, with saves in IndexedDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 data/
 .coverage
 cov.xml
+
+# Built at image-build time by web/build_zip.py; not checked in.
+web/game.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,38 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# jsonschema is a real runtime dependency, not a test-only one: src/fishE.py
-# imports it at module scope, so the game cannot start without it. pygame is
-# deliberately absent — it is imported lazily by the pygame front-end only,
-# which this image never selects.
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
+# This image does not run the game — the browser does. web/serve.py only hands
+# out the page, the Worker, and the game bundle; Pyodide then runs the Python
+# game in the player's own tab, with that tab's IndexedDB holding the saves.
+#
+# Two consequences worth spelling out:
+#   - No pip install. The game's one runtime dependency, jsonschema, is loaded
+#     browser-side by web/game-worker.js, and the server here is pure stdlib.
+#   - No save directory, and no volume to persist. Every visitor gets their own
+#     game and their own save slots, which is exactly what the server-backed
+#     front-end (examples/web_app.py) could not give them.
 COPY src/ ./src/
-COPY examples/ ./examples/
+COPY web/ ./web/
 # The JSON Schemas the save-file readers validate against. Their paths are
-# relative to the process cwd (see playerJsonReaderWriter.PLAYER_SCHEMA_PATH =
-# "schemas/player.json"), which is /app here — so they must be copied in, or
-# every save load/write raises FileNotFoundError.
+# relative to the process cwd, which the Worker sets to the unpacked bundle —
+# so these have to be copied in for build_zip.py to put them in the bundle, not
+# for anything in this image to read.
 COPY schemas/ ./schemas/
+COPY version.txt ./
 
-# Create the data/ directory (see saveFileManager.py's default
-# data_directory="data", resolved relative to the process cwd -> /app/data
-# here) and hand it to a non-root user before switching to it, so a named
-# volume mounted over /app/data on first run inherits writable ownership.
-RUN useradd --system --no-create-home fishe \
-    && mkdir -p /app/data \
-    && chown -R fishe:fishe /app/data
+# Bundle the game for the browser to download. Built here rather than checked
+# in so the bundle can never be a stale copy of src/.
+RUN python3 web/build_zip.py
+
+RUN useradd --system --no-create-home fishe
 USER fishe
 
-# WebUserInterface itself defaults to 127.0.0.1:8000 (unreachable from
-# outside its own network namespace); UserInterfaceFactory's WEB branch reads
-# these to override the bind address/port. 0.0.0.0 is required for Traefik
-# (a different container on the same bridge network) to reach this server.
+# web/serve.py defaults to 127.0.0.1 (unreachable from outside its own network
+# namespace), so 0.0.0.0 is required for Traefik — a different container on the
+# same bridge network — to reach it.
 ENV FISHE_WEB_HOST=0.0.0.0
-ENV FISHE_WEB_PORT=8000
+ENV FISHE_WEB_PORT=8080
 ENV PYTHONUNBUFFERED=1
 
-EXPOSE 8000
-CMD ["python3", "examples/web_app.py"]
+EXPOSE 8080
+CMD ["python3", "web/serve.py"]

--- a/README.md
+++ b/README.md
@@ -6,15 +6,27 @@ This game allows you to explore a fishing village and perform actions in it.
 
 ## Features
 
-### Play in your browser (web interface)
-FishE runs behind a single user-interface contract, so it supports multiple front-ends: the default text/console interface, a pygame window, and a browser-based **web interface**. To play in the browser, run the example web app and open the printed URL:
+### Play in your browser
+FishE runs behind a single user-interface contract, so it supports multiple front-ends: the default text/console interface, a pygame window, and two browser-based ones. The entire game — save-file manager, fishing, shop, bank, tavern, and NPC dialogue — plays in the browser either way, and both render from the same client (`web/client.js`), so they look and behave identically. Adding a new front-end means implementing `BaseUserInterface` and adding a `UIType` + factory branch.
+
+**In your own browser (`UIType.PYODIDE`)** — the game itself runs in your tab, under [Pyodide](https://pyodide.org). Nothing is sent to a server, every tab is its own game, and your **save files live in your browser's IndexedDB**, so they survive a reload and stay on your machine. This is how the game is deployed:
+
+```bash
+python3 web/build_zip.py    # bundle the game for the browser (once, and after any src/ change)
+python3 web/serve.py
+# then open http://127.0.0.1:8080
+```
+
+`web/serve.py` only serves files — it never runs the game. It does have to send the `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers it sets, though: without them the page is not cross-origin isolated, `SharedArrayBuffer` is unavailable, and the browser cannot deliver your input to the game. Any proxy placed in front of it must preserve those headers.
+
+**On a server (`UIType.WEB`)** — the game runs in the Python process and the browser is a terminal for it, with save files on the server's disk under `data/`. Handy for playing over a terminal-less machine on your own network, but everyone who opens the page shares one game and one set of saves:
 
 ```bash
 python3 examples/web_app.py
 # then open http://127.0.0.1:8000
 ```
 
-The entire game — save-file manager, fishing, shop, bank, tavern, and NPC dialogue — plays in the browser, with no extra dependencies (it uses only the Python standard library). Adding a new front-end means implementing `BaseUserInterface` and adding a `UIType` + factory branch.
+Both use only the Python standard library; the Pyodide front-end loads its one runtime dependency (`jsonschema`) in the browser.
 
 ### One Thing at a Time
 A new game opens on the docks with a rod, a bucket, and exactly one thing to do: **fish**. Everything else in the village arrives later, one option at a time, as you earn it — and each arrival tells you why it's there:
@@ -107,7 +119,9 @@ FishE supports multiple save files, allowing you to maintain different game prog
 - **Delete Save**: Remove unwanted save files
 - **Load**: Pick any existing save slot to continue your adventure
 
-Each save file is stored in its own slot (slot_1, slot_2, etc.) in the `data/` directory, ensuring your saves never conflict with each other.
+Each save file is stored in its own slot (slot_1, slot_2, etc.) in the `data/` directory, ensuring your saves never conflict with each other. Set `FISHE_SAVE_DIR` to keep them somewhere else.
+
+When you play in your own browser (the Pyodide front-end above), those same slots are written to your browser's IndexedDB instead of to disk — creating, saving and deleting a slot all take effect there, so your progress is waiting for you when you come back to the tab. They belong to that browser on that machine: clearing the site's data clears them, and they don't follow you to another browser or another device.
 
 ## Contributing
 

--- a/examples/web_app.py
+++ b/examples/web_app.py
@@ -1,7 +1,15 @@
-"""Example: run FishE with the browser-based web front-end.
+"""Example: run FishE with the server-backed web front-end.
 
 This shows how to drive the existing game through the WebUserInterface — no game
-logic changes, just a different UIType. Run it and open the printed URL:
+logic changes, just a different UIType. The game runs here, in this process, and
+the browser is a terminal for it: one game and one set of save files under
+data/, shared by everyone who opens the page.
+
+To give each player their own game and their own saves, run the browser-native
+front-end instead (`python3 web/serve.py`), which hands the game to Pyodide in
+the player's own tab and keeps the save slots in that browser's IndexedDB.
+
+Run it and open the printed URL:
 
     python3 examples/web_app.py
 

--- a/src/browserSaveSync.py
+++ b/src/browserSaveSync.py
@@ -1,0 +1,49 @@
+# @author Daniel McCoy Stephenson
+"""Flush FishE's save files to browser storage when running under Pyodide.
+
+The Pyodide front-end runs the whole game inside a Web Worker, so its save
+slots live in the Worker's in-memory Emscripten filesystem — memory that is
+discarded the moment the tab closes. ``web/game-worker.js`` exposes a
+``syncSaves()`` JavaScript global that walks the save directory and hands the
+files to the main thread, which writes them to IndexedDB (see that file for why
+the write cannot happen in the Worker itself).
+
+Every code path that writes or deletes a save must call ``syncBrowserSaves()``
+afterwards, or the change lives only until the tab is closed.
+
+Outside Pyodide (console, pygame, and the HTTP web front-end) the ``js`` module
+does not exist, so this is a no-op and the on-disk files are the real saves.
+"""
+
+import sys
+
+
+def syncBrowserSaves():
+    """Persist the save directory to browser storage, if running in a browser.
+
+    Returns True if a flush was performed, False if there was nothing to flush
+    to (i.e. this is not a browser build). Never raises: a browser that refuses
+    to store data must not take the game down with it.
+    """
+    # Imported via sys.modules rather than `import js` so that a plain CPython
+    # run doesn't depend on a module that only exists inside Pyodide, and so a
+    # test can install a fake one.
+    js = sys.modules.get("js")
+    if js is None:
+        return False
+
+    syncSaves = getattr(js, "syncSaves", None)
+    if syncSaves is None:
+        return False
+
+    try:
+        syncSaves()
+        return True
+    except Exception as e:
+        print(
+            "\n Warning: could not save your progress to browser storage: "
+            f"{e}\n Progress is kept for this session, but may be lost when "
+            "you reload. Check that this site is allowed to store data and "
+            "that you are not in a private/incognito window."
+        )
+        return False

--- a/src/browserSaveSync.py
+++ b/src/browserSaveSync.py
@@ -18,6 +18,28 @@ does not exist, so this is a no-op and the on-disk files are the real saves.
 import sys
 
 
+def getJsModule():
+    """Return Pyodide's `js` module, or None when not running in a browser.
+
+    `js` is importable under Pyodide but is NOT already in sys.modules — it
+    only lands there once something imports it. So this has to actually
+    attempt the import: looking in sys.modules alone reports "not a browser"
+    while running in one, which silently turned saving into a no-op and made
+    the Pyodide front-end refuse to start.
+
+    sys.modules is still consulted first, and `import` would consult it anyway,
+    so a test can inject a stand-in under that name.
+    """
+    js = sys.modules.get("js")
+    if js is not None:
+        return js
+    try:
+        import js  # noqa: F811 — only importable inside Pyodide
+    except ImportError:
+        return None
+    return js
+
+
 def syncBrowserSaves():
     """Persist the save directory to browser storage, if running in a browser.
 
@@ -25,10 +47,7 @@ def syncBrowserSaves():
     to (i.e. this is not a browser build). Never raises: a browser that refuses
     to store data must not take the game down with it.
     """
-    # Imported via sys.modules rather than `import js` so that a plain CPython
-    # run doesn't depend on a module that only exists inside Pyodide, and so a
-    # test can install a fake one.
-    js = sys.modules.get("js")
+    js = getJsModule()
     if js is None:
         return False
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,11 +1,18 @@
+import os
+
+
 # @author Daniel McCoy Stephenson
 class Config:
     def __init__(self):
-        # Save file paths
-        self.dataDirectory = "data"
-        self.playerSaveFile = "data/player.json"
-        self.statsSaveFile = "data/stats.json"
-        self.timeServiceSaveFile = "data/timeService.json"
+        # Save file paths. FISHE_SAVE_DIR relocates the whole save directory,
+        # which deployments use to point the game somewhere other than a
+        # cwd-relative "data" — a mounted volume for a server install, or the
+        # Worker-side directory that the Pyodide front-end mirrors to the
+        # browser's IndexedDB (see browserSaveSync and web/game-worker.js).
+        self.dataDirectory = os.environ.get("FISHE_SAVE_DIR") or "data"
+        self.playerSaveFile = os.path.join(self.dataDirectory, "player.json")
+        self.statsSaveFile = os.path.join(self.dataDirectory, "stats.json")
+        self.timeServiceSaveFile = os.path.join(self.dataDirectory, "timeService.json")
 
         # Initial player values
         self.initialMoney = 20

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -13,6 +13,7 @@ from stats.stats import Stats
 from ui.userInterfaceFactory import UserInterfaceFactory
 from ui.enum.uiType import UIType
 from saveFileManager import SaveFileManager
+from browserSaveSync import syncBrowserSaves
 from achievements import achievements
 from achievements.achievements import GOAL_AMOUNT, GOAL_MILESTONE_NAME
 from housing import housing
@@ -300,6 +301,12 @@ class FishE:
         except (IOError, OSError) as e:
             print(f"\n Warning: Failed to save game: {e}")
             # Game continues even if save fails
+            return
+
+        # Under the Pyodide front-end the writes above landed in the Worker's
+        # in-memory filesystem; this is what actually gets them into the
+        # browser's IndexedDB. A no-op for every other front-end.
+        syncBrowserSaves()
 
     def loadPlayer(self):
         try:

--- a/src/saveFileManager.py
+++ b/src/saveFileManager.py
@@ -3,6 +3,8 @@ import json
 import shutil
 from datetime import datetime
 
+from browserSaveSync import syncBrowserSaves
+
 
 # @author Daniel McCoy Stephenson
 class SaveFileManager:
@@ -130,6 +132,10 @@ class SaveFileManager:
 
         if os.path.exists(slot_path):
             shutil.rmtree(slot_path)
+            # Browser storage mirrors the save directory wholesale, so a
+            # deletion has to be flushed too — otherwise the slot comes back
+            # on the next page load. A no-op outside the Pyodide front-end.
+            syncBrowserSaves()
             return True
         return False
 
@@ -156,6 +162,9 @@ class SaveFileManager:
                 shutil.move(old_stats, os.path.join(slot_1_path, "stats.json"))
             if os.path.exists(old_time):
                 shutil.move(old_time, os.path.join(slot_1_path, "timeService.json"))
+            # The migration rewrote the save directory's layout; flush it so a
+            # browser-storage player doesn't re-migrate on every page load.
+            syncBrowserSaves()
             return True
         except (IOError, OSError):
             return False

--- a/src/ui/enum/uiType.py
+++ b/src/ui/enum/uiType.py
@@ -6,3 +6,7 @@ class UIType(Enum):
     CONSOLE = "console"
     PYGAME = "pygame"
     WEB = "web"
+    # The game running in the player's own browser under Pyodide, with saves in
+    # that browser's IndexedDB — as opposed to WEB, where the game and its save
+    # files live on a server and the browser is only a terminal for it.
+    PYODIDE = "pyodide"

--- a/src/ui/pyodideUserInterface.py
+++ b/src/ui/pyodideUserInterface.py
@@ -1,0 +1,158 @@
+# @author Daniel McCoy Stephenson
+"""FishE's browser-native front-end: the game itself runs in the player's tab.
+
+WebUserInterface puts the game on a server and the browser polls it, which means
+one server-side game and one set of server-side save files shared by everyone
+who opens the page. This front-end instead runs the whole Python game inside a
+Web Worker under Pyodide, so every tab has its own game and its own saves — the
+latter kept in the browser's IndexedDB (see browserSaveSync and
+web/game-worker.js).
+
+Only the transport differs from WebUserInterface, which this class subclasses:
+every screen the player sees is still built by WebUserInterface's primitives, so
+a new screen type is written once and appears in both. Here a screen is posted
+to the main thread as a JSON string, and the player's response is read from the
+SharedArrayBuffer ring buffer that web/index.html writes into.
+
+Why a ring buffer rather than Worker messages: the game loop is synchronous, so
+it blocks the Worker while waiting for input, and a blocked Worker can never run
+an onmessage handler. Shared memory is readable without the event loop, so the
+main thread can hand input to a blocked game.
+"""
+
+import json
+import sys
+import time
+
+from ui.webUserInterface import WebUserInterface
+
+
+# How long to sleep between checks of the input ring while waiting on the
+# player. Short enough to feel instant, long enough that a player reading a
+# screen isn't spun on. time.sleep() in Pyodide yields via Atomics.wait, so
+# this genuinely idles the Worker rather than burning the tab's CPU.
+INPUT_POLL_INTERVAL_SECONDS = 0.02
+
+_MESSAGE_TERMINATOR = 10  # b"\n" — the ring's message boundary
+
+
+class SharedArrayBufferBridge:
+    """Talks to the JavaScript side of the Pyodide front-end.
+
+    web/game-worker.js installs the globals used here before starting the game:
+    ``sendToMain`` (post a message to the main thread), and ``sabMeta`` /
+    ``sabData`` / ``sabRingSize`` / ``Atomics`` for the input ring buffer.
+    """
+
+    def __init__(self, js=None):
+        if js is None:
+            js = sys.modules.get("js")
+        if js is None:
+            raise RuntimeError(
+                "The Pyodide front-end can only run inside a browser: the 'js' "
+                "module it needs exists only under Pyodide. To play in a "
+                "browser, serve the game with 'python3 web/serve.py' and open "
+                "the page it prints. To play from a terminal or a desktop "
+                "window instead, use UIType.CONSOLE or UIType.PYGAME."
+            )
+        missing = [
+            name
+            for name in ("sendToMain", "Atomics", "sabMeta", "sabData", "sabRingSize")
+            if getattr(js, name, None) is None
+        ]
+        if missing:
+            raise RuntimeError(
+                "The Pyodide front-end is missing the JavaScript globals its "
+                f"Worker is supposed to install: {', '.join(missing)}. This "
+                "happens when the game is started by something other than "
+                "web/game-worker.js — start it from that Worker (web/index.html "
+                "does), or use UIType.CONSOLE outside a browser."
+            )
+        self._js = js
+        self._ringSize = int(js.sabRingSize)
+
+    def postScreen(self, screen):
+        """Send a screen to the main thread for rendering.
+
+        Sent as a JSON string rather than a converted JS object: the screen is
+        a plain nested dict/list structure, and a string crosses the Worker
+        boundary without any Pyodide FFI conversion to get wrong.
+        """
+        self._js.sendToMain(json.dumps({"type": "screen", "screen": screen}))
+
+    def readInput(self):
+        """Return the player's next response, or None if none has arrived yet."""
+        line = self._readLine()
+        if not line:
+            return None
+        try:
+            message = json.loads(line)
+        except ValueError:
+            # Not something this front-end sent; ignoring it keeps a stray
+            # write from ending the wait with a bogus response.
+            return None
+        if message.get("type") != "input":
+            return None
+        return message.get("value", "")
+
+    def _readLine(self):
+        """Pull one newline-terminated message out of the ring buffer."""
+        Atomics = self._js.Atomics
+        meta = self._js.sabMeta
+        data = self._js.sabData
+
+        writeIndex = int(Atomics.load(meta, 0))
+        readIndex = int(Atomics.load(meta, 1))
+        if writeIndex == readIndex:
+            return ""
+
+        raw = bytearray()
+        while readIndex != writeIndex:
+            byte = int(data[readIndex % self._ringSize])
+            readIndex += 1
+            if byte == _MESSAGE_TERMINATOR:
+                break
+            raw.append(byte)
+        Atomics.store(meta, 1, readIndex)
+        # Player-entered text (a business name, say) can be any UTF-8; a partial
+        # sequence is dropped rather than raising in the middle of the game.
+        return raw.decode("utf-8", errors="ignore")
+
+
+# @author Daniel McCoy Stephenson
+class PyodideUserInterface(WebUserInterface):
+    """WebUserInterface's screens, delivered over the Pyodide Worker bridge."""
+
+    def __init__(
+        self,
+        currentPrompt,
+        timeService,
+        player,
+        bridge=None,
+        pollIntervalSeconds=INPUT_POLL_INTERVAL_SECONDS,
+    ):
+        # start_server=False: there is no server here, and no sockets to bind
+        # in the browser. get_state()/submit_input() still work, which keeps the
+        # inherited screen bookkeeping (and its tests) intact.
+        super().__init__(currentPrompt, timeService, player, start_server=False)
+        self._bridge = bridge if bridge is not None else SharedArrayBufferBridge()
+        self._pollIntervalSeconds = pollIntervalSeconds
+
+    def _present(self, screen):
+        # Record it the way WebUserInterface does (version bookkeeping, and so a
+        # late-attaching reader can still ask for the current screen), then push
+        # it to the browser instead of waiting to be polled for it.
+        super()._present(screen)
+        self._bridge.postScreen(screen)
+
+    def _awaitInput(self):
+        # The queue is still honoured so submit_input() works for tests and for
+        # anything driving the interface directly; the ring buffer is what the
+        # browser actually writes to.
+        while True:
+            if not self._inputQueue.empty():
+                return self._inputQueue.get()
+            value = self._bridge.readInput()
+            if value is not None:
+                return value
+            time.sleep(self._pollIntervalSeconds)

--- a/src/ui/pyodideUserInterface.py
+++ b/src/ui/pyodideUserInterface.py
@@ -21,9 +21,9 @@ main thread can hand input to a blocked game.
 """
 
 import json
-import sys
 import time
 
+from browserSaveSync import getJsModule
 from ui.webUserInterface import WebUserInterface
 
 
@@ -46,7 +46,7 @@ class SharedArrayBufferBridge:
 
     def __init__(self, js=None):
         if js is None:
-            js = sys.modules.get("js")
+            js = getJsModule()
         if js is None:
             raise RuntimeError(
                 "The Pyodide front-end can only run inside a browser: the 'js' "

--- a/src/ui/userInterfaceFactory.py
+++ b/src/ui/userInterfaceFactory.py
@@ -51,5 +51,12 @@ class UserInterfaceFactory:
             return WebUserInterface(
                 currentPrompt, timeService, player, host=host, port=port
             )
+        elif ui_type == UIType.PYODIDE:
+            # Imported lazily like the others: it reaches for the browser-only
+            # `js` module as soon as it is constructed, so nothing outside a
+            # Pyodide Worker should pay for importing it.
+            from ui.pyodideUserInterface import PyodideUserInterface
+
+            return PyodideUserInterface(currentPrompt, timeService, player)
         else:
             raise ValueError(f"Unsupported UI type: {ui_type}")

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -38,15 +38,33 @@ def _readWebAsset(name):
         ) from e
 
 
-CLIENT_CSS = _readWebAsset("client.css")
-CLIENT_JS = _readWebAsset("client.js")
+# Read on first use rather than at import, and cached after. This module is
+# imported by the Pyodide front-end too (PyodideUserInterface subclasses the
+# class below), and there these files are NOT on the filesystem: the browser
+# fetches them over HTTP, so only the server-backed front-end has any reason to
+# read them. Reading them at import time made merely importing this module fail
+# inside the Worker.
+_clientAssetCache = {}
+_pageCache = {}
 
 
-# The single-page client. It polls /state and renders whatever screen the game
-# is currently waiting on, posting the player's response to /input. Served as-is
-# (no templating); it talks to the server via relative URLs.
-HTML_PAGE = (
-    """<!DOCTYPE html>
+def _clientAsset(name):
+    if name not in _clientAssetCache:
+        _clientAssetCache[name] = _readWebAsset(name)
+    return _clientAssetCache[name]
+
+
+def htmlPage():
+    """The single-page client, built on first use.
+
+    It polls /state and renders whatever screen the game is currently waiting
+    on, posting the player's response to /input. Served as-is (no templating);
+    it talks to the server via relative URLs.
+    """
+    if "page" in _pageCache:
+        return _pageCache["page"]
+    page = (
+        """<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
@@ -54,8 +72,8 @@ HTML_PAGE = (
 <title>FishE</title>
 <style>
 """
-    + CLIENT_CSS
-    + """</style>
+        + _clientAsset("client.css")
+        + """</style>
 </head>
 <body>
 <h2>FishE <span class="tagline">— fish a seaside village and build a fortune of $10,000</span></h2>
@@ -63,8 +81,8 @@ HTML_PAGE = (
 <p class="controls">Tip: click an option or press its number key (1-9). Enter or Space continues.</p>
 <script>
 """
-    + CLIENT_JS
-    + """
+        + _clientAsset("client.js")
+        + """
 // Transport: this front-end runs the game on a server, so responses are POSTed
 // and new screens are discovered by polling. (The Pyodide front-end swaps this
 // block for a Worker/SharedArrayBuffer transport and shares everything above.)
@@ -96,7 +114,25 @@ poll();
 </body>
 </html>
 """
-)
+    )
+    _pageCache["page"] = page
+    return page
+
+
+def __getattr__(name):
+    """Keep HTML_PAGE / CLIENT_CSS / CLIENT_JS readable as module attributes.
+
+    They are the names this module has always exposed, so tests and any other
+    reader still reach them the same way — they are just no longer computed
+    unless something actually asks (PEP 562).
+    """
+    if name == "HTML_PAGE":
+        return htmlPage()
+    if name == "CLIENT_CSS":
+        return _clientAsset("client.css")
+    if name == "CLIENT_JS":
+        return _clientAsset("client.js")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _makeRequestHandler(ui):
@@ -105,7 +141,7 @@ def _makeRequestHandler(ui):
     class _Handler(BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path in ("/", "/index.html"):
-                self._send(200, "text/html; charset=utf-8", HTML_PAGE.encode("utf-8"))
+                self._send(200, "text/html; charset=utf-8", htmlPage().encode("utf-8"))
             elif self.path.startswith("/state"):
                 body = json.dumps(ui.get_state()).encode("utf-8")
                 self._send(200, "application/json", body)

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -1,4 +1,5 @@
 import json
+import os
 import queue
 import threading
 import time
@@ -11,79 +12,66 @@ from world.timeService import TimeService
 from housing import housing
 
 
+# The browser client (renderer + styles) is shared verbatim with the Pyodide
+# front-end, which serves the same two files from web/. Keeping one copy is what
+# stops a screen type from being handled in one web front-end but not the other.
+# They are inlined into the page below rather than served as separate routes so
+# the server stays a two-route affair and the page needs a single request.
+WEB_ASSET_DIRECTORY = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "web")
+)
+
+
+def _readWebAsset(name):
+    """Read a shared browser-client file from web/, or explain why it could not."""
+    path = os.path.join(WEB_ASSET_DIRECTORY, name)
+    try:
+        with open(path, "r", encoding="utf-8") as assetFile:
+            return assetFile.read()
+    except OSError as e:
+        raise RuntimeError(
+            f"FishE's web front-end could not read its browser client "
+            f"'{name}' (looked in {path}): {e}. That file ships in the "
+            f"repository's web/ directory, alongside src/. Run the game from a "
+            f"complete checkout, or — if this is a container image — make sure "
+            f"the image copies web/ in as well as src/."
+        ) from e
+
+
+CLIENT_CSS = _readWebAsset("client.css")
+CLIENT_JS = _readWebAsset("client.js")
+
+
 # The single-page client. It polls /state and renders whatever screen the game
 # is currently waiting on, posting the player's response to /input. Served as-is
 # (no templating); it talks to the server via relative URLs.
-HTML_PAGE = """<!DOCTYPE html>
+HTML_PAGE = (
+    """<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>FishE</title>
 <style>
-  /* text-size-adjust keeps Safari from inflating text of its own accord once
-     the viewport is device-width (most visible in landscape). */
-  html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
-  body { font-family: monospace; background: #0b1d2a; color: #e0f0ff;
-         max-width: 680px; margin: 2rem auto; padding: 0 1rem;
-         /* The game can emit long unbroken strings; break them rather than
-            letting them scroll the page sideways. Inherited by the screens. */
-         overflow-wrap: break-word; }
-  .header { color: #7fb0d0; border-bottom: 1px solid #2a4a5a;
-            padding-bottom: .5rem; margin-bottom: 1rem;
-            display: flex; flex-wrap: wrap; gap: .15rem 1.1rem; }
-  .descriptor { margin: 1rem 0; font-size: 1.1rem; }
-  .prompt { color: #9fd0ff; margin: 1rem 0; }
-  .dialogue { white-space: pre-wrap; overflow-wrap: break-word;
-              margin: 1rem 0; line-height: 1.5; }
-  button { display: block; width: 100%; text-align: left; margin: .3rem 0;
-           padding: .6rem; background: #163345; color: #e0f0ff;
-           border: 1px solid #2a4a5a; border-radius: 4px; cursor: pointer;
-           font-family: monospace; font-size: 1rem;
-           overflow-wrap: break-word;
-           touch-action: manipulation; }  /* no double-tap-to-zoom delay */
-  button:hover { background: #1f4a63; }
-  button.danger { background: #4a1620; border-color: #7a2a35; }
-  button.danger:hover { background: #63202c; }
-  button:disabled { opacity: .45; cursor: not-allowed; }
-  button:disabled:hover { background: #163345; }
-  button.action { width: auto; text-align: center; padding: .6rem 1.4rem;
-                  background: #1d5a7a; border-color: #2f7ba0; }
-  button.action:hover { background: #246a90; }
-  input { width: 100%; padding: .6rem; font-family: monospace; font-size: 1rem;
-          background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
-          border-radius: 4px; }
-  .tagline { font-size: .8rem; font-weight: normal; color: #7fb0d0; }
-  .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
-              margin-top: 1.5rem; padding-top: .5rem; }
-  .low { color: #ff8a8a; font-weight: bold; }
-  .operator { color: #ffcf8f; font-weight: bold; }
-  .notice { color: #9fd0ff; margin-top: 1rem; }
-  .notice.warning { color: #ffcf8f; border-left: 3px solid #c77b2a; padding-left: .6rem; }
-  /* Phone-sized screens only: the desktop layout above is left as-is. Note that
-     font sizes are deliberately not reduced here — 1rem inputs (16px) are what
-     keeps iOS Safari from zooming the page in when a field is focused. */
-  @media (max-width: 600px) {
-    /* 2rem of vertical margin is a lot of a short screen to spend on nothing. */
-    body { margin: 1rem auto; padding: 0 .75rem; }
-    /* A wrapped header was stacking its rows almost on top of each other. */
-    .header { gap: .35rem 1rem; }
-    /* .6rem padding puts a button at ~40px tall, under the ~44px that is
-       comfortable to tap; .75rem clears it. Wider gaps between them, too. */
-    button { padding: .75rem .6rem; margin: .45rem 0; }
-    /* Continue/Submit/React! are the only thing to press on their screens —
-       give them the full width instead of a small target off to one side. */
-    button.action { width: 100%; padding: .75rem .6rem; }
-  }
-</style>
+"""
+    + CLIENT_CSS
+    + """</style>
 </head>
 <body>
 <h2>FishE <span class="tagline">— fish a seaside village and build a fortune of $10,000</span></h2>
 <div id="app">Connecting&hellip;</div>
 <p class="controls">Tip: click an option or press its number key (1-9). Enter or Space continues.</p>
 <script>
+"""
+    + CLIENT_JS
+    + """
+// Transport: this front-end runs the game on a server, so responses are POSTed
+// and new screens are discovered by polling. (The Pyodide front-end swaps this
+// block for a Worker/SharedArrayBuffer transport and shares everything above.)
+FisheClient.init(function (value) {
+  fetch("/input", { method: "POST", body: JSON.stringify({ value: value }) });
+});
 let version = -1;
-let currentScreen = null;
 let failures = 0;
 async function poll() {
   try {
@@ -92,128 +80,23 @@ async function poll() {
     const recovered = failures >= 5;
     failures = 0;
     if (recovered) version = -1;  // force a re-render to clear the disconnect banner
-    if (state.version !== version) { version = state.version; render(state.screen); }
+    if (state.version !== version) { version = state.version; FisheClient.render(state.screen); }
   } catch (e) {
     failures++;
     // Don't clobber the intentional "game ended" screen with a scary banner.
-    if (failures === 5 && !(currentScreen && currentScreen.type === "ended")) {
-      renderDisconnected();
+    const screen = FisheClient.getCurrentScreen();
+    if (failures === 5 && !(screen && screen.type === "ended")) {
+      FisheClient.renderDisconnected();
     }
   }
   setTimeout(poll, 300);
 }
-function renderNotice(text, className) {
-  const app = document.getElementById("app");
-  app.innerHTML = "";
-  app.append(el("div", { className: className || "notice", textContent: text }));
-}
-function renderDisconnected() {
-  currentScreen = null;
-  renderNotice("Lost connection to the game — is it still running? Retrying…", "notice warning");
-}
-async function send(value) {
-  currentScreen = null;  // ignore stray keypresses until the next screen arrives
-  document.getElementById("app").innerHTML = "&hellip;";
-  await fetch("/input", { method: "POST", body: JSON.stringify({ value: value }) });
-}
-function el(tag, props, ...kids) {
-  const e = document.createElement(tag);
-  Object.assign(e, props || {});
-  for (const k of kids) e.append(k);
-  return e;
-}
-function render(screen) {
-  const app = document.getElementById("app");
-  app.innerHTML = "";
-  currentScreen = screen;  // let keyboard shortcuts act on what's on screen
-  if (!screen || screen.type === "loading") { renderNotice("Waiting for the game…"); return; }
-  if (screen.type === "ended") { renderNotice("The game has ended. You can close this tab."); return; }
-  if (screen.header) {
-    const h = screen.header;
-    const header = el("div", { className: "header" });
-    // Each stat is its own chip; the flex-wrap row spaces them with whitespace
-    // and wraps cleanly on narrow screens instead of running off one long line.
-    const addPart = (content) => {
-      header.append(content instanceof Node ? content : el("span", { textContent: content }));
-    };
-    addPart(`Day ${h.day}`);
-    addPart(h.time);
-    addPart(`$${h.money.toFixed(2)}`);
-    addPart(`Fish: ${h.fish}`);
-    // Below the fishing threshold (10) the player is too tired to fish — flag it.
-    const energy = el("span", { textContent: `Energy: ${h.energy}/${h.maxEnergy}` });
-    if (h.energy < 10) energy.className = "low";
-    addPart(energy);
-    if (h.location) addPart(h.location);
-    if (h.goal) addPart(`Goal: ${h.goal}`);
-    if (h.operator) addPart(el("span", { textContent: "OPERATOR MODE", className: "operator" }));
-    app.append(header);
-    document.title = `FishE — Day ${h.day}, $${h.money.toFixed(2)}`;
-  }
-  if (screen.descriptor) app.append(el("div", { className: "descriptor", textContent: screen.descriptor }));
-  if (screen.prompt) app.append(el("div", { className: "prompt", textContent: screen.prompt }));
-  if (screen.type === "options") {
-    screen.options.forEach((opt, i) => {
-      const b = el("button", {
-        textContent: `[${i + 1}] ${opt}`,
-        className: /delete/i.test(opt) ? "danger" : "",
-      });
-      b.onclick = () => send(String(i + 1));
-      app.append(b);
-    });
-  } else if (screen.type === "dialogue") {
-    app.append(el("div", { className: "dialogue", textContent: screen.text }));
-    const b = el("button", { textContent: "Continue", className: "action" });
-    b.onclick = () => send("");
-    app.append(b);
-  } else if (screen.type === "prompt") {
-    app.append(el("div", { className: "descriptor", textContent: screen.text }));
-    const inp = el("input", { type: "text" });
-    const b = el("button", { textContent: "Submit", className: "action" });
-    const valid = () => !screen.numeric ||
-      (inp.value.trim() !== "" && !isNaN(Number(inp.value)));
-    const submit = () => { if (valid()) send(inp.value); };
-    if (screen.numeric) {
-      inp.inputMode = "decimal";
-      inp.placeholder = "Enter a number";
-      inp.oninput = () => { b.disabled = !valid(); };
-      b.disabled = true;  // nothing valid typed yet
-    }
-    inp.onkeydown = (e) => { if (e.key === "Enter") submit(); };
-    b.onclick = submit;
-    app.append(inp); app.append(b); inp.focus();
-  } else if (screen.type === "busy") {
-    // A pause the game takes on its own — shown, but with nothing to click;
-    // the next screen replaces it when the pause is over.
-    app.append(el("div", { className: "descriptor", textContent: screen.message }));
-  } else if (screen.type === "timed") {
-    app.append(el("div", { className: "descriptor", textContent: screen.message }));
-    const b = el("button", { textContent: "React!", className: "action" });
-    b.onclick = () => send("");
-    app.append(b);
-  }
-}
-// Keyboard control, matching the console/pygame front-ends: number keys pick an
-// option; Enter or Space advances a dialogue or the timed prompt. Typing in the
-// text field is left to the field itself.
-document.addEventListener("keydown", (e) => {
-  const s = currentScreen;
-  if (!s) return;
-  if (e.target && e.target.tagName === "INPUT") return;
-  if (s.type === "options") {
-    if (e.key >= "1" && e.key <= "9") {
-      const n = parseInt(e.key, 10);
-      if (n <= s.options.length) { e.preventDefault(); send(String(n)); }
-    }
-  } else if (s.type === "dialogue" || s.type === "timed") {
-    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); send(""); }
-  }
-});
 poll();
 </script>
 </body>
 </html>
 """
+)
 
 
 def _makeRequestHandler(ui):
@@ -300,10 +183,19 @@ class WebUserInterface(BaseUserInterface):
         """Deliver the player's browser response to the waiting game thread."""
         self._inputQueue.put(value)
 
+    # --- transport seams ---------------------------------------------------
+    # Every screen below is built once and shared by both web front-ends; only
+    # how a screen reaches the browser (_present) and how the response comes
+    # back (_awaitInput) differ. PyodideUserInterface overrides just these two,
+    # so a new screen type never has to be written twice.
     def _present(self, screen):
         with self._lock:
             self._screen = screen
             self._version += 1
+
+    def _awaitInput(self):
+        """Block until the browser submits a response, and return it."""
+        return self._inputQueue.get()
 
     def _header(self):
         return {
@@ -338,26 +230,26 @@ class WebUserInterface(BaseUserInterface):
         )
         valid = {str(i + 1) for i in range(len(optionList))}
         while True:
-            choice = str(self._inputQueue.get())
+            choice = str(self._awaitInput())
             if choice in valid:
                 return choice
             # ignore anything that isn't a listed option and keep waiting
 
     def showDialogue(self, text):
         self._present({"type": "dialogue", "text": text})
-        self._inputQueue.get()
+        self._awaitInput()
         self.currentPrompt.text = "What would you like to do?"
 
     def promptForText(self, promptText):
         self._present({"type": "prompt", "text": promptText})
-        return str(self._inputQueue.get())
+        return str(self._awaitInput())
 
     def promptForNumber(self, promptText):
         # Flag the prompt as numeric so the browser can offer a numeric keyboard
         # and block submission of non-numbers (the base default can't say so).
         self._present({"type": "prompt", "text": promptText, "numeric": True})
         try:
-            return float(self._inputQueue.get())
+            return float(self._awaitInput())
         except (ValueError, TypeError):
             return None
 
@@ -371,7 +263,7 @@ class WebUserInterface(BaseUserInterface):
     def timedKeyPress(self, message):
         self._present({"type": "timed", "message": message})
         startTime = time.time()
-        self._inputQueue.get()
+        self._awaitInput()
         return time.time() - startTime
 
     def cleanup(self):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,8 +1,19 @@
+import os
+
+import pytest
+
 from src.config.config import Config
 
 
 def createConfig():
     return Config()
+
+
+@pytest.fixture(autouse=True)
+def withoutSaveDirectoryOverride(monkeypatch):
+    # FISHE_SAVE_DIR relocates the save directory, so a value left in the
+    # environment would otherwise change what every test below sees.
+    monkeypatch.delenv("FISHE_SAVE_DIR", raising=False)
 
 
 def test_initialization():
@@ -11,10 +22,10 @@ def test_initialization():
 
     # check save file paths
     assert config.dataDirectory == "data"
-    assert config.playerSaveFile == "data/player.json"
-    assert config.statsSaveFile == "data/stats.json"
-    assert config.timeServiceSaveFile == "data/timeService.json"
-    
+    assert config.playerSaveFile == os.path.join("data", "player.json")
+    assert config.statsSaveFile == os.path.join("data", "stats.json")
+    assert config.timeServiceSaveFile == os.path.join("data", "timeService.json")
+
     # check initial player values
     assert config.initialMoney == 20
     assert config.initialEnergy == 100
@@ -22,3 +33,24 @@ def test_initialization():
     assert config.initialMoneyInBank == 0.01
     assert config.initialFishMultiplier == 1
     assert config.initialPriceForBait == 50
+
+
+def test_save_directory_can_be_relocated(monkeypatch):
+    # Deployments use this: a mounted volume for a server install, or the
+    # browser-backed directory the Pyodide front-end mirrors to IndexedDB.
+    monkeypatch.setenv("FISHE_SAVE_DIR", "/saves")
+
+    config = createConfig()
+
+    assert config.dataDirectory == "/saves"
+    assert config.playerSaveFile == os.path.join("/saves", "player.json")
+    assert config.statsSaveFile == os.path.join("/saves", "stats.json")
+    assert config.timeServiceSaveFile == os.path.join("/saves", "timeService.json")
+
+
+def test_an_empty_save_directory_override_falls_back_to_the_default(monkeypatch):
+    # An unset-but-present env var (a compose file with FISHE_SAVE_DIR=) must
+    # not resolve save paths against the filesystem root.
+    monkeypatch.setenv("FISHE_SAVE_DIR", "")
+
+    assert createConfig().dataDirectory == "data"

--- a/tests/test_browserSaveSync.py
+++ b/tests/test_browserSaveSync.py
@@ -1,0 +1,74 @@
+import sys
+
+from src.browserSaveSync import syncBrowserSaves
+
+
+class FakeJs:
+    def __init__(self, raises=None):
+        self.callCount = 0
+        self.raises = raises
+
+    def syncSaves(self):
+        self.callCount += 1
+        if self.raises is not None:
+            raise self.raises
+
+
+def installFakeJs(js):
+    previous = sys.modules.get("js")
+    sys.modules["js"] = js
+    return previous
+
+
+def restoreJs(previous):
+    if previous is None:
+        sys.modules.pop("js", None)
+    else:
+        sys.modules["js"] = previous
+
+
+def test_no_op_outside_a_browser():
+    # No `js` module: the console, pygame and server-backed web front-ends all
+    # write real files, so there is nothing to flush anywhere.
+    previous = sys.modules.pop("js", None)
+    try:
+        assert syncBrowserSaves() is False
+    finally:
+        restoreJs(previous)
+
+
+def test_no_op_when_the_worker_did_not_install_syncSaves():
+    class JsWithoutSyncSaves:
+        pass
+
+    previous = installFakeJs(JsWithoutSyncSaves())
+    try:
+        assert syncBrowserSaves() is False
+    finally:
+        restoreJs(previous)
+
+
+def test_flushes_through_the_worker_hook():
+    js = FakeJs()
+    previous = installFakeJs(js)
+    try:
+        assert syncBrowserSaves() is True
+    finally:
+        restoreJs(previous)
+    assert js.callCount == 1
+
+
+def test_a_browser_that_refuses_to_store_does_not_end_the_game(capsys):
+    js = FakeJs(raises=RuntimeError("QuotaExceededError"))
+    previous = installFakeJs(js)
+    try:
+        assert syncBrowserSaves() is False
+    finally:
+        restoreJs(previous)
+
+    # The player is told what happened, what it means for their progress, and
+    # what to check - not just handed the exception text.
+    output = capsys.readouterr().out
+    assert "QuotaExceededError" in output
+    assert "browser storage" in output
+    assert "private" in output

--- a/tests/test_browserSaveSync.py
+++ b/tests/test_browserSaveSync.py
@@ -1,6 +1,8 @@
+import os
 import sys
+import textwrap
 
-from src.browserSaveSync import syncBrowserSaves
+from src.browserSaveSync import getJsModule, syncBrowserSaves
 
 
 class FakeJs:
@@ -25,6 +27,36 @@ def restoreJs(previous):
         sys.modules.pop("js", None)
     else:
         sys.modules["js"] = previous
+
+
+def test_finds_js_when_it_is_importable_but_not_yet_imported(tmp_path, monkeypatch):
+    """Regression: this is exactly the state Pyodide starts the game in.
+
+    `js` is importable under Pyodide but is not in sys.modules until something
+    imports it. Looking only in sys.modules therefore reported "not a browser"
+    while running in one — which stopped the Pyodide front-end from starting
+    at all, and would have turned every save into a silent no-op.
+    """
+    jsModule = tmp_path / "js.py"
+    jsModule.write_text(
+        textwrap.dedent(
+            """
+        calls = []
+
+        def syncSaves():
+            calls.append(1)
+    """
+        )
+    )
+    monkeypatch.syspath_prepend(os.fspath(tmp_path))
+    monkeypatch.delitem(sys.modules, "js", raising=False)
+
+    try:
+        assert getJsModule() is not None
+        assert syncBrowserSaves() is True
+        assert sys.modules["js"].calls == [1]
+    finally:
+        sys.modules.pop("js", None)
 
 
 def test_no_op_outside_a_browser():

--- a/tests/test_saveFileManager.py
+++ b/tests/test_saveFileManager.py
@@ -3,7 +3,7 @@ import json
 import tempfile
 import shutil
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from src.saveFileManager import SaveFileManager
 
 
@@ -77,7 +77,7 @@ def test_list_save_files_ignores_invalid_names():
         os.makedirs(os.path.join(temp_dir, "slot_"))  # Missing number
         os.makedirs(os.path.join(temp_dir, "slot_0"))  # Slot 0 (invalid)
         os.makedirs(os.path.join(temp_dir, "slot_100"))  # Slot 100 (out of range)
-        
+
         # Create a regular file (not a directory)
         with open(os.path.join(temp_dir, "slot_2"), "w") as f:
             f.write("not a directory")
@@ -114,7 +114,7 @@ def test_list_save_files_multiple_slots_sorted():
 def test_list_save_files_oserror_handling():
     """Test that list_save_files returns empty list on OSError"""
     manager = SaveFileManager("/non/existent/path")
-    
+
     # This should not raise an exception
     save_files = manager.list_save_files()
     assert save_files == []
@@ -169,14 +169,14 @@ def test_get_next_available_slot_all_full():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create 99 save slots
         for i in range(1, 100):
             slot_path = os.path.join(temp_dir, f"slot_{i}")
             os.makedirs(slot_path)
             with open(os.path.join(slot_path, "player.json"), "w") as f:
                 json.dump({"money": 0}, f)
-        
+
         next_slot = manager.get_next_available_slot()
         assert next_slot is None
     finally:
@@ -192,15 +192,15 @@ def test_select_save_slot():
 def test_select_save_slot_boundary_values():
     """Test selecting boundary slot values"""
     manager = SaveFileManager()
-    
+
     # Test slot 1 (minimum valid)
     manager.select_save_slot(1)
     assert manager.selected_save_slot == 1
-    
+
     # Test slot 99 (maximum valid)
     manager.select_save_slot(99)
     assert manager.selected_save_slot == 99
-    
+
     # Test slot 0 (edge case - technically allowed by select but not recommended)
     manager.select_save_slot(0)
     assert manager.selected_save_slot == 0
@@ -211,11 +211,11 @@ def test_get_save_path():
     try:
         manager = SaveFileManager(temp_dir)
         manager.select_save_slot(1)
-        
+
         path = manager.get_save_path("player.json")
         expected = os.path.join(temp_dir, "slot_1", "player.json")
         assert path == expected
-        
+
         # Check that directory was created
         assert os.path.exists(os.path.join(temp_dir, "slot_1"))
     finally:
@@ -228,12 +228,12 @@ def test_get_save_path_creates_directory():
     try:
         manager = SaveFileManager(temp_dir)
         manager.select_save_slot(5)
-        
+
         slot_path = os.path.join(temp_dir, "slot_5")
         assert not os.path.exists(slot_path)
-        
+
         # Calling get_save_path should create the directory
-        path = manager.get_save_path("player.json")
+        manager.get_save_path("player.json")
         assert os.path.exists(slot_path)
         assert os.path.isdir(slot_path)
     finally:
@@ -246,15 +246,15 @@ def test_get_save_path_multiple_files():
     try:
         manager = SaveFileManager(temp_dir)
         manager.select_save_slot(1)
-        
+
         player_path = manager.get_save_path("player.json")
         stats_path = manager.get_save_path("stats.json")
         time_path = manager.get_save_path("timeService.json")
-        
+
         # All should be in the same slot directory
         assert os.path.dirname(player_path) == os.path.dirname(stats_path)
         assert os.path.dirname(stats_path) == os.path.dirname(time_path)
-        
+
         # But different files
         assert player_path != stats_path
         assert stats_path != time_path
@@ -285,6 +285,53 @@ def test_delete_save_slot():
         result = manager.delete_save_slot(1)
         assert result is True
         assert not os.path.exists(slot_path)
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_delete_save_slot_flushes_browser_storage():
+    # Browser storage mirrors the whole save directory, so a delete that isn't
+    # flushed comes back on the next page load.
+    temp_dir = tempfile.mkdtemp()
+    try:
+        manager = SaveFileManager(temp_dir)
+        slot_path = os.path.join(temp_dir, "slot_1")
+        os.makedirs(slot_path)
+        with open(os.path.join(slot_path, "player.json"), "w") as f:
+            json.dump({"money": 100}, f)
+
+        with patch("src.saveFileManager.syncBrowserSaves") as sync:
+            assert manager.delete_save_slot(1) is True
+
+        sync.assert_called_once()
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_delete_of_a_missing_slot_does_not_flush_browser_storage():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        manager = SaveFileManager(temp_dir)
+
+        with patch("src.saveFileManager.syncBrowserSaves") as sync:
+            assert manager.delete_save_slot(7) is False
+
+        sync.assert_not_called()
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+def test_migration_flushes_browser_storage():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        manager = SaveFileManager(temp_dir)
+        with open(os.path.join(temp_dir, "player.json"), "w") as f:
+            json.dump({"money": 100}, f)
+
+        with patch("src.saveFileManager.syncBrowserSaves") as sync:
+            assert manager.migrate_old_save_files() is True
+
+        sync.assert_called_once()
     finally:
         shutil.rmtree(temp_dir)
 
@@ -360,11 +407,11 @@ def test_read_save_metadata_missing_files():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create empty slot directory
         slot_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_path)
-        
+
         metadata = manager._read_save_metadata(slot_path)
         assert metadata is None
     finally:
@@ -375,13 +422,13 @@ def test_read_save_metadata_corrupted_json():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create slot with corrupted json
         slot_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_path)
         with open(os.path.join(slot_path, "player.json"), "w") as f:
             f.write("invalid json{")
-        
+
         metadata = manager._read_save_metadata(slot_path)
         assert metadata is None
     finally:
@@ -393,14 +440,14 @@ def test_read_save_metadata_empty_player_file():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         slot_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_path)
-        
+
         # Create empty player.json
         with open(os.path.join(slot_path, "player.json"), "w") as f:
             f.write("")
-        
+
         metadata = manager._read_save_metadata(slot_path)
         # Empty file still returns metadata with last_modified but no game data
         assert metadata is not None
@@ -417,14 +464,14 @@ def test_read_save_metadata_partial_data():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         slot_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_path)
-        
+
         # Create player.json with minimal data
         with open(os.path.join(slot_path, "player.json"), "w") as f:
             json.dump({"money": 50}, f)  # Missing fishCount and energy
-        
+
         metadata = manager._read_save_metadata(slot_path)
         assert metadata is not None
         assert metadata["money"] == 50
@@ -440,14 +487,14 @@ def test_read_save_metadata_missing_timeservice():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         slot_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_path)
-        
+
         # Create only player.json
         with open(os.path.join(slot_path, "player.json"), "w") as f:
             json.dump({"money": 100, "fishCount": 10}, f)
-        
+
         metadata = manager._read_save_metadata(slot_path)
         assert metadata is not None
         assert metadata["money"] == 100
@@ -463,7 +510,7 @@ def test_migrate_old_save_files():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create old format save files
         os.makedirs(temp_dir, exist_ok=True)
         with open(os.path.join(temp_dir, "player.json"), "w") as f:
@@ -472,16 +519,16 @@ def test_migrate_old_save_files():
             json.dump({"totalFishCaught": 10}, f)
         with open(os.path.join(temp_dir, "timeService.json"), "w") as f:
             json.dump({"day": 2}, f)
-        
+
         # Migrate
         result = manager.migrate_old_save_files()
         assert result is True
-        
+
         # Check that files were moved to slot_1
         assert os.path.exists(os.path.join(temp_dir, "slot_1", "player.json"))
         assert os.path.exists(os.path.join(temp_dir, "slot_1", "stats.json"))
         assert os.path.exists(os.path.join(temp_dir, "slot_1", "timeService.json"))
-        
+
         # Check that old files are gone
         assert not os.path.exists(os.path.join(temp_dir, "player.json"))
         assert not os.path.exists(os.path.join(temp_dir, "stats.json"))
@@ -505,18 +552,18 @@ def test_migrate_old_save_files_partial():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create only player.json (missing stats and timeService)
         with open(os.path.join(temp_dir, "player.json"), "w") as f:
             json.dump({"money": 100}, f)
-        
+
         result = manager.migrate_old_save_files()
         assert result is True
-        
+
         # Check that player.json was moved
         assert os.path.exists(os.path.join(temp_dir, "slot_1", "player.json"))
         assert not os.path.exists(os.path.join(temp_dir, "player.json"))
-        
+
         # Other files shouldn't exist in either location
         assert not os.path.exists(os.path.join(temp_dir, "stats.json"))
         assert not os.path.exists(os.path.join(temp_dir, "slot_1", "stats.json"))
@@ -529,21 +576,21 @@ def test_migrate_old_save_files_slot1_exists():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create existing slot_1 with data
         slot_1_path = os.path.join(temp_dir, "slot_1")
         os.makedirs(slot_1_path)
         with open(os.path.join(slot_1_path, "player.json"), "w") as f:
             json.dump({"money": 999}, f)  # Existing data
-        
+
         # Create old format files
         with open(os.path.join(temp_dir, "player.json"), "w") as f:
             json.dump({"money": 100}, f)
-        
+
         # Migration should still succeed (will overwrite)
         result = manager.migrate_old_save_files()
         assert result is True
-        
+
         # Check that old file was moved and overwrote existing
         with open(os.path.join(slot_1_path, "player.json"), "r") as f:
             data = json.load(f)
@@ -557,31 +604,31 @@ def test_integration_create_save_and_delete():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Create slot 1
         manager.select_save_slot(1)
         path1 = manager.get_save_path("player.json")
         with open(path1, "w") as f:
             json.dump({"money": 100}, f)
-        
+
         # Create slot 2
         manager.select_save_slot(2)
         path2 = manager.get_save_path("player.json")
         with open(path2, "w") as f:
             json.dump({"money": 200}, f)
-        
+
         # List should show both
         saves = manager.list_save_files()
         assert len(saves) == 2
-        
+
         # Delete slot 1
         manager.delete_save_slot(1)
-        
+
         # List should show only slot 2
         saves = manager.list_save_files()
         assert len(saves) == 1
         assert saves[0]["slot"] == 2
-        
+
         # Next available should be 1 (the gap)
         next_slot = manager.get_next_available_slot()
         assert next_slot == 1
@@ -594,11 +641,11 @@ def test_integration_full_workflow():
     temp_dir = tempfile.mkdtemp()
     try:
         manager = SaveFileManager(temp_dir)
-        
+
         # Start with no saves
         assert manager.list_save_files() == []
         assert manager.get_next_available_slot() == 1
-        
+
         # Create first save
         manager.select_save_slot(1)
         player_path = manager.get_save_path("player.json")
@@ -607,23 +654,23 @@ def test_integration_full_workflow():
         time_path = manager.get_save_path("timeService.json")
         with open(time_path, "w") as f:
             json.dump({"day": 5, "time": 12}, f)
-        
+
         # List saves and verify metadata
         saves = manager.list_save_files()
         assert len(saves) == 1
         assert saves[0]["metadata"]["money"] == 100
         assert saves[0]["metadata"]["day"] == 5
-        
+
         # Create second save
         manager.select_save_slot(2)
         player_path2 = manager.get_save_path("player.json")
         with open(player_path2, "w") as f:
             json.dump({"money": 500, "fishCount": 50, "energy": 100}, f)
-        
+
         # Verify two saves exist
         saves = manager.list_save_files()
         assert len(saves) == 2
-        
+
         # Next slot should be 3
         assert manager.get_next_available_slot() == 3
     finally:

--- a/tests/ui/test_pyodideUserInterface.py
+++ b/tests/ui/test_pyodideUserInterface.py
@@ -239,6 +239,44 @@ def test_ring_wraps_around_without_losing_a_message(fakeJs):
     assert ui.promptForText("Name?") == "Harbourmaster"
 
 
+# --- independence from the server-backed front-end's files ---------------
+
+
+def test_the_front_end_works_with_no_web_directory_on_disk(fakeJs, monkeypatch):
+    """Regression: the Worker's filesystem has src/ but not web/client.*.
+
+    web/client.js and web/client.css reach the browser over HTTP, so they are
+    not on the filesystem the Python game sees. WebUserInterface reads them to
+    build its own page, and PyodideUserInterface subclasses it — so reading
+    them at import time made the game fail to start in a real browser with
+    FileNotFoundError on /game/web/client.css. Nothing on this front-end's path
+    may touch them.
+    """
+    from ui import webUserInterface
+
+    monkeypatch.setattr(webUserInterface, "WEB_ASSET_DIRECTORY", "/no/such/directory")
+    monkeypatch.setattr(webUserInterface, "_clientAssetCache", {})
+    monkeypatch.setattr(webUserInterface, "_pageCache", {})
+
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("1")
+
+    assert ui.showOptions("The Docks", ["Fish", "Leave"]) == "1"
+    assert lastScreen(fakeJs)["options"] == ["Fish", "Leave"]
+
+
+def test_the_server_backed_page_is_not_built_unless_it_is_asked_for(fakeJs):
+    # The page is what needs those files; building it eagerly is what put the
+    # read on every importer's path.
+    from ui import webUserInterface
+
+    webUserInterface._pageCache.clear()
+
+    makePyodideUI(fakeJs)
+
+    assert webUserInterface._pageCache == {}
+
+
 # --- construction errors -------------------------------------------------
 
 

--- a/tests/ui/test_pyodideUserInterface.py
+++ b/tests/ui/test_pyodideUserInterface.py
@@ -1,0 +1,354 @@
+import json
+import os
+import sys
+import tempfile
+
+# Use the bare `ui.*`/`player.*` import style (matching production) so class
+# identities line up with the runtime MRO; pytest.ini exposes both `.` and `src`.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+import pytest
+
+from ui.baseUserInterface import BaseUserInterface
+from ui.enum.uiType import UIType
+from ui.pyodideUserInterface import (
+    PyodideUserInterface,
+    SharedArrayBufferBridge,
+)
+from ui.userInterfaceFactory import UserInterfaceFactory
+from ui.webUserInterface import WebUserInterface
+from player.player import Player
+from prompt.prompt import Prompt
+from stats.stats import Stats
+from world.timeService import TimeService
+
+RING_SIZE = 8192
+
+
+class FakeAtomics:
+    """The two Atomics operations the bridge uses, over a plain Python list."""
+
+    @staticmethod
+    def load(array, index):
+        return array[index]
+
+    @staticmethod
+    def store(array, index, value):
+        array[index] = value
+
+
+class FakeJs:
+    """Stand-in for Pyodide's `js` module and the globals game-worker.js sets.
+
+    The ring buffer is modelled exactly as the real one: sabMeta[0] is the write
+    index (advanced only by the browser), sabMeta[1] the read index (advanced
+    only by Python), both monotonic and taken modulo the ring size.
+    """
+
+    def __init__(self, ringSize=RING_SIZE):
+        self.Atomics = FakeAtomics
+        self.sabMeta = [0, 0]
+        self.sabData = bytearray(ringSize)
+        self.sabRingSize = ringSize
+        self.posted = []
+        self.syncCallCount = 0
+
+    def sendToMain(self, message):
+        self.posted.append(message)
+
+    def syncSaves(self):
+        self.syncCallCount += 1
+
+    # --- the browser side of the ring -------------------------------------
+    def writePlayerInput(self, value):
+        """Mirror of writeToRing() in web/index.html."""
+        self._writeToRing(json.dumps({"type": "input", "value": value}))
+
+    def _writeToRing(self, text):
+        payload = (text + "\n").encode("utf-8")
+        writeIndex = self.sabMeta[0]
+        for offset, byte in enumerate(payload):
+            self.sabData[(writeIndex + offset) % self.sabRingSize] = byte
+        self.sabMeta[0] = writeIndex + len(payload)
+
+
+def installFakeJs(js):
+    """Register a fake `js` module the way Pyodide would, and undo it after."""
+    previous = sys.modules.get("js")
+    sys.modules["js"] = js
+    return previous
+
+
+def restoreJs(previous):
+    if previous is None:
+        sys.modules.pop("js", None)
+    else:
+        sys.modules["js"] = previous
+
+
+@pytest.fixture
+def fakeJs():
+    js = FakeJs()
+    previous = installFakeJs(js)
+    try:
+        yield js
+    finally:
+        restoreJs(previous)
+
+
+def makePyodideUI(js):
+    prompt = Prompt("What would you like to do?")
+    player = Player()
+    stats = Stats()
+    timeService = TimeService(player, stats)
+    return PyodideUserInterface(
+        prompt,
+        timeService,
+        player,
+        bridge=SharedArrayBufferBridge(js=js),
+        # Nothing in these tests ever has to wait for input that isn't already
+        # in the ring, so the poll interval only affects the failure case.
+        pollIntervalSeconds=0,
+    )
+
+
+def lastScreen(js):
+    return json.loads(js.posted[-1])["screen"]
+
+
+# --- contract ------------------------------------------------------------
+
+
+def test_pyodide_ui_implements_interface(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    assert isinstance(ui, BaseUserInterface)
+    # It shares WebUserInterface's screens rather than redefining them, which
+    # is what keeps the two web front-ends from drifting apart.
+    assert isinstance(ui, WebUserInterface)
+
+
+def test_no_http_server_is_started(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    assert ui.address is None
+
+
+# --- screens out ---------------------------------------------------------
+
+
+def test_screens_are_posted_to_the_main_thread(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("1")
+
+    ui.showOptions("The Docks", ["Fish", "Leave"])
+
+    frame = json.loads(fakeJs.posted[-1])
+    assert frame["type"] == "screen"
+    assert frame["screen"]["type"] == "options"
+    assert frame["screen"]["options"] == ["Fish", "Leave"]
+
+
+def test_posted_screens_carry_the_shared_header(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("1")
+
+    ui.showOptions("The Docks", ["Fish"])
+
+    header = lastScreen(fakeJs)["header"]
+    assert header["day"] == ui.timeService.day
+    assert header["maxEnergy"] >= header["energy"]
+
+
+def test_present_still_updates_the_state_snapshot(fakeJs):
+    # get_state() is inherited bookkeeping rather than a transport; keeping it
+    # working means the screen contract is testable the same way for both
+    # web front-ends.
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("")
+
+    ui.showDialogue("You caught a fish!")
+
+    assert ui.get_state()["screen"]["text"] == "You caught a fish!"
+
+
+# --- input in ------------------------------------------------------------
+
+
+def test_showOptions_round_trips_a_choice_through_the_ring(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("2")
+
+    assert ui.showOptions("The Docks", ["Fish", "Leave"]) == "2"
+
+
+def test_showOptions_ignores_invalid_input_then_accepts_valid(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("9")  # not one of the two options
+    fakeJs.writePlayerInput("1")
+
+    assert ui.showOptions("The Docks", ["Fish", "Leave"]) == "1"
+
+
+def test_promptForText_round_trips_text_with_newlines(fakeJs):
+    # The response is JSON-encoded precisely so text like this can't be read as
+    # two ring messages and truncate the player's answer.
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("Salty\nDog")
+
+    assert ui.promptForText("Name your business:") == "Salty\nDog"
+
+
+def test_promptForNumber_parses_and_marks_the_screen_numeric(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("12.5")
+
+    assert ui.promptForNumber("How many?") == 12.5
+    assert lastScreen(fakeJs)["numeric"] is True
+
+
+def test_non_ascii_input_survives_the_ring(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs.writePlayerInput("Café du Quai")
+
+    assert ui.promptForText("Name your business:") == "Café du Quai"
+
+
+def test_messages_that_are_not_input_are_ignored(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    fakeJs._writeToRing(json.dumps({"type": "resize", "w": 10}))
+    fakeJs._writeToRing("not json at all")
+    fakeJs.writePlayerInput("1")
+
+    assert ui.showOptions("The Docks", ["Fish"]) == "1"
+
+
+def test_submit_input_still_works_alongside_the_ring(fakeJs):
+    ui = makePyodideUI(fakeJs)
+    ui.submit_input("1")
+
+    assert ui.showOptions("The Docks", ["Fish"]) == "1"
+
+
+def test_ring_wraps_around_without_losing_a_message(fakeJs):
+    # Push the indices near the end of the buffer so the next message straddles
+    # the wrap point, which is where an off-by-one would show up.
+    ui = makePyodideUI(fakeJs)
+    fakeJs.sabMeta[0] = RING_SIZE - 4
+    fakeJs.sabMeta[1] = RING_SIZE - 4
+    fakeJs.writePlayerInput("Harbourmaster")
+
+    assert ui.promptForText("Name?") == "Harbourmaster"
+
+
+# --- construction errors -------------------------------------------------
+
+
+def test_bridge_outside_a_browser_explains_itself():
+    previous = sys.modules.pop("js", None)
+    try:
+        with pytest.raises(RuntimeError) as error:
+            SharedArrayBufferBridge()
+    finally:
+        restoreJs(previous)
+    message = str(error.value)
+    assert "browser" in message
+    assert "UIType.CONSOLE" in message  # tells the player what to use instead
+
+
+def test_bridge_without_worker_globals_names_what_is_missing(fakeJs):
+    fakeJs.sendToMain = None
+    with pytest.raises(RuntimeError) as error:
+        SharedArrayBufferBridge(js=fakeJs)
+    assert "sendToMain" in str(error.value)
+
+
+# --- factory -------------------------------------------------------------
+
+
+def test_factory_creates_the_pyodide_front_end(fakeJs):
+    prompt = Prompt("What would you like to do?")
+    player = Player()
+    stats = Stats()
+    timeService = TimeService(player, stats)
+
+    ui = UserInterfaceFactory.create_user_interface(
+        UIType.PYODIDE, prompt, timeService, player
+    )
+
+    assert isinstance(ui, PyodideUserInterface)
+
+
+# --- end to end ----------------------------------------------------------
+
+
+def test_a_game_played_in_the_browser_saves_into_browser_storage(fakeJs):
+    """The whole point of this front-end, exercised against a real game.
+
+    A save directory that only exists in the Worker's memory, a game booted
+    through the Pyodide front-end, and a save that reaches the browser rather
+    than stopping at the filesystem.
+    """
+    from fishE import FishE
+
+    # Mirror of makeSyncSaves() in web/game-worker.js: walk the save directory
+    # and hand the file map to the browser to store.
+    browserStorage = {}
+
+    with tempfile.TemporaryDirectory() as saveDirectory:
+
+        def syncSaves():
+            browserStorage.clear()
+            for root, _dirs, files in os.walk(saveDirectory):
+                for name in files:
+                    path = os.path.join(root, name)
+                    with open(path) as saveFile:
+                        browserStorage[path] = saveFile.read()
+
+        fakeJs.syncSaves = syncSaves
+
+        previousSaveDirectory = os.environ.get("FISHE_SAVE_DIR")
+        os.environ["FISHE_SAVE_DIR"] = saveDirectory
+        try:
+            # "Create New Save (Slot 1)" is the only option on a fresh install.
+            fakeJs.writePlayerInput("1")
+            game = FishE(interfaceType=UIType.PYODIDE)
+
+            menu = json.loads(fakeJs.posted[0])["screen"]
+            assert menu["descriptor"] == "FishE - Save File Manager"
+
+            game.player.money = 4321
+            game.save()
+        finally:
+            if previousSaveDirectory is None:
+                os.environ.pop("FISHE_SAVE_DIR", None)
+            else:
+                os.environ["FISHE_SAVE_DIR"] = previousSaveDirectory
+
+        playerSaves = [p for p in browserStorage if p.endswith("player.json")]
+        assert len(playerSaves) == 1
+        assert "slot_1" in playerSaves[0]
+        assert json.loads(browserStorage[playerSaves[0]])["money"] == 4321
+
+
+def test_quitting_ends_the_page_instead_of_raising(fakeJs):
+    # "Quit" calls exit(), which in a tab has no process to end: the Worker
+    # would report it as an error rather than the game finishing. The entry
+    # point is exec'd here the same way web/game-worker.js runs it.
+    entryPoint = os.path.join(
+        os.path.dirname(__file__), "..", "..", "web", "pyodide_main.py"
+    )
+
+    with tempfile.TemporaryDirectory() as saveDirectory:
+        previousSaveDirectory = os.environ.get("FISHE_SAVE_DIR")
+        os.environ["FISHE_SAVE_DIR"] = saveDirectory
+        try:
+            # A fresh save directory offers "Create New Save (Slot 1)" then "Quit".
+            fakeJs.writePlayerInput("2")
+            with open(entryPoint) as entryPointFile:
+                exec(compile(entryPointFile.read(), entryPoint, "exec"), {})
+        finally:
+            if previousSaveDirectory is None:
+                os.environ.pop("FISHE_SAVE_DIR", None)
+            else:
+                os.environ["FISHE_SAVE_DIR"] = previousSaveDirectory
+
+    assert lastScreen(fakeJs) == {"type": "ended"}

--- a/tests/web/test_buildZip.py
+++ b/tests/web/test_buildZip.py
@@ -42,6 +42,17 @@ def test_bundle_carries_the_worker_entry_point(tmp_path, monkeypatch):
     assert os.path.join("web", "pyodide_main.py") in names
 
 
+def test_bundle_carries_the_shared_browser_client(tmp_path, monkeypatch):
+    # The page fetches these over HTTP, so the browser does not need them from
+    # the bundle - but webUserInterface reads them from the filesystem, and the
+    # Pyodide front-end subclasses it. Shipping them means that read can never
+    # be the thing that fails inside the Worker.
+    names = buildBundle(tmp_path, monkeypatch)
+
+    assert os.path.join("web", "client.js") in names
+    assert os.path.join("web", "client.css") in names
+
+
 def test_bundle_excludes_build_artifacts(tmp_path, monkeypatch):
     names = buildBundle(tmp_path, monkeypatch)
 

--- a/tests/web/test_buildZip.py
+++ b/tests/web/test_buildZip.py
@@ -1,0 +1,49 @@
+import os
+import zipfile
+
+from web.build_zip import build
+
+REPOSITORY_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def buildBundle(tmp_path, monkeypatch):
+    # The bundle stores repo-relative paths, so it has to be built from the
+    # repository root - that is what makes the unpacked tree in the browser
+    # match a checkout.
+    monkeypatch.chdir(REPOSITORY_ROOT)
+    outputPath = tmp_path / "game.zip"
+    build(outputPath=str(outputPath))
+    with zipfile.ZipFile(outputPath) as bundle:
+        return bundle.namelist()
+
+
+def test_bundle_carries_the_game(tmp_path, monkeypatch):
+    names = buildBundle(tmp_path, monkeypatch)
+
+    assert os.path.join("src", "fishE.py") in names
+    assert os.path.join("src", "ui", "pyodideUserInterface.py") in names
+    assert os.path.join("src", "browserSaveSync.py") in names
+
+
+def test_bundle_carries_the_schemas_the_save_readers_validate_against(
+    tmp_path, monkeypatch
+):
+    # The *JsonReaderWriter modules resolve these paths relative to the cwd the
+    # Worker chdir's into, so a bundle without them fails every save load.
+    names = buildBundle(tmp_path, monkeypatch)
+
+    for schema in ("player.json", "stats.json", "timeService.json"):
+        assert os.path.join("schemas", schema) in names
+
+
+def test_bundle_carries_the_worker_entry_point(tmp_path, monkeypatch):
+    names = buildBundle(tmp_path, monkeypatch)
+
+    assert os.path.join("web", "pyodide_main.py") in names
+
+
+def test_bundle_excludes_build_artifacts(tmp_path, monkeypatch):
+    names = buildBundle(tmp_path, monkeypatch)
+
+    assert not [name for name in names if "__pycache__" in name]
+    assert not [name for name in names if name.endswith(".pyc")]

--- a/tests/web/test_clientParity.py
+++ b/tests/web/test_clientParity.py
@@ -1,0 +1,57 @@
+"""Both web front-ends must render from the same browser client.
+
+FishE has three front-ends behind one contract, and the two browser ones are
+the easiest pair to let drift: a screen type handled in the server-backed page
+but not in the Pyodide one looks fine in local testing and blank in production.
+Neither front-end owning its own copy of the renderer is what prevents that, so
+these tests assert the sharing itself rather than any particular screen.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from ui import webUserInterface  # noqa: E402
+
+REPOSITORY_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+WEB_DIRECTORY = os.path.join(REPOSITORY_ROOT, "web")
+
+
+def readWebFile(name):
+    with open(os.path.join(WEB_DIRECTORY, name), encoding="utf-8") as webFile:
+        return webFile.read()
+
+
+def test_server_backed_page_inlines_the_shared_client():
+    page = webUserInterface.HTML_PAGE
+
+    assert readWebFile("client.js") in page
+    assert readWebFile("client.css") in page
+
+
+def test_pyodide_page_links_the_shared_client():
+    page = readWebFile("index.html")
+
+    assert "/web/client.js" in page
+    assert "/web/client.css" in page
+
+
+def test_both_front_ends_hand_the_client_a_transport():
+    # FisheClient.init(sendFn) is the seam: the renderer is shared, how a
+    # response gets back to the game is not.
+    assert "FisheClient.init(" in webUserInterface.HTML_PAGE
+    assert "FisheClient.init(" in readWebFile("index.html")
+
+
+def test_a_missing_client_file_explains_where_it_should_be():
+    try:
+        webUserInterface._readWebAsset("no-such-client.js")
+        raised = None
+    except RuntimeError as e:
+        raised = e
+
+    assert raised is not None
+    message = str(raised)
+    assert "web/" in message
+    assert "no-such-client.js" in message

--- a/tests/web/test_serve.py
+++ b/tests/web/test_serve.py
@@ -1,0 +1,84 @@
+import threading
+import urllib.error
+import urllib.request
+
+from web.serve import _Handler, _Server
+
+
+def startServer():
+    server = _Server(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    host, port = server.server_address[0], server.server_address[1]
+    return server, f"http://{host}:{port}"
+
+
+def get(url):
+    return urllib.request.urlopen(url, timeout=5)
+
+
+def test_serves_the_game_page():
+    server, base = startServer()
+    try:
+        response = get(base + "/")
+        body = response.read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.status == 200
+    assert "game-worker.js" in body
+
+
+def test_cross_origin_isolation_headers_are_present():
+    # Without these the page is not cross-origin isolated, SharedArrayBuffer is
+    # undefined, and the player's input can never reach the blocked game Worker.
+    server, base = startServer()
+    try:
+        response = get(base + "/")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin"
+    assert response.headers["Cross-Origin-Embedder-Policy"] == "require-corp"
+
+
+def test_serves_the_shared_browser_client():
+    server, base = startServer()
+    try:
+        body = get(base + "/web/client.js").read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "FisheClient" in body
+
+
+def test_play_path_serves_the_game_page():
+    server, base = startServer()
+    try:
+        body = get(base + "/play").read().decode("utf-8")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert "game-worker.js" in body
+
+
+def test_does_not_serve_the_rest_of_the_repository():
+    # SimpleHTTPRequestHandler is rooted at the repository, so anything outside
+    # web/ has to be refused explicitly.
+    server, base = startServer()
+    try:
+        try:
+            get(base + "/src/fishE.py")
+            served = True
+        except urllib.error.HTTPError as e:
+            served = False
+            status = e.code
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert not served
+    assert status == 404

--- a/web/build_zip.py
+++ b/web/build_zip.py
@@ -17,7 +17,17 @@ OUTPUT_PATH = "web/game.zip"
 # tree that matches a checkout — which is what makes the cwd-relative schema
 # paths in the *JsonReaderWriter modules resolve there.
 SOURCE_DIRECTORIES = ("src", "schemas")
-EXTRA_FILES = ("version.txt", "web/pyodide_main.py")
+# client.js/client.css are fetched over HTTP by the page, so the browser does
+# not need them from the bundle — they are included anyway because
+# webUserInterface reads them from the filesystem, and PyodideUserInterface
+# subclasses it. Belt and braces: the read is lazy so it never happens in the
+# browser, and if a future change makes it happen, the files are there.
+EXTRA_FILES = (
+    "version.txt",
+    "web/pyodide_main.py",
+    "web/client.js",
+    "web/client.css",
+)
 
 
 def build(outputPath=OUTPUT_PATH):

--- a/web/build_zip.py
+++ b/web/build_zip.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# @author Daniel McCoy Stephenson
+"""Build web/game.zip — the bundle the browser's Pyodide Worker downloads.
+
+Everything the game needs to run in a tab goes in: the Python source tree, the
+JSON Schemas the save readers validate against, and the Worker's entry point.
+Run from the repository root (the Dockerfile does this at build time):
+
+    python3 web/build_zip.py
+"""
+import os
+import zipfile
+
+OUTPUT_PATH = "web/game.zip"
+
+# Paths are stored repo-relative so the Worker can unpack into /game and get a
+# tree that matches a checkout — which is what makes the cwd-relative schema
+# paths in the *JsonReaderWriter modules resolve there.
+SOURCE_DIRECTORIES = ("src", "schemas")
+EXTRA_FILES = ("version.txt", "web/pyodide_main.py")
+
+
+def build(outputPath=OUTPUT_PATH):
+    with zipfile.ZipFile(outputPath, "w", zipfile.ZIP_DEFLATED) as bundle:
+        for directory in SOURCE_DIRECTORIES:
+            for root, dirs, files in os.walk(directory):
+                dirs[:] = [d for d in dirs if d != "__pycache__"]
+                for name in files:
+                    if name.endswith(".pyc"):
+                        continue
+                    path = os.path.join(root, name)
+                    bundle.write(path, path)
+        for path in EXTRA_FILES:
+            if os.path.exists(path):
+                bundle.write(path, path)
+    print(f"Built {outputPath}")
+
+
+if __name__ == "__main__":
+    build()

--- a/web/client.css
+++ b/web/client.css
@@ -1,0 +1,54 @@
+  /* text-size-adjust keeps Safari from inflating text of its own accord once
+     the viewport is device-width (most visible in landscape). */
+  html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+  body { font-family: monospace; background: #0b1d2a; color: #e0f0ff;
+         max-width: 680px; margin: 2rem auto; padding: 0 1rem;
+         /* The game can emit long unbroken strings; break them rather than
+            letting them scroll the page sideways. Inherited by the screens. */
+         overflow-wrap: break-word; }
+  .header { color: #7fb0d0; border-bottom: 1px solid #2a4a5a;
+            padding-bottom: .5rem; margin-bottom: 1rem;
+            display: flex; flex-wrap: wrap; gap: .15rem 1.1rem; }
+  .descriptor { margin: 1rem 0; font-size: 1.1rem; }
+  .prompt { color: #9fd0ff; margin: 1rem 0; }
+  .dialogue { white-space: pre-wrap; overflow-wrap: break-word;
+              margin: 1rem 0; line-height: 1.5; }
+  button { display: block; width: 100%; text-align: left; margin: .3rem 0;
+           padding: .6rem; background: #163345; color: #e0f0ff;
+           border: 1px solid #2a4a5a; border-radius: 4px; cursor: pointer;
+           font-family: monospace; font-size: 1rem;
+           overflow-wrap: break-word;
+           touch-action: manipulation; }  /* no double-tap-to-zoom delay */
+  button:hover { background: #1f4a63; }
+  button.danger { background: #4a1620; border-color: #7a2a35; }
+  button.danger:hover { background: #63202c; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  button:disabled:hover { background: #163345; }
+  button.action { width: auto; text-align: center; padding: .6rem 1.4rem;
+                  background: #1d5a7a; border-color: #2f7ba0; }
+  button.action:hover { background: #246a90; }
+  input { width: 100%; padding: .6rem; font-family: monospace; font-size: 1rem;
+          background: #163345; color: #e0f0ff; border: 1px solid #2a4a5a;
+          border-radius: 4px; }
+  .tagline { font-size: .8rem; font-weight: normal; color: #7fb0d0; }
+  .controls { font-size: .8rem; color: #6a8aa0; border-top: 1px solid #2a4a5a;
+              margin-top: 1.5rem; padding-top: .5rem; }
+  .low { color: #ff8a8a; font-weight: bold; }
+  .operator { color: #ffcf8f; font-weight: bold; }
+  .notice { color: #9fd0ff; margin-top: 1rem; }
+  .notice.warning { color: #ffcf8f; border-left: 3px solid #c77b2a; padding-left: .6rem; }
+  /* Phone-sized screens only: the desktop layout above is left as-is. Note that
+     font sizes are deliberately not reduced here — 1rem inputs (16px) are what
+     keeps iOS Safari from zooming the page in when a field is focused. */
+  @media (max-width: 600px) {
+    /* 2rem of vertical margin is a lot of a short screen to spend on nothing. */
+    body { margin: 1rem auto; padding: 0 .75rem; }
+    /* A wrapped header was stacking its rows almost on top of each other. */
+    .header { gap: .35rem 1rem; }
+    /* .6rem padding puts a button at ~40px tall, under the ~44px that is
+       comfortable to tap; .75rem clears it. Wider gaps between them, too. */
+    button { padding: .75rem .6rem; margin: .45rem 0; }
+    /* Continue/Submit/React! are the only thing to press on their screens —
+       give them the full width instead of a small target off to one side. */
+    button.action { width: 100%; padding: .75rem .6rem; }
+  }

--- a/web/client.js
+++ b/web/client.js
@@ -1,0 +1,152 @@
+// The FishE browser client: renders the screen JSON that every web front-end
+// publishes, and hands the player's response back to whatever is driving it.
+//
+// Two front-ends share this file, so the game looks and behaves identically in
+// both and a screen type only ever has to be implemented once:
+//
+//   - WebUserInterface (src/ui/webUserInterface.py) — the game runs on a
+//     server; the page polls GET /state and POSTs to /input.
+//   - PyodideUserInterface (src/ui/pyodideUserInterface.py) — the game runs in
+//     this browser under Pyodide; screens arrive as Worker messages and input
+//     goes back over a SharedArrayBuffer ring.
+//
+// A host wires itself up with FisheClient.init(sendFn) and then calls
+// FisheClient.render(screen) for each screen the game publishes. The screen
+// JSON contract is BaseUserInterface's primitives — see WebUserInterface.
+
+window.FisheClient = (function () {
+  let currentScreen = null;
+  let sendToGame = () => {};
+
+  function app() {
+    return document.getElementById("app");
+  }
+
+  function el(tag, props, ...kids) {
+    const e = document.createElement(tag);
+    Object.assign(e, props || {});
+    for (const k of kids) e.append(k);
+    return e;
+  }
+
+  function renderNotice(text, className) {
+    const a = app();
+    a.innerHTML = "";
+    a.append(el("div", { className: className || "notice", textContent: text }));
+  }
+
+  function renderDisconnected() {
+    currentScreen = null;
+    renderNotice("Lost connection to the game — is it still running? Retrying…", "notice warning");
+  }
+
+  // Nothing is on screen between sending a response and the next screen
+  // arriving, so drop currentScreen to make stray keypresses inert.
+  function send(value) {
+    currentScreen = null;
+    app().innerHTML = "&hellip;";
+    sendToGame(value);
+  }
+
+  function render(screen) {
+    const a = app();
+    a.innerHTML = "";
+    currentScreen = screen;  // let keyboard shortcuts act on what's on screen
+    if (!screen || screen.type === "loading") { renderNotice("Waiting for the game…"); return; }
+    if (screen.type === "ended") { renderNotice("The game has ended. You can close this tab."); return; }
+    if (screen.header) {
+      const h = screen.header;
+      const header = el("div", { className: "header" });
+      // Each stat is its own chip; the flex-wrap row spaces them with whitespace
+      // and wraps cleanly on narrow screens instead of running off one long line.
+      const addPart = (content) => {
+        header.append(content instanceof Node ? content : el("span", { textContent: content }));
+      };
+      addPart(`Day ${h.day}`);
+      addPart(h.time);
+      addPart(`$${h.money.toFixed(2)}`);
+      addPart(`Fish: ${h.fish}`);
+      // Below the fishing threshold (10) the player is too tired to fish — flag it.
+      const energy = el("span", { textContent: `Energy: ${h.energy}/${h.maxEnergy}` });
+      if (h.energy < 10) energy.className = "low";
+      addPart(energy);
+      if (h.location) addPart(h.location);
+      if (h.goal) addPart(`Goal: ${h.goal}`);
+      if (h.operator) addPart(el("span", { textContent: "OPERATOR MODE", className: "operator" }));
+      a.append(header);
+      document.title = `FishE — Day ${h.day}, $${h.money.toFixed(2)}`;
+    }
+    if (screen.descriptor) a.append(el("div", { className: "descriptor", textContent: screen.descriptor }));
+    if (screen.prompt) a.append(el("div", { className: "prompt", textContent: screen.prompt }));
+    if (screen.type === "options") {
+      screen.options.forEach((opt, i) => {
+        const b = el("button", {
+          textContent: `[${i + 1}] ${opt}`,
+          className: /delete/i.test(opt) ? "danger" : "",
+        });
+        b.onclick = () => send(String(i + 1));
+        a.append(b);
+      });
+    } else if (screen.type === "dialogue") {
+      a.append(el("div", { className: "dialogue", textContent: screen.text }));
+      const b = el("button", { textContent: "Continue", className: "action" });
+      b.onclick = () => send("");
+      a.append(b);
+    } else if (screen.type === "prompt") {
+      a.append(el("div", { className: "descriptor", textContent: screen.text }));
+      const inp = el("input", { type: "text" });
+      const b = el("button", { textContent: "Submit", className: "action" });
+      const valid = () => !screen.numeric ||
+        (inp.value.trim() !== "" && !isNaN(Number(inp.value)));
+      const submit = () => { if (valid()) send(inp.value); };
+      if (screen.numeric) {
+        inp.inputMode = "decimal";
+        inp.placeholder = "Enter a number";
+        inp.oninput = () => { b.disabled = !valid(); };
+        b.disabled = true;  // nothing valid typed yet
+      }
+      inp.onkeydown = (e) => { if (e.key === "Enter") submit(); };
+      b.onclick = submit;
+      a.append(inp); a.append(b); inp.focus();
+    } else if (screen.type === "busy") {
+      // A pause the game takes on its own — shown, but with nothing to click;
+      // the next screen replaces it when the pause is over.
+      a.append(el("div", { className: "descriptor", textContent: screen.message }));
+    } else if (screen.type === "timed") {
+      a.append(el("div", { className: "descriptor", textContent: screen.message }));
+      const b = el("button", { textContent: "React!", className: "action" });
+      b.onclick = () => send("");
+      a.append(b);
+    }
+  }
+
+  // Keyboard control, matching the console/pygame front-ends: number keys pick
+  // an option; Enter or Space advances a dialogue or the timed prompt. Typing
+  // in the text field is left to the field itself.
+  function onKeyDown(e) {
+    const s = currentScreen;
+    if (!s) return;
+    if (e.target && e.target.tagName === "INPUT") return;
+    if (s.type === "options") {
+      if (e.key >= "1" && e.key <= "9") {
+        const n = parseInt(e.key, 10);
+        if (n <= s.options.length) { e.preventDefault(); send(String(n)); }
+      }
+    } else if (s.type === "dialogue" || s.type === "timed") {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); send(""); }
+    }
+  }
+
+  function init(sendFn) {
+    sendToGame = sendFn;
+    document.addEventListener("keydown", onKeyDown);
+  }
+
+  return {
+    init: init,
+    render: render,
+    renderNotice: renderNotice,
+    renderDisconnected: renderDisconnected,
+    getCurrentScreen: () => currentScreen,
+  };
+})();

--- a/web/game-worker.js
+++ b/web/game-worker.js
@@ -1,0 +1,195 @@
+// Web Worker: loads Pyodide, unpacks the game bundle, and runs FishE's Python
+// game loop in the player's own browser.
+//
+// Communication with the main thread:
+//   main → worker:  { type: 'init', sab: SharedArrayBuffer }
+//   worker → main:  { type: 'status', msg: string }
+//                   { type: 'ready' }
+//                   { type: 'error', msg: string }
+//                   { type: 'save', files: { path: content, ... } }
+//                   string — a JSON {"type":"screen","screen":{...}} frame
+//                            posted by PyodideUserInterface
+//
+// The player's responses arrive the other way, through the SharedArrayBuffer
+// ring buffer the main thread writes into (see web/index.html). They cannot
+// come over postMessage: FishE's game loop is synchronous, so it blocks the
+// Worker while waiting for input, and a blocked Worker never runs onmessage.
+//
+// ── Why IndexedDB writes live on the main thread ─────────────────────────────
+// Pyodide's build uses Atomics.wait() for time.sleep() when SharedArrayBuffer
+// is available, which blocks the Worker's JS event loop entirely — so IDB
+// callbacks (macrotasks) can never fire while Python is running. Instead the
+// Worker walks /saves synchronously and postMessages the file map to the main
+// thread, which writes to IDB from its own, unblocked, event loop. The initial
+// restore still happens here in the Worker because it runs before Python
+// starts, when nothing is blocking the event loop yet.
+
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js');
+
+const SAVE_DIRECTORY = '/saves';
+
+const IDB_NAME    = 'fishe-saves';
+const IDB_STORE   = 'files';
+const IDB_VERSION = 1;
+
+function idbOpen() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+        req.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains(IDB_STORE)) {
+                db.createObjectStore(IDB_STORE);
+            }
+        };
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror   = (e) => reject(e.target.error);
+    });
+}
+
+// ── Save restore: read IndexedDB into /saves before Python starts ────────────
+// Always resolves, never rejects: a browser that won't hand back stored data
+// should start the player on a fresh save file, not refuse to load the game.
+async function loadSavesFromIDB(pyodide) {
+    try {
+        const db = await Promise.race([
+            idbOpen(),
+            new Promise((_, rej) =>
+                setTimeout(() => rej(new Error('IndexedDB open timed out')), 5000)
+            ),
+        ]);
+
+        const entries = await new Promise((resolve, reject) => {
+            const result = [];
+            let tx, cursorReq;
+            try {
+                tx        = db.transaction(IDB_STORE, 'readonly');
+                cursorReq = tx.objectStore(IDB_STORE).openCursor();
+            } catch (e) { reject(e); return; }
+            cursorReq.onsuccess = (ev) => {
+                const c = ev.target.result;
+                if (c) { result.push({ path: c.key, content: c.value }); c.continue(); }
+                else   resolve(result);
+            };
+            cursorReq.onerror = () => reject(cursorReq.error);
+            tx.onerror        = () => reject(tx.error);
+            tx.onabort        = () => reject(new Error('IndexedDB transaction aborted'));
+        });
+
+        let restored = 0;
+        for (const { path, content } of entries) {
+            // Save slots are directories (/saves/slot_1/player.json), so the
+            // parents have to exist before the file can be written.
+            const parts = path.split('/').filter(Boolean);
+            let dir = '';
+            for (let i = 0; i < parts.length - 1; i++) {
+                dir += '/' + parts[i];
+                try { pyodide.FS.mkdir(dir); } catch {}  // already there: fine
+            }
+            try {
+                pyodide.FS.writeFile(path, content, { encoding: 'utf8' });
+                restored++;
+            } catch (e) {
+                console.warn('[fishe] could not restore save file', path, e);
+            }
+        }
+        if (restored > 0) console.log(`[fishe] ${restored} save file(s) restored`);
+        try { db.close(); } catch {}
+
+    } catch (err) {
+        console.warn('[fishe] save restore skipped (starting fresh):', err);
+    }
+}
+
+// ── Save flush: collect /saves and hand it to the main thread ────────────────
+// Installed as globalThis.syncSaves, which src/browserSaveSync.py calls after
+// every write or delete. Walking pyodide.FS is pure JavaScript and needs no
+// event loop, and postMessage is synchronous from the Worker's side — so this
+// works even though Python is mid-call and the Worker is otherwise blocked.
+
+function makeSyncSaves(pyodide) {
+    return () => {
+        const files = {};
+        function walk(path) {
+            let entries;
+            try { entries = pyodide.FS.readdir(path); } catch { return; }
+            for (const name of entries) {
+                if (name === '.' || name === '..') continue;
+                const full = `${path}/${name}`;
+                let stat;
+                try { stat = pyodide.FS.stat(full); } catch { continue; }
+                const isDirectory = (stat.mode & 0o170000) === 0o040000;
+                if (isDirectory) {
+                    walk(full);
+                } else {
+                    // FishE's saves are JSON, so UTF-8 is the whole story here.
+                    try {
+                        files[full] = pyodide.FS.readFile(full, { encoding: 'utf8' });
+                    } catch (e) {
+                        console.warn('[fishe] could not read save file', full, e);
+                    }
+                }
+            }
+        }
+        walk(SAVE_DIRECTORY);
+        self.postMessage({ type: 'save', files });
+    };
+}
+
+// ── Worker entry point ───────────────────────────────────────────────────────
+
+self.onmessage = async (e) => {
+    if (e.data.type !== 'init') return;
+
+    const { sab } = e.data;
+    // [0] = write index, [1] = read index, both monotonically increasing and
+    // taken modulo the ring size when indexing into the data region.
+    globalThis.sabMeta     = new Int32Array(sab, 0, 2);
+    globalThis.sabData     = new Uint8Array(sab, 8, e.data.ringSize);
+    globalThis.sabRingSize = e.data.ringSize;
+    globalThis.sendToMain  = (data) => self.postMessage(data);
+
+    try {
+        self.postMessage({ type: 'status', msg: 'Loading Python runtime…' });
+
+        const pyodide = await loadPyodide({
+            stdout: (msg) => console.log('[fishe]', msg),
+            stderr: (msg) => console.warn('[fishe]', msg),
+        });
+
+        self.postMessage({ type: 'status', msg: 'Restoring saved games…' });
+
+        pyodide.FS.mkdir(SAVE_DIRECTORY);
+        await loadSavesFromIDB(pyodide);      // before Python: IDB callbacks still fire
+        globalThis.syncSaves = makeSyncSaves(pyodide);
+
+        self.postMessage({ type: 'status', msg: 'Installing Python packages…' });
+
+        // jsonschema is a real runtime dependency: the save readers validate
+        // against schemas/*.json on every load (see requirements.txt).
+        await pyodide.loadPackage(['jsonschema']);
+
+        self.postMessage({ type: 'status', msg: 'Downloading the village…' });
+
+        const resp = await fetch('/web/game.zip');
+        if (!resp.ok) throw new Error(`game.zip fetch failed: ${resp.status}`);
+        const buf = await resp.arrayBuffer();
+        pyodide.FS.mkdir('/game');
+        pyodide.unpackArchive(new Uint8Array(buf), 'zip', { extractDir: '/game' });
+
+        self.postMessage({ type: 'status', msg: 'Casting off…' });
+        self.postMessage({ type: 'ready' });
+
+        // chdir to /game so the cwd-relative schema paths in the save readers
+        // resolve; FISHE_SAVE_DIR points Config at the IndexedDB-backed dir.
+        await pyodide.runPythonAsync(`
+import os, sys
+sys.path.insert(0, '/game/src')
+os.chdir('/game')
+os.environ['FISHE_SAVE_DIR'] = '${SAVE_DIRECTORY}'
+exec(open('/game/web/pyodide_main.py').read())
+`);
+
+    } catch (err) {
+        self.postMessage({ type: 'error', msg: String(err) });
+    }
+};

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>FishE</title>
+<!-- The renderer and styles are the same files the server-backed web front-end
+     inlines into its page (src/ui/webUserInterface.py), so both look and behave
+     identically. Only the transport below differs: here the game is running in
+     this tab, not on a server. -->
+<link rel="stylesheet" href="/web/client.css">
+<style>
+  /* Boot progress, shown until the first screen arrives. The game itself is
+     rendered entirely by client.js into #app. */
+  .status { color: #7fb0d0; margin: 1rem 0; }
+  .status.error { color: #ff8a8a; }
+</style>
+</head>
+<body>
+<h2>FishE <span class="tagline">— fish a seaside village and build a fortune of $10,000</span></h2>
+<div id="status" class="status">Starting&hellip;</div>
+<div id="app"></div>
+<p class="controls">Tip: click an option or press its number key (1-9). Enter or Space continues. Your saved games live in this browser.</p>
+<script src="/web/client.js"></script>
+<script>
+(function () {
+  const statusEl = document.getElementById("status");
+
+  function setStatus(msg, isError) {
+    statusEl.textContent = msg;
+    statusEl.style.display = msg ? "" : "none";
+    statusEl.classList.toggle("error", !!isError);
+  }
+
+  // ── Input transport: SharedArrayBuffer ring buffer ────────────────────────
+  //
+  // FishE's game loop is synchronous, so the Worker is blocked whenever the
+  // game is waiting for the player — and a blocked Worker can never run an
+  // onmessage handler. Shared memory needs no event loop, so it is how input
+  // reaches a blocked game. sabMeta holds [writeIndex, readIndex]; this side
+  // only ever advances writeIndex, Python only ever advances readIndex.
+  //
+  // SharedArrayBuffer requires the page to be cross-origin isolated, which is
+  // what web/serve.py's COOP/COEP headers are for.
+  const RING_SIZE = 8192;
+
+  if (typeof SharedArrayBuffer === "undefined") {
+    setStatus(
+      "This browser can't run FishE here: SharedArrayBuffer is unavailable, " +
+      "which usually means the page wasn't served with the " +
+      "Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers " +
+      "web/serve.py sets. Open the game over https (or http://localhost) from " +
+      "that server rather than from a file:// path or a plain static host.",
+      true
+    );
+    return;
+  }
+
+  const sab     = new SharedArrayBuffer(8 + RING_SIZE);
+  const sabMeta = new Int32Array(sab, 0, 2);
+  const sabData = new Uint8Array(sab, 8, RING_SIZE);
+
+  function writeToRing(text) {
+    const bytes = new TextEncoder().encode(text + "\n");
+    const writeIndex = Atomics.load(sabMeta, 0);
+    const readIndex  = Atomics.load(sabMeta, 1);
+    if (bytes.length > RING_SIZE - (writeIndex - readIndex)) {
+      // Only reachable if the game stopped draining input; overwriting would
+      // corrupt the message it is mid-way through reading.
+      console.warn("[fishe] input dropped: the ring buffer is full");
+      return;
+    }
+    for (let i = 0; i < bytes.length; i++) {
+      sabData[(writeIndex + i) % RING_SIZE] = bytes[i];
+    }
+    Atomics.store(sabMeta, 0, writeIndex + bytes.length);
+  }
+
+  // JSON-encoded so that whatever the player typed — a business name with a
+  // newline pasted into it, say — can't be read as two messages.
+  FisheClient.init(function (value) {
+    writeToRing(JSON.stringify({ type: "input", value: value }));
+  });
+
+  // ── Save persistence: IndexedDB writes happen here, not in the Worker ─────
+  // The Worker is blocked by Python whenever the game runs, so it can't drive
+  // IDB callbacks; it posts the save files over and this event loop stores
+  // them. See the comment at the top of game-worker.js.
+  const IDB_NAME    = "fishe-saves";
+  const IDB_STORE   = "files";
+  const IDB_VERSION = 1;
+
+  function idbOpen() {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+      req.onupgradeneeded = (ev) => {
+        const db = ev.target.result;
+        if (!db.objectStoreNames.contains(IDB_STORE)) {
+          db.createObjectStore(IDB_STORE);
+        }
+      };
+      req.onsuccess = (ev) => resolve(ev.target.result);
+      req.onerror   = (ev) => reject(ev.target.error);
+    });
+  }
+
+  // The file map is the whole save directory, so the store is cleared first —
+  // that is what makes deleting a save slot in-game actually stick.
+  function idbWrite(files) {
+    idbOpen().then((db) => {
+      let tx;
+      try { tx = db.transaction(IDB_STORE, "readwrite"); }
+      catch (e) { console.warn("[fishe] could not save to IndexedDB:", e); db.close(); return; }
+      try { tx.objectStore(IDB_STORE).clear(); } catch {}
+      for (const [path, content] of Object.entries(files)) {
+        try { tx.objectStore(IDB_STORE).put(content, path); } catch (e) {
+          console.warn("[fishe] could not save", path, e);
+        }
+      }
+      tx.oncomplete = () => db.close();
+      tx.onerror    = () => { console.warn("[fishe] save failed:", tx.error); db.close(); };
+    }).catch((err) => console.warn("[fishe] could not open save storage:", err));
+  }
+
+  // ── Worker ────────────────────────────────────────────────────────────────
+  const worker = new Worker("/web/game-worker.js");
+  worker.onmessage = (e) => {
+    const message = e.data;
+    if (typeof message === "string") {
+      let frame;
+      try { frame = JSON.parse(message); }
+      catch (err) { console.warn("[fishe] unreadable frame:", err); return; }
+      if (frame.type === "screen") {
+        setStatus("");           // the game is up; stop showing boot progress
+        FisheClient.render(frame.screen);
+      }
+      return;
+    }
+    if (message.type === "status") { setStatus(message.msg); return; }
+    if (message.type === "ready")  { return; }
+    if (message.type === "save")   { idbWrite(message.files); return; }
+    if (message.type === "error")  {
+      setStatus("The game stopped: " + message.msg + " — reload the page to start again. " +
+                "Your saved games are stored in this browser and are not affected.", true);
+    }
+  };
+  worker.onerror = (e) => {
+    setStatus("The game could not be started: " + (e.message || "unknown error") +
+              " — reload the page to try again.", true);
+  };
+  worker.postMessage({ type: "init", sab: sab, ringSize: RING_SIZE });
+})();
+</script>
+</body>
+</html>

--- a/web/pyodide_main.py
+++ b/web/pyodide_main.py
@@ -1,0 +1,42 @@
+# @author Daniel McCoy Stephenson
+"""Pyodide entry point — runs inside the Web Worker once game.zip is unpacked.
+
+By the time this file is exec()'d, web/game-worker.js has already:
+  - put /game/src on sys.path and chdir'd to /game, so the schema paths the
+    save readers validate against ("schemas/player.json") resolve
+  - created /saves, restored it from IndexedDB, and pointed FISHE_SAVE_DIR at it
+  - installed the JavaScript globals the front-end needs: sendToMain, Atomics,
+    sabMeta, sabData, sabRingSize, and syncSaves
+
+So there is nothing browser-specific left to do here: build the game against
+the Pyodide front-end and play it, exactly as examples/web_app.py does for the
+server-backed one.
+"""
+
+from ui.enum.uiType import UIType
+from ui.pyodideUserInterface import SharedArrayBufferBridge
+from fishE import FishE
+
+
+def main():
+    game = None
+    try:
+        game = FishE(interfaceType=UIType.PYODIDE)
+        game.play()
+    except SystemExit:
+        # Choosing "Quit" in the save-file manager calls exit(). In a browser
+        # tab there is no process to end, and letting SystemExit escape would
+        # surface as a Worker error, so it is treated as a normal finish.
+        pass
+
+    # Nothing else calls cleanup() when the game loop ends, and without it the
+    # tab would sit on the last screen forever rather than saying it's over.
+    if game is not None:
+        game.userInterface.cleanup()
+    else:
+        # Quit before the game finished being built: there is no interface to
+        # clean up, so tell the page directly.
+        SharedArrayBufferBridge().postScreen({"type": "ended"})
+
+
+main()

--- a/web/serve.py
+++ b/web/serve.py
@@ -1,0 +1,94 @@
+# @author Daniel McCoy Stephenson
+"""Static file server for the browser-native (Pyodide) build of FishE.
+
+Unlike examples/web_app.py, this server does not run the game — it only hands
+the browser the files it needs, and the game then runs in the player's own tab
+with its saves in that browser's IndexedDB. Every visitor gets their own game
+and their own save slots, and the server keeps no state at all.
+
+    python3 web/serve.py        # then open the URL it prints
+
+Routes:
+  /  /play  /play/  /index.html  → web/index.html
+  /web/...                       → the web/ directory (game.zip, worker, client)
+  everything else                → 404
+
+The Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy headers below are
+not optional: without them the page is not cross-origin isolated, and
+SharedArrayBuffer — which is how the player's input reaches the blocked game
+Worker — is not available at all. web/index.html says so on screen if they are
+missing, which is the usual symptom of a proxy in front of this server dropping
+them.
+"""
+
+import http.server
+import os
+from urllib.parse import unquote, urlparse
+
+REPOSITORY_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+WEB_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
+INDEX_PATHS = ("/", "/play", "/play/", "/index.html")
+
+
+class _Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=REPOSITORY_ROOT, **kwargs)
+
+    def do_GET(self):
+        path = unquote(urlparse(self.path).path)
+        if path in INDEX_PATHS:
+            self._sendIndex()
+            return
+        if not path.startswith("/web/"):
+            self.send_error(404, "Not found")
+            return
+        super().do_GET()
+
+    def _sendIndex(self):
+        indexPath = os.path.join(WEB_DIRECTORY, "index.html")
+        try:
+            with open(indexPath, "rb") as indexFile:
+                body = indexFile.read()
+        except OSError as e:
+            self.send_error(
+                500,
+                "FishE's page is missing",
+                f"Could not read {indexPath}: {e}. That file ships in the "
+                f"repository's web/ directory — serve the game from a complete "
+                f"checkout.",
+            )
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def end_headers(self):
+        # Required for SharedArrayBuffer, which the Pyodide front-end uses to
+        # deliver input to the (blocked) game Worker.
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        super().end_headers()
+
+    def log_message(self, *args):
+        pass  # keep the container's logs to what the game itself says
+
+
+class _Server(http.server.ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main():
+    host = os.environ.get("FISHE_WEB_HOST", "127.0.0.1")
+    port = int(os.environ.get("FISHE_WEB_PORT", "8080"))
+    print(f"FishE is being served at http://{host}:{port}/")
+    print("Open that URL to play. Press Ctrl+C here to stop.")
+    _Server((host, port), _Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

FishE's web front-end ran the game **on the server** and wrote save slots to the server's disk, so every visitor to a deployment shared one game loop and one set of save files. This adds a second browser front-end that runs the whole Python game **in the player's own tab** under Pyodide, with that tab's save slots kept in the browser's IndexedDB — the same approach Roam uses for its web build.

The server-backed front-end (`UIType.WEB`, `examples/web_app.py`) is unchanged and still there; the deployed image now serves the browser-native one.

### Front-end parity

`PyodideUserInterface` subclasses `WebUserInterface` and overrides only the two transport seams introduced here, `_present` and `_awaitInput`. Every screen — options, dialogue, prompt, busy, timed, ended — is still defined exactly once, so the two browser front-ends cannot drift.

The browser half is shared the same way: the renderer and styles moved out of `HTML_PAGE` into `web/client.js` and `web/client.css`, which the server-backed page inlines and the Pyodide page links. `tests/web/test_clientParity.py` asserts the sharing itself.

### Why a SharedArrayBuffer

FishE's game loop is synchronous, so it blocks the Worker whenever it waits for the player — and a blocked Worker can never run an `onmessage` handler. Shared memory needs no event loop, so that is how input reaches a blocked game. This is also why `web/serve.py` must send the COOP/COEP headers: without cross-origin isolation, `SharedArrayBuffer` does not exist and nothing the player clicks reaches the game. `web/index.html` says exactly that on screen if it happens.

For the same reason, IndexedDB writes happen on the main thread rather than in the Worker: the Worker posts the save file map over, and the page stores it.

### Saves

- `browserSaveSync.syncBrowserSaves()` flushes the save directory through the Worker's `syncSaves` hook after every save write, slot deletion and legacy migration. It is a no-op outside Pyodide, where the files on disk are the real saves.
- `FISHE_SAVE_DIR` relocates the save directory (the Worker points it at its IndexedDB-backed `/saves`).
- Deleting a slot in-game clears and rewrites the store, so a deletion sticks across a reload.

### Deployment

`web/serve.py` serves the bundle and never runs the game. The Dockerfile serves that instead of `examples/web_app.py`, which means the image needs no `pip install` (the game's one dependency, `jsonschema`, is loaded browser-side) and no save volume at all.

## Test plan

- [x] `python3 -m compileall -q src tests web`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — **716 passed**, 97% coverage (`src/ui/pyodideUserInterface.py` 97%)
- [x] `python3 -m black --check src tests web` clean; `autoflake` run per `format.sh`
- [x] New tests: `tests/ui/test_pyodideUserInterface.py` (18), `tests/web/` (13), `tests/test_browserSaveSync.py` (4), plus save-flush and `FISHE_SAVE_DIR` cases
  - Includes an end-to-end test that boots a **real** `FishE` through the Pyodide front-end against a fake `js` module whose `syncSaves` mirrors `web/game-worker.js`, and asserts the saved game lands in simulated browser storage
  - Includes a ring-buffer wraparound test and a test that quitting ends the page instead of surfacing `SystemExit` as a Worker error
- [x] Both browser front-ends touched and verified; console and pygame untouched
- [x] All four JS blocks (`client.js`, `game-worker.js`, and both inline transport scripts) pass `node --check`
- [x] `web/serve.py` smoke-tested live: `/` and `/play` serve the page with COOP/COEP set, `/web/*` serves the client, worker and 98 KB bundle, and `/src/fishE.py` is refused with a 404
- [ ] Not verified: an actual browser loading Pyodide and playing a save through IndexedDB — there is no browser in the environment this was built in. The Python side of that path is covered by the end-to-end test above, and the JavaScript side mirrors Roam's proven implementation, but the first real load is worth watching.

No schema or save-format change: `Player`, `Stats` and `TimeService` are untouched, so `schemas/*.json` and the `*JsonReaderWriter` classes stay in sync.

---

_drafted by Claude on behalf of Daniel Stephenson_