### PR TITLE
Fix PLANNING.md's premise to match the homeless-start progression

### DIFF
--- a/PLANNING.md
+++ b/PLANNING.md
@@ -1,7 +1,6 @@
 General Idea
-You are a fisherman living in a home by the docks. There’s a store nearby that you can walk to and you sell your fish there. You’re able to buy better fishing gear and deposit your money in the bank. Every day is a new opportunity to collect fish.
+You are a fisherman who starts out homeless with nothing but a rod. Catching fish and selling them opens up the shop and the bank, and progression from there earns you a home, a fleet of boats, and the rest of the village. Every day is a new opportunity to collect fish.
 
 
 Maybes
 - Maybe make the fishMultiplier a chance thing
-- Aesthetic upgrades?


### PR DESCRIPTION
## Summary
- `PLANNING.md`'s opening premise described starting with a home and an unlocked shop/bank, which contradicts the actual homeless-start → earn-the-shop-and-bank progression (`src/player/player.py`, `src/housing/housing.py`, `src/progression/progression.py`).
- Rewrote the premise to match current behavior and dropped the stale "Aesthetic upgrades?" maybe now that a 541-line pygame front-end and the web build both ship.

## Test plan
- [x] `python3 -m compileall -q src`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 726 passed

Docs-only change; no code paths touched.

Closes #159

---

_drafted by Claude on behalf of Daniel Stephenson_