### PR TITLE
Stop a damaged save from being destroyed, and say so on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ FishE supports multiple save files, allowing you to maintain different game prog
 
 Each save file is stored in its own slot (slot_1, slot_2, etc.) in the `data/` directory, ensuring your saves never conflict with each other. Set `FISHE_SAVE_DIR` to keep them somewhere else.
 
+Saves are written atomically — each file goes to a temporary file beside it and is swapped into place only once it's complete — so a crash or a power cut mid-save leaves the previous save intact rather than a half-written one. If a slot still turns out to be unreadable, the game tells you so on startup instead of starting quietly from scratch, and copies the whole slot into a `damaged-<date>-<time>` folder inside it before the new game overwrites anything. That folder is yours to inspect or restore by hand; deleting the slot from the menu deletes it too.
+
 When you play in your own browser (the Pyodide front-end above), those same slots are written to your browser's IndexedDB instead of to disk — creating, saving and deleting a slot all take effect there, so your progress is waiting for you when you come back to the tab. They belong to that browser on that machine: clearing the site's data clears them, and they don't follow you to another browser or another device.
 
 ## Contributing

--- a/src/fishE.py
+++ b/src/fishE.py
@@ -1,5 +1,7 @@
 import os
 import json
+import shutil
+from datetime import datetime
 from jsonschema.exceptions import ValidationError
 from location import bank, docks, home, shop, tavern
 from location.enum.locationType import LocationType
@@ -36,6 +38,11 @@ class FishE:
         self.statsJsonReaderWriter = StatsJsonReaderWriter()
         self.saveFileManager = SaveFileManager(data_directory=self.config.dataDirectory)
 
+        # What the load block below could not read, one description per file.
+        # Collected rather than reported one file at a time so a slot with
+        # three bad files costs the player one dialogue instead of three.
+        self.failedLoads = []
+
         # Start from default (new-game) state, then build the UI so the save-file
         # manager can render and read input through the active front-end. A
         # chosen save is loaded over these defaults below.
@@ -65,6 +72,12 @@ class FishE:
         time_path = self.saveFileManager.get_save_path("timeService.json")
         if os.path.exists(time_path) and os.path.getsize(time_path) > 0:
             self.loadTimeService()
+
+        # A failed load leaves fresh objects in place of the player's run, and
+        # save() writes them back after the very next action - so the bytes
+        # that failed have to be copied aside before play() is ever reached.
+        if self.failedLoads:
+            self._preserveDamagedSave()
 
         # loadPlayer()/loadStats() rebind self.player/self.stats to brand-new
         # objects, but only loadTimeService() rebuilds the TimeService around
@@ -274,32 +287,141 @@ class FishE:
             return True
         return False
 
+    def _describeLoadFailure(self, filename, error):
+        """One short line naming a save file and why it would not load.
+
+        Kept to a single trimmed line because this ends up inside a dialogue
+        box: jsonschema's ValidationError renders as a multi-paragraph dump of
+        the whole instance and schema, which no front-end can show and no
+        player would read. Its .message is the one-line reason; every other
+        error the load handlers catch is already short."""
+        reason = getattr(error, "message", None) or str(error)
+        lines = reason.splitlines()
+        reason = lines[0] if lines else error.__class__.__name__
+        if len(reason) > 120:
+            reason = reason[:117] + "..."
+        return "%s (%s)" % (filename, reason)
+
+    def _preserveDamagedSave(self):
+        """Copy a slot that would not load aside, and tell the player about it.
+
+        The load handlers fall back to fresh objects, and save() runs at the
+        end of every loop iteration, so without this the player's first action
+        writes a brand-new character over the run that failed to load - bytes
+        that were recoverable by hand until that moment.
+
+        The whole slot is copied, not only the file that failed: restoring a
+        run needs player.json, stats.json and timeService.json together, so
+        keeping just the unreadable one would preserve nothing usable.
+
+        Returns the backup directory, or None if nothing could be copied."""
+        slotDirectory = os.path.dirname(
+            self.saveFileManager.get_save_path("player.json")
+        )
+        backupDirectory = os.path.join(
+            slotDirectory, "damaged-%s" % datetime.now().strftime("%Y%m%d-%H%M%S")
+        )
+
+        copied = []
+        try:
+            os.makedirs(backupDirectory, exist_ok=True)
+            for name in sorted(os.listdir(slotDirectory)):
+                source = os.path.join(slotDirectory, name)
+                if os.path.isfile(source):
+                    shutil.copy2(source, os.path.join(backupDirectory, name))
+                    copied.append(name)
+        except (IOError, OSError):
+            copied = []
+
+        if not copied:
+            # An empty or half-written backup is worse than none: it looks like
+            # a rescued save and would be trusted as one.
+            shutil.rmtree(backupDirectory, ignore_errors=True)
+            backupDirectory = None
+
+        if backupDirectory is not None:
+            # Same reason delete_save_slot flushes: under the browser front-end
+            # the copy exists only in the Worker's in-memory filesystem until
+            # it is mirrored to IndexedDB.
+            syncBrowserSaves()
+            whereItWent = (
+                "A copy of the slot as it was has been kept in:\n  %s\n\n"
+                % backupDirectory
+            )
+        else:
+            whereItWent = (
+                "The slot could not be copied aside, so it will be overwritten "
+                "as you play. Close the game now if you want to keep it.\n\n"
+            )
+
+        self.userInterface.showDialogue(
+            "This save could not be read, so a new game has been started in "
+            "its slot.\n\nWhat failed to load:\n  %s\n\n%sNothing you did "
+            "caused this - a save can be damaged by a crash or a power cut "
+            "while the game is writing to disk."
+            % ("\n  ".join(self.failedLoads), whereItWent)
+        )
+        return backupDirectory
+
+    def _writeSaveFile(self, filename, writeContents):
+        """Write one save file so a failure can never truncate the old one.
+
+        Opening the real path with mode "w" empties it before a single byte is
+        written, so a crash, a full disk or a kill mid-dump leaves a partial
+        file and no intact copy anywhere - which is how a slot becomes
+        unreadable in the first place. The contents go to a temporary file
+        beside the target instead, and os.replace() (atomic on POSIX and
+        Windows) swaps it in only once it is complete."""
+        path = self.saveFileManager.get_save_path(filename)
+        temporaryPath = path + ".tmp"
+        try:
+            with open(temporaryPath, "w") as saveFile:
+                writeContents(saveFile)
+            os.replace(temporaryPath, path)
+        except (IOError, OSError):
+            # A half-written temporary file is worth nothing and would only
+            # confuse a later recovery, so it goes; the previous save stays.
+            try:
+                os.remove(temporaryPath)
+            except OSError:
+                pass
+            raise
+
     def save(self):
         # create data directory - use SaveFileManager's directory
         if not os.path.exists(self.saveFileManager.data_directory):
             os.makedirs(self.saveFileManager.data_directory, exist_ok=True)
 
         try:
-            with open(
-                self.saveFileManager.get_save_path("player.json"), "w"
-            ) as playerSaveFile:
-                self.playerJsonReaderWriter.writePlayerToFile(
-                    self.player, playerSaveFile
-                )
-
-            with open(
-                self.saveFileManager.get_save_path("timeService.json"), "w"
-            ) as timeServiceSaveFile:
-                self.timeServiceJsonReaderWriter.writeTimeServiceToFile(
-                    self.timeService, timeServiceSaveFile
-                )
-
-            with open(
-                self.saveFileManager.get_save_path("stats.json"), "w"
-            ) as statsSaveFile:
-                self.statsJsonReaderWriter.writeStatsToFile(self.stats, statsSaveFile)
+            self._writeSaveFile(
+                "player.json",
+                lambda saveFile: self.playerJsonReaderWriter.writePlayerToFile(
+                    self.player, saveFile
+                ),
+            )
+            self._writeSaveFile(
+                "timeService.json",
+                lambda saveFile: self.timeServiceJsonReaderWriter.writeTimeServiceToFile(
+                    self.timeService, saveFile
+                ),
+            )
+            self._writeSaveFile(
+                "stats.json",
+                lambda saveFile: self.statsJsonReaderWriter.writeStatsToFile(
+                    self.stats, saveFile
+                ),
+            )
         except (IOError, OSError) as e:
-            print(f"\n Warning: Failed to save game: {e}")
+            # Said through the front-end rather than printed: stdout is not
+            # rendered at all by pygame or either web front-end, and the
+            # console clears it on the next screen. Repeated on every action
+            # that fails to save, because a run that is no longer being
+            # written down is exactly what the player must not miss.
+            self.userInterface.showDialogue(
+                "Your game could not be saved: %s\n\n"
+                "The run continues, but progress since the last successful "
+                "save is not on disk. Check for a full or read-only disk." % e
+            )
             # Game continues even if save fails
             return
 
@@ -317,8 +439,7 @@ class FishE:
                     playerSaveFile
                 )
         except (IOError, OSError, json.JSONDecodeError, ValidationError) as e:
-            print(f"\n Warning: Failed to load player data: {e}")
-            print(" Creating new player...")
+            self.failedLoads.append(self._describeLoadFailure("player.json", e))
             self.player = Player(self.config)
 
     def loadStats(self):
@@ -328,8 +449,7 @@ class FishE:
             ) as statsSaveFile:
                 self.stats = self.statsJsonReaderWriter.readStatsFromFile(statsSaveFile)
         except (IOError, OSError, json.JSONDecodeError, ValidationError) as e:
-            print(f"\n Warning: Failed to load stats data: {e}")
-            print(" Creating new stats...")
+            self.failedLoads.append(self._describeLoadFailure("stats.json", e))
             self.stats = Stats()
 
     def loadTimeService(self):
@@ -343,8 +463,7 @@ class FishE:
                     )
                 )
         except (IOError, OSError, json.JSONDecodeError, ValidationError) as e:
-            print(f"\n Warning: Failed to load time service data: {e}")
-            print(" Creating new time service...")
+            self.failedLoads.append(self._describeLoadFailure("timeService.json", e))
             self.timeService = TimeService(self.player, self.stats)
 
 

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -119,6 +119,10 @@ def createGameForPersistence(data_directory):
     saveFileManager = SaveFileManager(data_directory=data_directory)
     saveFileManager.select_save_slot(1)
     game.saveFileManager = saveFileManager
+    # __init__ sets both up before the load block; save()/load*() report through
+    # the front-end and record what would not load, so they are needed here too.
+    game.failedLoads = []
+    game.userInterface = MagicMock()
     return game
 
 
@@ -140,7 +144,12 @@ def createGameThroughInit(data_directory, saveFiles):
     os.makedirs(slot, exist_ok=True)
     for filename, contents in saveFiles.items():
         with open(os.path.join(slot, filename), "w") as f:
-            json.dump(contents, f)
+            # A raw string is written verbatim so a test can plant a damaged
+            # file; anything else is serialized as the JSON it stands for.
+            if isinstance(contents, str):
+                f.write(contents)
+            else:
+                json.dump(contents, f)
 
     config = Config()
     config.dataDirectory = data_directory
@@ -449,6 +458,200 @@ def test_save_handles_write_failure_without_raising():
         # call - must not raise even though writing to disk fails
         with patch("builtins.open", side_effect=IOError("disk full")):
             game.save()
+
+
+def test_save_failure_is_reported_through_the_front_end():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare
+        game = createGameForPersistence(data_directory)
+        game.player = Player()
+        game.stats = Stats()
+        game.timeService = TimeService(game.player, game.stats)
+
+        # call
+        with patch("builtins.open", side_effect=IOError("disk full")):
+            game.save()
+
+        # check - the player is told through the UI contract every front-end
+        # implements, rather than on a stdout none of them render
+        game.userInterface.showDialogue.assert_called_once()
+        said = game.userInterface.showDialogue.call_args[0][0]
+        assert "could not be saved" in said
+        assert "disk full" in said
+
+
+def test_save_leaves_no_temporary_files_behind():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare
+        game = createGameForPersistence(data_directory)
+        game.player = Player()
+        game.stats = Stats()
+        game.timeService = TimeService(game.player, game.stats)
+
+        # call
+        game.save()
+
+        # check - the temporary files the atomic write goes through are all
+        # renamed into place, so nothing ending in .tmp survives the save
+        slot = os.path.join(data_directory, "slot_1")
+        assert [name for name in os.listdir(slot) if name.endswith(".tmp")] == []
+
+
+def test_a_failed_save_does_not_truncate_the_previous_one():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - a slot holding a good save
+        game = createGameForPersistence(data_directory)
+        game.player = Player()
+        game.player.fishCount = 42
+        game.stats = Stats()
+        game.timeService = TimeService(game.player, game.stats)
+        game.save()
+
+        # call - the next save dies partway through writing player.json
+        game.player.fishCount = 99
+        with patch.object(
+            game.playerJsonReaderWriter,
+            "writePlayerToFile",
+            side_effect=IOError("disk full"),
+        ):
+            game.save()
+
+        # check - the save on disk is still the one that completed, not an
+        # empty file left behind by a truncating open()
+        reloaded = createGameForPersistence(data_directory)
+        reloaded.loadPlayer()
+        assert reloaded.player.fishCount == 42
+        slot = os.path.join(data_directory, "slot_1")
+        assert [name for name in os.listdir(slot) if name.endswith(".tmp")] == []
+
+
+def corruptPlayerSlot():
+    """A slot whose player.json is unreadable beside two intact files."""
+    return {
+        "player.json": "{ not valid json",
+        "stats.json": StatsJsonReaderWriter().createJsonFromStats(Stats()),
+        "timeService.json": TimeServiceJsonReaderWriter().createJsonFromTimeService(
+            TimeService(Player(), Stats())
+        ),
+    }
+
+
+def damagedBackupDirectories(data_directory):
+    slot = os.path.join(data_directory, "slot_1")
+    return sorted(name for name in os.listdir(slot) if name.startswith("damaged-"))
+
+
+def test_load_failure_is_reported_through_the_front_end_not_stdout(capsys):
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - a slot whose player.json cannot be parsed
+        game = createGameThroughInit(data_directory, corruptPlayerSlot())
+
+        # check - said through the front-end, naming the file that failed
+        said = "\n".join(
+            call[0][0] for call in game.userInterface.showDialogue.call_args_list
+        )
+        assert "player.json" in said
+        assert "new game has been started" in said
+        # nothing on stdout, which no front-end renders
+        assert "player.json" not in capsys.readouterr().out
+
+
+def test_load_failure_names_every_file_that_failed_in_one_dialogue():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - two of the three files are unreadable
+        saveFiles = corruptPlayerSlot()
+        saveFiles["stats.json"] = "{ not valid json either"
+        game = createGameThroughInit(data_directory, saveFiles)
+
+        # check - one dialogue, both files named
+        game.userInterface.showDialogue.assert_called_once()
+        said = game.userInterface.showDialogue.call_args[0][0]
+        assert "player.json" in said
+        assert "stats.json" in said
+
+
+def test_a_schema_failure_is_described_in_one_short_line():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - a syntactically valid save with an out-of-range value,
+        # which jsonschema reports as a multi-paragraph dump of instance and
+        # schema; a dialogue box can show no such thing
+        savedPlayer = PlayerJsonReaderWriter().createJsonFromPlayer(Player())
+        savedPlayer["homeTier"] = 99
+        game = createGameThroughInit(data_directory, {"player.json": savedPlayer})
+
+        # check - the reason is named, on one trimmed line
+        said = game.userInterface.showDialogue.call_args[0][0]
+        described = [line for line in said.splitlines() if "player.json" in line]
+        assert len(described) == 1
+        assert len(described[0]) < 160
+
+
+def test_describeLoadFailure_trims_a_reason_too_long_for_a_dialogue():
+    # prepare
+    game = fishE.FishE.__new__(fishE.FishE)
+
+    # call
+    described = game._describeLoadFailure("player.json", IOError("x" * 500))
+
+    # check - named, trimmed, and marked as trimmed
+    assert described.startswith("player.json (")
+    assert described.endswith("...)")
+    assert len(described) < 160
+
+
+def test_a_save_that_fails_to_load_is_copied_aside_before_it_is_overwritten():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare - remember the bytes of the whole slot before the game runs
+        saveFiles = corruptPlayerSlot()
+        game = createGameThroughInit(data_directory, saveFiles)
+        slot = os.path.join(data_directory, "slot_1")
+
+        # call - the first action of the fresh fallback game writes the slot
+        game.save()
+
+        # check - one backup directory holds every file as it was, so the run
+        # that would not load is still recoverable by hand
+        backups = damagedBackupDirectories(data_directory)
+        assert len(backups) == 1
+        backup = os.path.join(slot, backups[0])
+        assert sorted(os.listdir(backup)) == [
+            "player.json",
+            "stats.json",
+            "timeService.json",
+        ]
+        with open(os.path.join(backup, "player.json")) as f:
+            assert f.read() == "{ not valid json"
+
+
+def test_a_slot_that_loads_cleanly_is_not_copied_aside():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - an intact save
+        createGameThroughInit(
+            data_directory,
+            {
+                "player.json": PlayerJsonReaderWriter().createJsonFromPlayer(Player()),
+                "stats.json": StatsJsonReaderWriter().createJsonFromStats(Stats()),
+                "timeService.json": TimeServiceJsonReaderWriter().createJsonFromTimeService(
+                    TimeService(Player(), Stats())
+                ),
+            },
+        )
+
+        # check
+        assert damagedBackupDirectories(data_directory) == []
+
+
+def test_a_damaged_save_that_cannot_be_copied_aside_says_so():
+    with tempfile.TemporaryDirectory() as data_directory:
+        # prepare/call - the copy itself fails
+        with patch("src.fishE.shutil.copy2", side_effect=OSError("read-only")):
+            game = createGameThroughInit(data_directory, corruptPlayerSlot())
+
+        # check - the player is warned the slot will be overwritten rather
+        # than being told about a backup that does not exist
+        said = game.userInterface.showDialogue.call_args[0][0]
+        assert "could not be copied aside" in said
+        assert damagedBackupDirectories(data_directory) == []
 
 
 def test_selectSaveFile_new_game_selects_next_slot():

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -601,9 +601,9 @@ def test_describeLoadFailure_trims_a_reason_too_long_for_a_dialogue():
 
 def test_a_save_that_fails_to_load_is_copied_aside_before_it_is_overwritten():
     with tempfile.TemporaryDirectory() as data_directory:
-        # prepare - remember the bytes of the whole slot before the game runs
-        saveFiles = corruptPlayerSlot()
-        game = createGameThroughInit(data_directory, saveFiles)
+        # prepare - a slot whose player.json cannot be parsed, loaded by a
+        # game that therefore falls back to a brand-new character
+        game = createGameThroughInit(data_directory, corruptPlayerSlot())
         slot = os.path.join(data_directory, "slot_1")
 
         # call - the first action of the fresh fallback game writes the slot

--- a/tests/test_saveFileManager.py
+++ b/tests/test_saveFileManager.py
@@ -59,6 +59,32 @@ def test_list_save_files_with_saves():
         shutil.rmtree(temp_dir)
 
 
+def test_list_save_files_ignores_a_damaged_save_backup_inside_a_slot():
+    # A slot the game could not read gets copied into a "damaged-..."
+    # subdirectory of itself (see FishE._preserveDamagedSave), which must stay
+    # invisible to the menu rather than being offered as a slot of its own.
+    temp_dir = tempfile.mkdtemp()
+    try:
+        manager = SaveFileManager(temp_dir)
+
+        slot_path = os.path.join(temp_dir, "slot_1")
+        backup_path = os.path.join(slot_path, "damaged-20260101-000000")
+        os.makedirs(backup_path)
+
+        for directory in (slot_path, backup_path):
+            with open(os.path.join(directory, "player.json"), "w") as f:
+                json.dump({"money": 100, "fishCount": 5, "energy": 80}, f)
+            with open(os.path.join(directory, "timeService.json"), "w") as f:
+                json.dump({"day": 3, "time": 10}, f)
+
+        save_files = manager.list_save_files()
+        assert len(save_files) == 1
+        assert save_files[0]["slot"] == 1
+        assert manager.get_next_available_slot() == 2
+    finally:
+        shutil.rmtree(temp_dir)
+
+
 def test_list_save_files_ignores_invalid_names():
     """Test that list_save_files ignores directories with invalid names"""
     temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary

Two failure modes around save files were addressed, both of which cost a player their whole run without a word on screen.

**Save and load errors are now shown through the front-end contract (#142).** They were reported with `print()`, which reaches nobody: stdout is not rendered at all by the pygame front-end or by either browser front-end, and on the console it is wiped by the `lotsOfSpace()` at the top of the next screen. `showDialogue` is used instead — an abstract primitive on `BaseUserInterface`, so all four front-ends were served by the one change rather than one of them.

**A save that will not load is no longer overwritten by the fresh game that replaces it (#143).** Two independent changes:

- Writes are made atomic. Each file is written to a temporary file beside the target and swapped in with `os.replace` (atomic on POSIX and Windows) once complete. Previously each path was opened with mode `"w"`, which truncates it before a single byte is written — so a crash, a full disk or a kill mid-dump left a partial file and no intact copy anywhere, which is how a slot became unreadable to begin with.
- A slot that would not load is copied into a `damaged-<date>-<time>` subdirectory of itself before the fallback game is allowed to write. The whole slot is copied rather than only the file that failed, because restoring a run needs `player.json`, `stats.json` and `timeService.json` together. Under the Pyodide front-end the copy is flushed to IndexedDB, for the same reason `delete_save_slot` flushes.

Supporting details:

- The failed loads are collected and reported in one dialogue rather than one per file, so a slot with three bad files costs one acknowledgement.
- Each reason is trimmed to a single short line. `jsonschema`'s `ValidationError` renders as a multi-paragraph dump of the whole instance and schema; its `.message` is the one-line reason, and no dialogue box could show the former.
- A failed save is reported on every action that fails, rather than once. A run that is no longer being written down is judged to be exactly the thing a player must not be allowed to miss.
- `README.md`'s "Multiple Save Files" section was extended to describe the atomic write and what a `damaged-...` folder in a slot is.

One residual risk is recorded rather than hidden: `os.replace` over an existing file was not exercised under Pyodide in this environment. Emscripten's `FS.rename` unlinks an existing destination, so it is expected to behave, but it was verified by reading rather than by running.

Closes #142
Closes #143

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `python3 -m pytest --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — 781 passed, `src/fishE.py` at 99% (the only uncovered lines being the pre-existing `if __name__ == "__main__"` block)
- [x] `black` and `autoflake` run over the changed files only
- [x] Front-ends: no per-front-end code was needed. Every new message goes through `BaseUserInterface.showDialogue`, which `UserInterface` (console), `PygameUserInterface`, `WebUserInterface` and `PyodideUserInterface` (a subclass of `WebUserInterface`) all implement. The rendered text was printed and checked for length and line breaks; pygame's `_wrapText`/`_splitLongWord` handles the long backup path.
- [x] New tests cover: the save-failure dialogue, no `.tmp` file surviving a save, a failed save leaving the previous one intact, the load-failure dialogue reaching the front-end and not stdout, several failures folded into one dialogue, a schema failure described in one short line, an over-long reason being trimmed, the whole slot being copied aside before the fallback game overwrites it, a clean slot not being copied aside, and a copy that itself fails saying so.
- [x] `tests/test_saveFileManager.py` gained a regression test that the new nested `damaged-...` directory stays invisible to the save menu and does not disturb `get_next_available_slot()`.

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).
