### PR TITLE
Fix stale price and reaction-window claims in NPC dialogue

### DIFF
--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -55,11 +55,7 @@ class Docks:
                 },
                 {
                     "question": "How do I fish at the docks?",
-                    "response": "Fishing is what this village is all about! You need at least 10 energy to fish. "
-                    "When you cast your line, you'll spend several random hours (1-10) fishing. "
-                    "Each hour uses 10 energy. When a fish bites, press Enter fast - within 2 seconds! "
-                    "Your reaction time matters. The more successful catches, the more fish you'll get. "
-                    "Don't worry if you miss a few - you'll still catch at least one fish if you tried!",
+                    "response": self._howToFishDialogue,
                 },
                 {
                     "question": "What other locations can I visit?",
@@ -200,6 +196,22 @@ class Docks:
 
         elif action == "quit":
             return LocationType.NONE
+
+    def _howToFishDialogue(self):
+        """Sam's explanation of the catch timing minigame, quoting the
+        player's actual reaction window - it widens with rod level, bought
+        at the shop (#145)."""
+        window = REACTION_BASE_WINDOW + (self.player.rodLevel - 1) * ROD_WINDOW_STEP
+        return (
+            "Fishing is what this village is all about! You need at least 10 energy to fish. "
+            "When you cast your line, you'll spend several random hours (1-10) fishing. "
+            "Each hour uses 10 energy. When a fish bites, press Enter fast - you've got "
+            "about %.1f seconds right now, and a better rod widens that window. "
+            "React slower and you'll still catch something, just less of it. "
+            "The more successful catches, the more fish you'll get. "
+            "Don't worry if you miss a few - you'll still catch at least one fish if you tried!"
+            % window
+        )
 
     def _locationsDialogue(self):
         """Sam's tour of the village - only the parts of it the player has

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -1,4 +1,5 @@
 from location.enum.locationType import LocationType
+from location import docks
 from player.player import Player
 from prompt.prompt import Prompt
 from world.timeService import TimeService
@@ -34,6 +35,14 @@ def rodUpgradeCost(rodLevel):
     return ROD_BASE_PRICE * rodLevel
 
 
+def _cheapestAndPriciestFish():
+    """The catalogue's cheapest and priciest species, by sale bounds - used to
+    quote a true price range in dialogue instead of a hardcoded one (#144)."""
+    cheapest = min(fish.FISH_TYPES, key=lambda fishType: fishType["minValue"])
+    priciest = max(fish.FISH_TYPES, key=lambda fishType: fishType["maxValue"])
+    return cheapest, priciest
+
+
 # @author Daniel McCoy Stephenson
 class Shop:
     def __init__(
@@ -63,18 +72,11 @@ class Shop:
                 },
                 {
                     "question": "What do you sell here?",
-                    "response": "I deal in all things fishing! I'll buy any fish you catch - the price varies, "
-                    "but you can expect $3 to $5 per fish. I also sell better bait that'll help you catch more fish. "
-                    "The price goes up each time you upgrade, but trust me, it's worth it! "
-                    "Better bait means more fish, and more fish means more money!",
+                    "response": self._sellPitchDialogue,
                 },
                 {
                     "question": "How does fishing work?",
-                    "response": "Ah, fishing! Head down to the docks when you've got some energy. "
-                    "You'll spend a few hours out there, and each hour costs 10 energy. "
-                    "When a fish bites, you need to press Enter quickly - within 2 seconds! "
-                    "Your success rate determines how many fish you catch. "
-                    "Better bait from my shop will multiply your catch!",
+                    "response": self._howFishingWorksDialogue,
                 },
                 {
                     "question": "Tell me about the bait upgrades.",
@@ -86,10 +88,7 @@ class Shop:
                 },
                 {
                     "question": "Any tips for selling fish?",
-                    "response": "Well, the price per fish is random between $3 and $5, so sometimes you get lucky! "
-                    "I'd say don't hoard your fish too long - sell regularly to keep money flowing. "
-                    "Use that money to buy better bait, which helps you catch more, which means more money! "
-                    "It's a beautiful cycle, really. And don't forget to save some money at the bank!",
+                    "response": self._sellingTipsDialogue,
                 },
                 {
                     "question": "Have you noticed my crew hauling in fish?",
@@ -113,6 +112,47 @@ class Shop:
         # Daily budget for buying fish; refills when a new day begins.
         self.money = SHOP_DAILY_BUDGET
         self.lastRefillDay = self.timeService.day
+
+    def _sellPitchDialogue(self):
+        """Gilbert's pitch on fish prices, quoting the catalogue's actual
+        cheapest and priciest species so it can't drift from it (#144)."""
+        cheapest, priciest = _cheapestAndPriciestFish()
+        return (
+            "I deal in all things fishing! I'll buy any fish you catch - the price "
+            "varies by species, anywhere from $%d for a %s up to $%d for a %s. "
+            "I also sell better bait that'll help you catch more fish. "
+            "The price goes up each time you upgrade, but trust me, it's worth it! "
+            "Better bait means more fish, and more fish means more money!"
+            % (cheapest["minValue"], cheapest["name"], priciest["maxValue"], priciest["name"])
+        )
+
+    def _sellingTipsDialogue(self):
+        """Gilbert's selling tips, quoting the same catalogue-derived range as
+        _sellPitchDialogue so what you catch is framed as mattering."""
+        cheapest, priciest = _cheapestAndPriciestFish()
+        return (
+            "Well, the price per fish depends on what you land - anywhere from $%d "
+            "for a %s up to $%d for a %s, so what you catch matters as much as how much! "
+            "I'd say don't hoard your fish too long - sell regularly to keep money flowing. "
+            "Use that money to buy better bait, which helps you catch more, which means more money! "
+            "It's a beautiful cycle, really. And don't forget to save some money at the bank!"
+            % (cheapest["minValue"], cheapest["name"], priciest["maxValue"], priciest["name"])
+        )
+
+    def _howFishingWorksDialogue(self):
+        """Gilbert's explanation of the catch timing minigame, quoting the
+        player's actual reaction window - it widens with rod level (#145)."""
+        window = docks.REACTION_BASE_WINDOW + (
+            self.player.rodLevel - 1
+        ) * docks.ROD_WINDOW_STEP
+        return (
+            "Ah, fishing! Head down to the docks when you've got some energy. "
+            "You'll spend a few hours out there, and each hour costs 10 energy. "
+            "When a fish bites, you need to press Enter quickly - you've got about "
+            "%.1f seconds right now, and a better rod from me widens that window. "
+            "React slower and you'll still land something, just less of it. "
+            "Better bait from my shop will multiply your catch!" % window
+        )
 
     def _crewDialogue(self):
         """Gilbert's take on the player's fishing business, staged by whether

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -1962,3 +1962,30 @@ def test_locations_dialogue_covers_the_whole_village_once_it_is_open():
     assert "Old Tom" in text
     assert "the bank" in text
     assert "in your own time" not in text
+
+
+def test_sam_fishing_explanation_quotes_the_base_reaction_window():
+    # prepare - rod level 1 is the base window
+    docksInstance = createDocks()
+    assert docksInstance.player.rodLevel == 1
+
+    # call
+    response = docksInstance._howToFishDialogue()
+
+    # check
+    assert "within 2 seconds" not in response
+    assert "%.1f seconds" % docks.REACTION_BASE_WINDOW in response
+
+
+def test_sam_fishing_explanation_widens_with_rod_level():
+    # prepare - a maxed-out rod widens the window well past the base 2.0s
+    docksInstance = createDocks()
+    docksInstance.player.rodLevel = 10
+    expectedWindow = docks.REACTION_BASE_WINDOW + 9 * docks.ROD_WINDOW_STEP
+
+    # call
+    response = docksInstance._howToFishDialogue()
+
+    # check
+    assert "%.1f seconds" % expectedWindow in response
+    assert "%.1f seconds" % docks.REACTION_BASE_WINDOW not in response

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -1,5 +1,6 @@
 from src.location.enum.locationType import LocationType
 from src.location import shop
+from src.location import docks
 from src.player.player import Player
 from src.prompt.prompt import Prompt
 from src.stats.stats import Stats
@@ -497,3 +498,64 @@ def test_run_buying_bait_fires_from_its_actual_position():
     # check
     assert nextLocation == LocationType.SHOP
     shopInstance.buyBetterBait.assert_called_once()
+
+
+def test_gilbert_sell_pitch_quotes_the_actual_catalogue_range():
+    # prepare
+    shopInstance = createShop()
+    cheapest, priciest = shop._cheapestAndPriciestFish()
+
+    # call
+    response = shopInstance._sellPitchDialogue()
+
+    # check - the old flat $3-5 range is gone, replaced by the real bounds
+    assert "$3 to $5" not in response
+    assert "$%d" % cheapest["minValue"] in response
+    assert cheapest["name"] in response
+    assert "$%d" % priciest["maxValue"] in response
+    assert priciest["name"] in response
+    assert cheapest["name"] == "Minnow"
+    assert priciest["name"] == "Golden Koi"
+
+
+def test_gilbert_selling_tips_quotes_the_actual_catalogue_range():
+    # prepare
+    shopInstance = createShop()
+    cheapest, priciest = shop._cheapestAndPriciestFish()
+
+    # call
+    response = shopInstance._sellingTipsDialogue()
+
+    # check
+    assert "between $3 and $5" not in response
+    assert "$%d" % cheapest["minValue"] in response
+    assert "$%d" % priciest["maxValue"] in response
+
+
+def test_gilbert_fishing_explanation_quotes_the_base_reaction_window():
+    # prepare - rod level 1 is the base window
+    shopInstance = createShop()
+    assert shopInstance.player.rodLevel == 1
+
+    # call
+    response = shopInstance._howFishingWorksDialogue()
+
+    # check
+    assert "within 2 seconds" not in response
+    assert "%.1f seconds" % docks.REACTION_BASE_WINDOW in response
+
+
+def test_gilbert_fishing_explanation_widens_with_rod_level():
+    # prepare - a maxed-out rod widens the window well past the base 2.0s
+    shopInstance = createShop()
+    shopInstance.player.rodLevel = shop.MAX_ROD_LEVEL
+    expectedWindow = docks.REACTION_BASE_WINDOW + (
+        shop.MAX_ROD_LEVEL - 1
+    ) * docks.ROD_WINDOW_STEP
+
+    # call
+    response = shopInstance._howFishingWorksDialogue()
+
+    # check
+    assert "%.1f seconds" % expectedWindow in response
+    assert "%.1f seconds" % docks.REACTION_BASE_WINDOW not in response


### PR DESCRIPTION
## Summary
- Gilbert's shop dialogue quoted a flat "$3 to $5 per fish" price, but the species catalogue (`src/fish/fish.py`) now prices fish from $2 (Minnow) to $80 (Golden Koi). Both of his price-related lines ("What do you sell here?" and "Any tips for selling fish?") are now computed from `fish.FISH_TYPES` so they can't drift from the catalogue again.
- Both Sam's (docks) and Gilbert's (shop) explanations of the catch-timing minigame claimed a fixed "within 2 seconds" window, but the window actually widens with rod level (`REACTION_BASE_WINDOW + (rodLevel - 1) * ROD_WINDOW_STEP`, currently 2.0s-6.5s) - the only mechanical effect a rod purchase has. Both lines are now computed from the player's actual rod level, and correct the "you'll miss the fish" framing to "you'll still catch something, just less of it," matching the actual catch-quality-tier logic.

## Test plan
- [x] python3 -m compileall -q src
- [x] SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest - 726 passed
- [x] Added tests asserting the old hardcoded strings are gone and the new dialogue reflects the catalogue bounds / rod-scaled window, including a widened-rod-level case

Closes #144
Closes #145

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._