### PR TITLE
Remove four Config settings nothing reads

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -10,13 +10,10 @@ class Config:
         # Worker-side directory that the Pyodide front-end mirrors to the
         # browser's IndexedDB (see browserSaveSync and web/game-worker.js).
         self.dataDirectory = os.environ.get("FISHE_SAVE_DIR") or "data"
-        self.playerSaveFile = os.path.join(self.dataDirectory, "player.json")
-        self.statsSaveFile = os.path.join(self.dataDirectory, "stats.json")
-        self.timeServiceSaveFile = os.path.join(self.dataDirectory, "timeService.json")
 
-        # Initial player values
+        # Initial player values. Starting energy isn't configured here - see
+        # player.py, which sources it from the housing ladder instead.
         self.initialMoney = 20
-        self.initialEnergy = 100
         self.initialFishCount = 0
         self.initialMoneyInBank = 0.01
         self.initialFishMultiplier = 1

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -12,10 +12,10 @@ class Player:
         self.fishMultiplier = 1 if config is None else config.initialFishMultiplier
         self.priceForBait = 50 if config is None else config.initialPriceForBait
         # Starts at the Homeless tier's energy cap (see src/housing) - a
-        # fresh player hasn't found anywhere to stay yet. Deliberately not
-        # sourced from Config.initialEnergy: the housing ladder is the
-        # source of truth for energy caps (see src/housing/housing.py), and
-        # a flat configured starting energy could exceed the Homeless cap.
+        # fresh player hasn't found anywhere to stay yet. Deliberately not a
+        # configured value: the housing ladder is the source of truth for
+        # energy caps (see src/housing/housing.py), and a flat configured
+        # starting energy could exceed the Homeless cap.
         self.energy = housing.HOUSING_TIERS[0]["maxEnergy"]
         self.rodLevel = 1
         # Per-species breakdown of the fish currently held. fishCount remains the

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from src.config.config import Config
@@ -20,15 +18,11 @@ def test_initialization():
     # call
     config = createConfig()
 
-    # check save file paths
+    # check
     assert config.dataDirectory == "data"
-    assert config.playerSaveFile == os.path.join("data", "player.json")
-    assert config.statsSaveFile == os.path.join("data", "stats.json")
-    assert config.timeServiceSaveFile == os.path.join("data", "timeService.json")
 
     # check initial player values
     assert config.initialMoney == 20
-    assert config.initialEnergy == 100
     assert config.initialFishCount == 0
     assert config.initialMoneyInBank == 0.01
     assert config.initialFishMultiplier == 1
@@ -43,9 +37,6 @@ def test_save_directory_can_be_relocated(monkeypatch):
     config = createConfig()
 
     assert config.dataDirectory == "/saves"
-    assert config.playerSaveFile == os.path.join("/saves", "player.json")
-    assert config.statsSaveFile == os.path.join("/saves", "stats.json")
-    assert config.timeServiceSaveFile == os.path.join("/saves", "timeService.json")
 
 
 def test_an_empty_save_directory_override_falls_back_to_the_default(monkeypatch):


### PR DESCRIPTION
## Summary
- Removed `Config.playerSaveFile`, `statsSaveFile`, and `timeServiceSaveFile` — the multi-slot save layout resolves paths through `SaveFileManager.get_save_path()` instead, so these three have been dead since #51; a grep confirms every remaining match outside `config.py`/the test was a local `as` variable in `fishE.py`, never `self.config.*`.
- Removed `Config.initialEnergy` — `player.py` already documents that starting energy deliberately comes from the housing ladder, not a configured value, so the attribute had no reader. Updated that comment since it referenced the now-removed attribute by name.
- Trimmed the matching assertions out of `tests/config/test_config.py` (they were pinning dead values) and dropped the now-unused `os` import.

## Test plan
- [x] `python3 -m compileall -q src`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest` — 729 passed
- [x] `grep -rn '\.playerSaveFile\|\.statsSaveFile\|\.timeServiceSaveFile\|\.initialEnergy' --include='*.py' .` — no remaining references anywhere
- [x] README/PLANNING.md grepped for the removed names — no doc drift

Closes #147

---

_drafted by Claude on behalf of Daniel Stephenson_