### PR TITLE
Fix role-blind crew dialogue and remove three dead symbols

### DIFF
--- a/src/business/boats.py
+++ b/src/business/boats.py
@@ -184,6 +184,15 @@ def assignedNames(player):
     return names
 
 
+def boatFor(player, name):
+    """The boat a named crew member is assigned to, or None if they haven't
+    been put to work on one yet."""
+    for boat in player.boats:
+        if name in boat["crew"]:
+            return boat
+    return None
+
+
 def unassignedNames(player):
     """Hired villagers who aren't on any boat. They still draw wages - which is
     the pressure to either give them a berth or let them go."""
@@ -380,12 +389,6 @@ def _trimAssignedHands(player):
         taken = min(surplus, boat["hands"])
         boat["hands"] -= taken
         surplus -= taken
-
-
-def fishingCrewCount(player):
-    """How many hands are actually out catching fish - crew on fishing boats
-    only. An unassigned worker, or one on a pirate boat, brings in no catch."""
-    return sum(crewSize(boat) for boat in boatsWithRole(player, ROLE_FISHING))
 
 
 def tierFactor(boat):

--- a/src/business/export.py
+++ b/src/business/export.py
@@ -44,11 +44,6 @@ EXPORT_MARKETS = [
     },
 ]
 
-# The cheapest boat any market will accept, i.e. the tier at which exporting
-# becomes available at all.
-MIN_EXPORT_BOAT_TIER = min(market["minBoatTier"] for market in EXPORT_MARKETS)
-
-
 def exportCapacity(player):
     """How many fish one run can carry (0 with no boat, or none big enough to
     make the crossing).

--- a/src/location/shop.py
+++ b/src/location/shop.py
@@ -8,6 +8,7 @@ from ui.userInterface import UserInterface
 from npc.npc import NPC
 from npc import villagers
 from fish import fish
+from business import boats
 from business import business
 from business import export
 from progression import progression
@@ -163,8 +164,7 @@ class Shop:
                 "docks - Sam will set you up. Then you'll really see the fish "
                 "pile in."
             )
-        fishPerDay = business.tierInfo(business.currentTier(self.player))["fishPerDay"]
-        dailyCatch = fishPerDay * self.player.workers
+        dailyCatch = boats.fleetDailyCatch(self.player)
         return (
             "That I have! Word is your crew hauls in about %d fish a day. "
             "Keep that up and I might need a bigger vault!" % dailyCatch

--- a/src/npc/villagers.py
+++ b/src/npc/villagers.py
@@ -9,6 +9,7 @@
 # capacity (see business.BOAT_TIERS) so a player can always fill every slot
 # with a named villager.
 
+from business import boats
 from business import business
 from npc.npc import NPC
 
@@ -158,11 +159,23 @@ def createCrewNPC(player, name):
         }
 
     def workDialogue():
-        info = business.tierInfo(business.currentTier(player))
+        boat = boats.boatFor(player, name)
+        if boat is None:
+            return (
+                "Not assigned to a boat right now - just say the word and "
+                "I'll get to work."
+            )
+        info = business.tierInfo(boat["tier"])
+        if boat["role"] == boats.ROLE_FISHING:
+            return (
+                "Busy, and that's how I like it. I'm on %s most days, and "
+                "I'm landing about %d fish a day for you off the %s."
+                % (villager["specialty"], boats.dailyCatch(boat), info["name"])
+            )
         return (
-            "Busy, and that's how I like it. I'm on %s most days, and I'm "
-            "landing about %d fish a day for you off the %s."
-            % (villager["specialty"], info["fishPerDay"], info["name"])
+            "Busy, and that's how I like it. I'm on %s most days, aboard "
+            "the %s - she %s."
+            % (villager["specialty"], info["name"], boats.ROLES[boat["role"]]["summary"])
         )
 
     def boatDialogue():

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -120,18 +120,10 @@ poll();
 
 
 def __getattr__(name):
-    """Keep HTML_PAGE / CLIENT_CSS / CLIENT_JS readable as module attributes.
-
-    They are the names this module has always exposed, so tests and any other
-    reader still reach them the same way — they are just no longer computed
-    unless something actually asks (PEP 562).
-    """
+    """Keep HTML_PAGE readable as a module attribute; the page is built lazily
+    so a missing web/ directory doesn't break import."""
     if name == "HTML_PAGE":
         return htmlPage()
-    if name == "CLIENT_CSS":
-        return _clientAsset("client.css")
-    if name == "CLIENT_JS":
-        return _clientAsset("client.js")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/tests/location/test_shop.py
+++ b/tests/location/test_shop.py
@@ -145,14 +145,27 @@ def test_npc_crew_dialogue_reports_daily_catch():
     from src.business import business
 
     shopInstance = createShop()
-    boats.addBoat(shopInstance.player, 2)
+    boat = boats.addBoat(shopInstance.player, 2)
+    boat["hands"] = 3
     shopInstance.player.workers = 3
 
-    # check - the reported total matches tier fishPerDay * worker count
+    # check - the reported total matches the fleet's actual daily catch
     expected = business.tierInfo(2)["fishPerDay"] * 3
     response = shopInstance._crewDialogue()
     assert str(expected) in response
     assert "That I have" in response
+
+
+def test_npc_crew_dialogue_ignores_non_fishing_boats():
+    # prepare - crew are aboard, but on a piracy boat, so they land no fish
+    shopInstance = createShop()
+    boat = boats.addBoat(shopInstance.player, 2, role=boats.ROLE_PIRACY)
+    boat["hands"] = 3
+    shopInstance.player.workers = 3
+
+    # check - Gilbert reports the true (zero) catch, not the best hull's rate
+    response = shopInstance._crewDialogue()
+    assert "0 fish a day" in response
 
 
 def test_sellFish():

--- a/tests/npc/test_villagers.py
+++ b/tests/npc/test_villagers.py
@@ -8,6 +8,7 @@ def createEmployedPlayer(name="Marta Kell", tier=1):
     player = Player()
     boats.addBoat(player, tier)
     player.money = 1000
+    # hireWorker auto-berths on the first boat with room.
     boats.hireWorker(player, name)
     return player
 
@@ -88,6 +89,38 @@ def test_createCrewNPC_work_dialogue_reflects_the_boat():
         "fishPerDay"
     ] in fleetAnswer.get_dialogue_response(1)
     assert "mending nets" in rowboatAnswer.get_dialogue_response(1)
+
+
+def test_createCrewNPC_work_dialogue_is_honest_off_a_fishing_boat():
+    # prepare - the only boat is a piracy boat, so hiring berths her there
+    player = Player()
+    boats.addBoat(player, 2, role=boats.ROLE_PIRACY)
+    player.money = 1000
+    boats.hireWorker(player, "Marta Kell")
+
+    # call - question 2 is "How's the work going?"
+    npc = villagers.createCrewNPC(player, "Marta Kell")
+    response = npc.get_dialogue_response(1)
+
+    # check - no fish figure is quoted; the role's own summary is
+    assert "fish a day" not in response
+    assert boats.ROLES[boats.ROLE_PIRACY]["summary"] in response
+
+
+def test_createCrewNPC_work_dialogue_handles_an_unassigned_hand():
+    # prepare - hired, then pulled off her boat with nowhere else to work
+    player = Player()
+    boat = boats.addBoat(player, 1)
+    player.money = 1000
+    boats.hireWorker(player, "Marta Kell")
+    boats.unassignCrew(player, boat["id"], "Marta Kell")
+
+    # call
+    npc = villagers.createCrewNPC(player, "Marta Kell")
+    response = npc.get_dialogue_response(1)
+
+    # check
+    assert "Not assigned to a boat" in response
 
 
 def test_createCrewNPC_wage_dialogue_warns_when_payroll_is_short():


### PR DESCRIPTION
## Summary
- Gilbert's shop dialogue and a hired crew member's work-status line both quoted the *best hull's* `fishPerDay` × total fleet headcount, ignoring boat role and which boat a hand is actually on (`src/location/shop.py`, `src/npc/villagers.py`). A piracy or transport posting landed a nonzero fish quote it never earns.
- Both now go through the fleet's own accounting: Gilbert uses `boats.fleetDailyCatch(player)` (already used by the docks daily-report screen); the crew member uses a new `boats.boatFor(player, name)` lookup plus `boats.dailyCatch(boat)`, and reports the role's own summary line (e.g. piracy raiding) when the boat isn't a fishing boat, or an honest "not assigned" line when unberthed.
- Removed three symbols with zero callers found during triage: `boats.fishingCrewCount` (superseded by `dailyCatch`/`fleetDailyCatch`), `export.MIN_EXPORT_BOAT_TIER` (a second, divergent answer to what `canExport()` already answers), and the dead `CLIENT_CSS`/`CLIENT_JS` branches of `webUserInterface.__getattr__` (the underlying `_clientAsset()` calls are still used directly elsewhere).

## Test plan
- [x] `python3 -m compileall -q src`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 729 passed
- [x] Added `test_npc_crew_dialogue_ignores_non_fishing_boats` (shop) and `test_createCrewNPC_work_dialogue_is_honest_off_a_fishing_boat` / `test_createCrewNPC_work_dialogue_handles_an_unassigned_hand` (villagers), each of which fails against the pre-fix formula
- [x] Updated `test_npc_crew_dialogue_reports_daily_catch` to actually crew the boat (was asserting the old fleet-headcount formula, which no fishing role check enforced)

Closes #157
Closes #161

---

_drafted by Claude on behalf of Daniel Stephenson_