### PR TITLE
Reject non-positive bank amounts and fix stale crew/interest dialogue

### DIFF
--- a/src/location/bank.py
+++ b/src/location/bank.py
@@ -1,13 +1,18 @@
 from location.enum.locationType import LocationType
 from player.player import Player
 from prompt.prompt import Prompt
-from world.timeService import TimeService
+from world.timeService import TimeService, INTEREST_RATE, MAX_INTEREST_PER_DAY
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
 from business import business
 from investments import investments
 from progression import progression
+
+# The break-even point past which the daily interest cap binds - used so the
+# teller's dialogue can state the real rule instead of drifting from it (see
+# src/world/timeService.py for the underlying constants).
+_INTEREST_CAP_BALANCE = int(MAX_INTEREST_PER_DAY / INTEREST_RATE)
 
 
 # @author Daniel McCoy Stephenson
@@ -42,16 +47,20 @@ class Bank:
                     "response": "The bank is simple and safe! You can deposit money when you have some on hand, "
                     "and withdraw it whenever you need. We keep your money secure - "
                     "no risk of losing it to gambling or spending it accidentally! "
-                    "Plus, your savings earn interest over time. The more you save, the more you earn. "
-                    "It's the smart way to grow your wealth!",
+                    "Plus, your savings earn interest over time - up to $%d a day. "
+                    "It's the smart way to grow your wealth!" % MAX_INTEREST_PER_DAY,
                 },
                 {
                     "question": "Tell me about interest rates.",
-                    "response": "Ah yes, interest! Every day that passes, your savings grow by a small percentage. "
-                    "It might not seem like much at first, but over time it really adds up! "
+                    "response": "Ah yes, interest! Every day that passes, your savings grow by %d%%, "
+                    "up to $%d a day - past about $%d banked you've maxed out what I can pay you. "
                     "The interest is automatically added to your bank account. "
-                    "Think of it as the bank paying you for keeping your money with us. "
-                    "The more you save, the more interest you earn!",
+                    "Think of it as the bank paying you for keeping your money with us."
+                    % (
+                        int(INTEREST_RATE * 100),
+                        MAX_INTEREST_PER_DAY,
+                        _INTEREST_CAP_BALANCE,
+                    ),
                 },
                 {
                     "question": "Should I save or spend my money?",
@@ -222,6 +231,12 @@ class Bank:
             if amount is None:
                 self.currentPrompt.text = "Try again. Money: $%.2f" % self.player.money
                 continue
+            if amount <= 0:
+                self.currentPrompt.text = (
+                    "Enter an amount greater than zero. Money: $%.2f"
+                    % self.player.money
+                )
+                continue
 
             if self.player.canAfford(amount):
                 self.player.moneyInBank += amount
@@ -238,6 +253,12 @@ class Bank:
             if amount is None:
                 self.currentPrompt.text = (
                     "Try again. Money In Bank: $%.2f" % self.player.moneyInBank
+                )
+                continue
+            if amount <= 0:
+                self.currentPrompt.text = (
+                    "Enter an amount greater than zero. Money In Bank: $%.2f"
+                    % self.player.moneyInBank
                 )
                 continue
 

--- a/src/npc/villagers.py
+++ b/src/npc/villagers.py
@@ -212,11 +212,10 @@ def createCrewNPC(player, name):
         )
 
     def crowdedDialogue():
-        info = business.tierInfo(business.currentTier(player))
         return (
-            "All %d berths full on the %s. Elbow to elbow out there! If you "
-            "want more hands you'll need more boat."
-            % (info["maxWorkers"], info["name"])
+            "All %d berths full across the fleet. Elbow to elbow out there! "
+            "If you want more hands you'll need another boat."
+            % boats.totalCrewBerths(player)
         )
 
     def businessNameDialogue():
@@ -257,8 +256,7 @@ def createCrewNPC(player, name):
                 # Only worth asking once there's no room left to hire.
                 "question": "Getting crowded out there, isn't it?",
                 "response": crowdedDialogue,
-                "condition": lambda: player.workers
-                >= business.tierInfo(business.currentTier(player))["maxWorkers"],
+                "condition": lambda: player.workers >= boats.totalCrewBerths(player),
             },
             {
                 # The outfit has to have a name before anyone can have an

--- a/tests/location/test_bank.py
+++ b/tests/location/test_bank.py
@@ -194,6 +194,26 @@ def test_npc_business_dialogue_fleet_tier():
     assert "retire a wealthy soul" in bankInstance._businessDialogue()
 
 
+def test_npc_interest_dialogue_discloses_the_daily_cap():
+    # prepare - the teller's "interest rates" answer must state the actual
+    # rule (the daily cap timeService.py enforces), not just "the more you
+    # save, the more you earn"
+    from src.world.timeService import INTEREST_RATE, MAX_INTEREST_PER_DAY
+
+    bankInstance = createBank()
+    options = bankInstance.npc.get_dialogue_options()
+    questions = [option["question"] for option in options]
+    index = questions.index("Tell me about interest rates.")
+
+    # call
+    response = bankInstance.npc.get_dialogue_response(index)
+
+    # check
+    assert "%d%%" % int(INTEREST_RATE * 100) in response
+    assert "$%d" % MAX_INTEREST_PER_DAY in response
+    assert "maxed out" in response
+
+
 def test_deposit_success():
     # prepare
     bankInstance = createBank()
@@ -331,6 +351,50 @@ def test_withdraw_invalid_input_retries_then_succeeds():
     assert bankInstance.userInterface.promptForNumber.call_count == 2
     assert bankInstance.player.moneyInBank == 90
     assert bankInstance.player.money == 10
+
+
+def test_deposit_negative_amount_is_rejected():
+    # prepare - a negative "deposit" would otherwise pass canAfford (money >=
+    # negative is always true) and mint cash out of nothing
+    bankInstance = createBank()
+    bankInstance.userInterface.lotsOfSpace = MagicMock()
+    bankInstance.userInterface.divider = MagicMock()
+    bankInstance.player.money = 20
+    bankInstance.player.moneyInBank = 0
+    bankInstance.userInterface.promptForNumber = MagicMock(
+        side_effect=[-100.0, 10.0]
+    )
+
+    # call
+    bankInstance.deposit()
+
+    # check - the negative attempt is rejected and re-prompted, then the
+    # valid second attempt goes through
+    assert bankInstance.userInterface.promptForNumber.call_count == 2
+    assert bankInstance.player.money == 10
+    assert bankInstance.player.moneyInBank == 10
+
+
+def test_withdraw_negative_amount_is_rejected():
+    # prepare - a negative "withdrawal" would otherwise pass the
+    # amount <= moneyInBank check and drive player.money negative
+    bankInstance = createBank()
+    bankInstance.userInterface.lotsOfSpace = MagicMock()
+    bankInstance.userInterface.divider = MagicMock()
+    bankInstance.player.moneyInBank = 400
+    bankInstance.player.money = 20
+    bankInstance.userInterface.promptForNumber = MagicMock(
+        side_effect=[-500.0, 10.0]
+    )
+
+    # call
+    bankInstance.withdraw()
+
+    # check - the negative attempt is rejected and re-prompted, then the
+    # valid second attempt goes through
+    assert bankInstance.userInterface.promptForNumber.call_count == 2
+    assert bankInstance.player.moneyInBank == 390
+    assert bankInstance.player.money == 30
 
 
 def test_manageInvestments_buy_when_affordable():

--- a/tests/npc/test_villagers.py
+++ b/tests/npc/test_villagers.py
@@ -256,6 +256,25 @@ def test_createCrewNPC_crowded_response_quotes_the_berth_count():
     assert "All %d berths" % business.tierInfo(1)["maxWorkers"] in response
 
 
+def test_createCrewNPC_crowded_question_stays_hidden_with_room_on_another_boat():
+    # prepare - two Rowboats, full crew on the first but the second still has
+    # room, so hiring is fleet-wide and the player isn't actually crowded out
+    player = createEmployedPlayer(tier=1)
+    boats.addBoat(player, 1)
+    for villager in villagers.availableVillagers(player)[
+        : business.tierInfo(1)["maxWorkers"] - 1
+    ]:
+        boats.hireWorker(player, villager["name"])
+    npc = villagers.createCrewNPC(player, "Marta Kell")
+
+    # call
+    questions = [option["question"] for option in npc.get_dialogue_options()]
+
+    # check
+    assert "Getting crowded out there, isn't it?" not in questions
+    assert player.workers < boats.totalCrewBerths(player)
+
+
 def test_createCrewNPC_ambition_response_mentions_the_business():
     # prepare
     player = createEmployedPlayer(tier=len(business.BOAT_TIERS))


### PR DESCRIPTION
## Summary

Three small, independent bugs found during triage are addressed here.

- **#149** — Negative amounts were accepted by `Bank.deposit()`/`Bank.withdraw()`. A negative deposit passed `canAfford()` (money >= a negative number is always true) and minted cash, while a negative withdrawal drove `player.money` negative — both wrote a save that `schemas/player.json`'s `"minimum": 0` constraint would reject on the next load. Non-positive amounts are now rejected with a re-prompt, mirroring the existing `is None` retry branch.
- **#152** — The crew NPC's "berths full" dialogue and its unlock condition were keyed off the best hull's `maxWorkers`, even though hiring has been fleet-wide (`boats.totalCrewBerths`) since a prior change. A player with a second boat and open berths was told to buy a bigger boat while hiring still worked normally. Both the condition and the response text are now derived from `totalCrewBerths`, matching the README's documented "one shared roster" rule.
- **#158** — The bank teller's "interest rates" dialogue claimed "the more you save, the more you earn," which stopped being true once `MAX_INTEREST_PER_DAY` was introduced to cap the daily payout. The line is now derived from `INTEREST_RATE`/`MAX_INTEREST_PER_DAY` so it states the real rule and the point at which it caps, and can't drift from the constants again.

The broader, structural write-side validation this triage also flagged (unvalidated writes letting an invalid save land on disk at all) is left to #160, which is a materially larger change touching `saveFileManager.py`/`*JsonReaderWriter.py`.

## Issues deferred this cycle

The rest of the open backlog is deferred without further comment, since this cycle's scope was kept to three small, low-risk fixes: #160 (save-write atomicity/validation — large, touches protected save-path files), #156 (voyage-event test coverage — a sizeable standalone test-expansion effort), #153 (web front-end "ended" screen), #151 (overnight report dropped at three call sites), #150 (corrupt save vanishing from the menu), #143 and #142 (save/load error reporting).

## Test plan

- [x] `python3 -m compileall -q src`
- [x] Full suite: `731 passed` under headless SDL drivers (`SDL_VIDEODRIVER=dummy`, `SDL_AUDIODRIVER=dummy`)
- [x] New regression tests added for negative-amount rejection (deposit/withdraw), the interest-rate dialogue's disclosed cap, and the fleet-wide berths dialogue/condition

Closes #149
Closes #152
Closes #158

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->