### PR TITLE
Fix README's no-dependencies claim and restore run.sh dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 This game allows you to explore a fishing village and perform actions in it.
 
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+The game itself depends on `jsonschema` (it validates save files on every load and save), so this step is required before running any front-end from a local Python interpreter — console or the server-backed web front-end (`python3 examples/web_app.py`). `run.sh` runs this for you. The pygame front-end (`UIType.PYGAME`) additionally needs `pip install pygame`, kept out of `requirements.txt` since it's only imported lazily when that front-end is selected.
+
 ## Features
 
 ### Play in your browser
@@ -26,7 +34,7 @@ python3 examples/web_app.py
 # then open http://127.0.0.1:8000
 ```
 
-Both use only the Python standard library; the Pyodide front-end loads its one runtime dependency (`jsonschema`) in the browser.
+Both need `jsonschema` (see Setup above) — the Pyodide front-end loads it into the browser sandbox automatically when the page opens, while the server-backed front-end runs on your local Python and needs it installed first.
 
 ### One Thing at a Time
 A new game opens on the docks with a rod, a bucket, and exactly one thing to do: **fish**. Everything else in the village arrives later, one option at a time, as you earn it — and each arrival tells you why it's there:

--- a/run.sh
+++ b/run.sh
@@ -20,29 +20,35 @@ printVersion() {
     echo ""
 }
 
-# checkDependencies() {
-#     # check that dependencies are installed
-#     echo "Checking dependencies"
-#     if ! command -v python &> /dev/null
-#     then
-#         echo "Python could not be found. Download it from https://www.python.org/downloads/"
-#         exit
-#     fi
-#     if ! command -v pip &> /dev/null
-#     then
-#         echo "Pip could not be found. Download it from https://pip.pypa.io/en/stable/installation/ or run 'python -m ensurepip' in a terminal"
-#         exit
-#     fi
-#     pip install pygame --pre --quiet
-#     pip install -r requirements.txt --quiet
-#     echo ""
-# }
+checkDependencies() {
+    # check that dependencies are installed
+    echo "Checking dependencies"
+    if ! command -v python3 &> /dev/null
+    then
+        echo "Python could not be found. Download it from https://www.python.org/downloads/"
+        exit 1
+    fi
+    if ! command -v pip &> /dev/null
+    then
+        echo "Pip could not be found. Download it from https://pip.pypa.io/en/stable/installation/ or run 'python -m ensurepip' in a terminal"
+        exit 1
+    fi
+    pip install pygame --pre --quiet
+    pip install pytest --quiet
+    pip install -r requirements.txt --quiet
+    echo ""
+}
 
 runTests() {
     # run tests
     echo "Running tests"
     python3 -m pytest
+    testExitCode=$?
     echo ""
+    if [ $testExitCode -ne 0 ]; then
+        echo "Tests failed. Aborting."
+        exit $testExitCode
+    fi
 }
 
 startProgram() {
@@ -55,6 +61,6 @@ startProgram() {
 getLatest
 printBranchStatus
 printVersion
-# checkDependencies
+checkDependencies
 runTests
 startProgram


### PR DESCRIPTION
## Summary
- README claimed both browser front-ends "use only the Python standard library," but `jsonschema` is a hard, module-scope dependency of the game itself (`src/fishE.py`, `src/validation/schemaValidator.py`) — every documented source-install path actually raises `ModuleNotFoundError` on a clean interpreter.
- Added a `## Setup` section to `README.md` with the `pip install -r requirements.txt` step, and corrected the "Play in your browser" claim to scope which front-end needs a local install (server-backed web) vs. an automatic in-browser one (Pyodide).
- Uncommented and repaired `checkDependencies()` in `run.sh` (checks `python3` instead of `python`, exits nonzero on failure, installs `pytest` alongside `requirements.txt`) and re-enabled its call in `main`.
- Made `runTests()` abort with the test's exit code instead of always falling through to `startProgram()` regardless of test results.

## Deferred backlog (recorded per Phase 1)
This cycle picked #146 as the sole issue (doc/build-fix tiebreaker). Other open issues were left for later cycles:
- Save-file-safety cluster (#149, #150, #143, #142) — touches protected paths (`src/saveFileManager.py`, `*JsonReaderWriter.py`) that need an explicit human merge decision per the do-not-auto-merge gate, so sequencing them after clean work avoids stranding the loop.
- Dialogue-accuracy bugs (#144, #145, #152) and the test/config cleanups (#154, #147, #151, #153) are all clean, non-protected candidates for upcoming cycles.

## Test plan
- [x] `python3 -m compileall -q src`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 720 passed
- [x] `bash -n run.sh` — syntax OK

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_drafted by Claude on behalf of Daniel Stephenson_