### PR TITLE
Report the overnight fleet news everywhere a day rolls over

### DIFF
--- a/src/fishE.py
+++ b/src/fishE.py
@@ -10,7 +10,7 @@ from prompt.prompt import Prompt
 from player.playerJsonReaderWriter import PlayerJsonReaderWriter
 from stats.statsJsonReaderWriter import StatsJsonReaderWriter
 from world.timeServiceJsonReaderWriter import TimeServiceJsonReaderWriter
-from world.timeService import TimeService
+from world.timeService import TimeService, appendDayReport
 from stats.stats import Stats
 from ui.userInterfaceFactory import UserInterfaceFactory
 from ui.enum.uiType import UIType
@@ -18,7 +18,6 @@ from saveFileManager import SaveFileManager
 from browserSaveSync import syncBrowserSaves
 from achievements import achievements
 from achievements.achievements import GOAL_AMOUNT, GOAL_MILESTONE_NAME
-from housing import housing
 from progression import progression
 from config.config import Config
 
@@ -306,12 +305,15 @@ class FishE:
             # announce reaching the wealth goal once (the run continues)
             self.announceGoalIfReached()
 
-            # increase time - almost any action can roll a day over, so this
-            # is the one place guaranteed to catch an eviction regardless of
-            # what triggered it (appended so the action's own message is
-            # preserved on the next screen, same as milestones above)
-            if self.timeService.increaseTime()["evicted"]:
-                self.prompt.text += "  " + housing.EVICTION_MESSAGE
+            # increase time - almost any action can roll a day over, so this is
+            # the one place guaranteed to catch an eviction (and the fleet's
+            # overnight takings) regardless of what triggered it. Two spaces
+            # because this is appended to whatever the action itself already
+            # wrote, and is preserved on the next screen the same way the
+            # milestones above are.
+            appendDayReport(
+                self.prompt, self.timeService.increaseTime(), separator="  "
+            )
 
             self.save()
 

--- a/src/location/docks.py
+++ b/src/location/docks.py
@@ -3,7 +3,7 @@ import random
 from location.enum.locationType import LocationType
 from player.player import Player
 from prompt.prompt import Prompt
-from world.timeService import TimeService
+from world.timeService import TimeService, appendDayReport, dayReportLines
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
@@ -13,7 +13,6 @@ from business import business
 from business import boats
 from business import export
 from business import adventures
-from housing import housing
 from progression import progression
 
 
@@ -920,11 +919,15 @@ class Docks:
             outcome = adventures.resolveChoice(voyage, choices[picked - 1])
             notes = adventures.advanceLeg(voyage)
 
-            self.userInterface.showDialogue(
-                "\n".join([outcome] + notes) if notes else outcome
-            )
-            # A day at sea is a day at home too.
-            self.timeService.increaseDay()
+            # A day at sea is a day at home too - the fleet still lands its
+            # catch and rent still comes due while the player is away. The
+            # day rolls before the dialogue is built so its news goes on the
+            # same screen as the leg that caused it; dropping it is how a
+            # player could sail a five-day voyage and come home evicted with
+            # nothing on screen having said so.
+            dayLines = dayReportLines(self.timeService.increaseDay())
+
+            self.userInterface.showDialogue("\n".join([outcome] + notes + dayLines))
 
         self._endVoyage(voyage)
 
@@ -972,14 +975,6 @@ class Docks:
             else "  Hull     sound"
         )
         return "\n".join(lines)
-
-    def _reportTheDay(self, summary):
-        """Append what happened while a day passed - the fleet's overnight
-        takings, and anything that went wrong at home."""
-        for line in summary.get("report", []):
-            self.currentPrompt.text += " " + line
-        if summary["evicted"]:
-            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
 
     def _exportStatus(self):
         """What the next export run would look like, shown above the market
@@ -1076,7 +1071,7 @@ class Docks:
         # The round trip is what stops exporting from being a free repeatable
         # action, so the day passes here (and everything a new day brings -
         # the crew's catch, wages, rent - happens while you're away).
-        self._reportTheDay(self.timeService.increaseDay())
+        appendDayReport(self.currentPrompt, self.timeService.increaseDay())
         return True
 
     def _exportRefusal(self, summary, market):
@@ -1181,14 +1176,17 @@ class Docks:
             quality, qualityLabel = 0.25, "The fish nearly got away."
 
         # Spend the fishing hours: time passes and energy is consumed. A long
-        # enough trip can cross a day boundary (and so, e.g., miss a rent
-        # payment) without the player ever seeing a "new day" screen, so
-        # track that across the loop to mention it in the trip's own report.
-        evicted = False
+        # enough trip can cross a day boundary - missing a rent payment, or
+        # landing the fleet's catch - without the player ever seeing a "new
+        # day" screen, so the day's news is collected here and folded into the
+        # trip's own report below. It has to be collected rather than appended
+        # as it happens, because that report is written further down and would
+        # overwrite anything put on the prompt now. A trip runs 1-10 hours, so
+        # it crosses at most one 8am boundary and these lines can't stack up.
+        dayLines = []
         for i in range(hours):
             self.stats.hoursSpentFishing += 1
-            if self.timeService.increaseTime()["evicted"]:
-                evicted = True
+            dayLines += dayReportLines(self.timeService.increaseTime())
             self.player.spendEnergy(10)  # Consume 10 energy per hour
 
         baseFish = random.randint(1, 10)
@@ -1216,8 +1214,10 @@ class Docks:
         if weatherLabel:
             self.currentPrompt.text += " " + weatherLabel
 
-        if evicted:
-            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
+        # What the fleet did while the player was out on the water, and the
+        # eviction notice if a day turned over mid-trip.
+        for line in dayLines:
+            self.currentPrompt.text += " " + line
 
     def talkToNPC(self):
         self.userInterface.showInteractiveDialogue(self.npc)

--- a/src/location/home.py
+++ b/src/location/home.py
@@ -1,7 +1,7 @@
 from location.enum.locationType import LocationType
 from player.player import Player
 from prompt.prompt import Prompt
-from world.timeService import TimeService
+from world.timeService import TimeService, appendDayReport
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from achievements import achievements
@@ -84,10 +84,7 @@ class Home:
         )
         # What the fleet did overnight, so a crew lost or a hull damaged is
         # news the player is told rather than something they discover later.
-        for line in summary.get("report", []):
-            self.currentPrompt.text += " " + line
-        if summary["evicted"]:
-            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
+        appendDayReport(self.currentPrompt, summary)
 
     def _moveCostLabel(self, netCost):
         if netCost > 0:

--- a/src/location/tavern.py
+++ b/src/location/tavern.py
@@ -4,13 +4,12 @@ from location.enum.locationType import LocationType
 
 from player.player import Player
 from prompt.prompt import Prompt
-from world.timeService import TimeService
+from world.timeService import TimeService, appendDayReport
 from stats.stats import Stats
 from ui.userInterface import UserInterface
 from npc.npc import NPC
 from npc import villagers
 from business import business
-from housing import housing
 from progression import progression
 
 
@@ -222,11 +221,7 @@ class Tavern:
         else:
             self.currentPrompt.text = "You have a headache."
 
-        summary = self.timeService.increaseDay()
-        for line in summary.get("report", []):
-            self.currentPrompt.text += " " + line
-        if summary["evicted"]:
-            self.currentPrompt.text += " " + housing.EVICTION_MESSAGE
+        appendDayReport(self.currentPrompt, self.timeService.increaseDay())
 
     def gamble(self):
         while True:

--- a/src/world/timeService.py
+++ b/src/world/timeService.py
@@ -73,3 +73,35 @@ class TimeService:
             "evicted": rentSummary["evicted"],
             "report": boats.describeDay(fleetSummary),
         }
+
+
+def dayReportLines(summary):
+    """What the player has to be told about a day that just passed.
+
+    Takes increaseDay()'s (or increaseTime()'s) return value and turns it into
+    display lines: the fleet's overnight takings, then the eviction notice if
+    rent went unpaid.
+
+    Lives beside the producer because reading only "evicted" and dropping
+    "report" is the mistake this is here to stop being possible - a player
+    could sail a multi-day voyage and come home a crew member short, or
+    homeless, without a line of text saying so. increaseTime() returns
+    {"evicted": False, "report": []} on the hours that don't roll a day, so
+    every caller can pass its return value straight in without first checking
+    whether a day actually turned over; the result is simply empty."""
+    lines = list(summary.get("report", []))
+    if summary.get("evicted"):
+        lines.append(housing.EVICTION_MESSAGE)
+    return lines
+
+
+def appendDayReport(prompt, summary, separator=" "):
+    """Append dayReportLines() to the prompt the player is about to be shown.
+
+    separator is the gap placed before each line. It defaults to one space,
+    which is what a location uses when the line continues a sentence it just
+    wrote ("You sleep until the next morning. ..."). FishE's game loop passes
+    two, because there the day's news is being appended to whatever a
+    completely different subsystem already put on the screen."""
+    for line in dayReportLines(summary):
+        prompt.text += separator + line

--- a/tests/location/test_docks.py
+++ b/tests/location/test_docks.py
@@ -1330,7 +1330,7 @@ def test_exportFish_reports_an_eviction_from_the_day_that_passed():
 
     def evictOnNewDay():
         docksInstance.player.homeTier = 0
-        return {"evicted": True}
+        return {"evicted": True, "report": ["The Marauder landed 9 fish."]}
 
     docksInstance.timeService.increaseDay = MagicMock(side_effect=evictOnNewDay)
     docksInstance.userInterface.showOptions = MagicMock(return_value="1")
@@ -1338,8 +1338,10 @@ def test_exportFish_reports_an_eviction_from_the_day_that_passed():
     # call
     docksInstance.exportFish()
 
-    # check - the trip report mentions what happened while the player was away
+    # check - the trip report mentions what happened while the player was away:
+    # both the eviction and the fleet's own takings for the day.
     assert housing.EVICTION_MESSAGE in docksInstance.currentPrompt.text
+    assert "The Marauder landed 9 fish." in docksInstance.currentPrompt.text
 
 
 def createSailingDocks(role=None, tier=3, crew=2, damage=0, money=5000):
@@ -2082,3 +2084,58 @@ def test_repair_menu_greys_out_a_hull_the_player_cannot_pay_for():
     call = docksInstance.userInterface.showOptions.call_args
     assert call[0][2] == {1: "repair costs $%d" % cost}
     assert call[0][1][-1] == "Back"
+
+
+def test_fish_reports_what_the_fleet_did_while_the_player_was_on_the_water():
+    # A trip long enough to cross 8am used to read only the "evicted" flag and
+    # drop the fleet's overnight report, so a crew member who didn't come back
+    # went unmentioned until the player happened to open Manage Fleet.
+    docksInstance = createDocks()
+    docksInstance.userInterface.lotsOfSpace = MagicMock()
+    docksInstance.userInterface.divider = MagicMock()
+    docksInstance.userInterface.timedKeyPress = MagicMock(return_value=0.5)
+
+    with patch("src.location.docks.random.randint", side_effect=[3, 6]):
+        # the day rolls over partway through the trip, with news
+        docksInstance.timeService.increaseTime = MagicMock(
+            side_effect=[
+                {"evicted": False, "report": []},
+                {"evicted": False, "report": ["The Marauder came home a man short."]},
+                {"evicted": False, "report": []},
+            ]
+        )
+
+        # call
+        docksInstance.fish()
+
+    # check - the trip's own message still leads, with the day's news after it
+    assert "You caught" in docksInstance.currentPrompt.text
+    assert "The Marauder came home a man short." in docksInstance.currentPrompt.text
+
+
+def test_a_voyage_leg_reports_what_happened_back_home():
+    # Each leg rolls a day, which runs wages, rent and eviction at home. The
+    # leg used to bind nothing from increaseDay(), so a player could sail a
+    # multi-day voyage and come home evicted with nothing having said so.
+    docksInstance, boat = createSailingDocks()
+    docksInstance.userInterface.showOptions = MagicMock(
+        side_effect=voyageChooser(
+            "Marauder", "A short run", "Full stores", then="first"
+        )
+    )
+    docksInstance.userInterface.showDialogue = MagicMock()
+    docksInstance.timeService.increaseDay = MagicMock(
+        return_value={"evicted": True, "report": ["The fleet landed 9 fish."]}
+    )
+
+    # call
+    with patch("src.business.adventures.random.randint", return_value=0):
+        with patch("src.business.adventures.random.random", return_value=0.99):
+            docksInstance.takeTheHelm()
+
+    # check - the news is on the same screen as the leg that caused it
+    said = "\n".join(
+        call[0][0] for call in docksInstance.userInterface.showDialogue.call_args_list
+    )
+    assert "The fleet landed 9 fish." in said
+    assert housing.EVICTION_MESSAGE in said

--- a/tests/location/test_home.py
+++ b/tests/location/test_home.py
@@ -550,3 +550,21 @@ def test_manageHome_marks_nothing_when_every_move_is_affordable():
 
     # check
     assert markedOptions(homeInstance) == {}
+
+
+def test_sleep_reports_what_the_fleet_did_overnight():
+    # Sleeping is the commonest way a day passes, so the overnight report has to
+    # survive the shared helper this site now routes through.
+    homeInstance = createHome()
+    homeInstance.timeService.increaseDay = MagicMock(
+        return_value={"evicted": False, "report": ["The Marauder landed 12 fish."]}
+    )
+
+    # call
+    homeInstance.sleep()
+
+    # check - the night's own message leads, the fleet's news follows
+    assert homeInstance.currentPrompt.text.startswith(
+        "You sleep until the next morning"
+    )
+    assert "The Marauder landed 12 fish." in homeInstance.currentPrompt.text

--- a/tests/location/test_tavern.py
+++ b/tests/location/test_tavern.py
@@ -673,3 +673,22 @@ def test_gamble_frees_the_dice_once_a_bet_is_on_the_table():
 
     # check
     assert markedOptions(tavernInstance) == {}
+
+
+def test_getDrunk_reports_what_the_fleet_did_overnight():
+    # Drinking rolls the day over the same way sleeping does, so it owes the
+    # player the same overnight report.
+    from src.housing import housing
+
+    tavernInstance = createTavern()
+    tavernInstance.player.money = tavern.DRINK_COST
+    tavernInstance.timeService.increaseDay = MagicMock(
+        return_value={"evicted": True, "report": ["The Marauder landed 12 fish."]}
+    )
+
+    # call
+    tavernInstance.getDrunk()
+
+    # check
+    assert "The Marauder landed 12 fish." in tavernInstance.currentPrompt.text
+    assert housing.EVICTION_MESSAGE in tavernInstance.currentPrompt.text

--- a/tests/test_fishE.py
+++ b/tests/test_fishE.py
@@ -1124,3 +1124,39 @@ def test_play_announces_one_unlock_per_screen():
     ]
     assert len(announcements) == 1
     assert game.stats.unlockedFeatures == [progression.SHOP]
+
+
+def test_play_appends_the_overnight_fleet_report():
+    # The hourly tick is the one place guaranteed to run whatever the player
+    # did, and it used to read only "evicted" - dropping the fleet's overnight
+    # report on any action that happened to roll the day over.
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.timeService.increaseTime.return_value = {
+        "evicted": False,
+        "report": ["The Marauder landed 12 fish."],
+    }
+
+    # call
+    game.play()
+
+    # check
+    assert "The Marauder landed 12 fish." in game.prompt.text
+
+
+def test_play_appends_the_fleet_report_and_the_eviction_together():
+    # Both halves of the day's news survive the same tick, separated from the
+    # action's own message by the game loop's wider gap.
+    game = createGameForPlay()
+    game.locations[LocationType.HOME].run.return_value = LocationType.NONE
+    game.timeService.increaseTime.return_value = {
+        "evicted": True,
+        "report": ["The Marauder landed 12 fish."],
+    }
+
+    # call
+    game.play()
+
+    # check
+    assert "The Marauder landed 12 fish." in game.prompt.text
+    assert housing.EVICTION_MESSAGE in game.prompt.text

--- a/tests/world/test_timeService.py
+++ b/tests/world/test_timeService.py
@@ -3,7 +3,13 @@ from unittest.mock import patch
 
 from src.player.player import Player
 from src.stats.stats import Stats
-from src.world.timeService import TimeService
+from src.housing import housing
+from src.prompt.prompt import Prompt
+from src.world.timeService import (
+    TimeService,
+    appendDayReport,
+    dayReportLines,
+)
 
 
 def createTimeService():
@@ -202,3 +208,58 @@ def test_increaseDay_rolls_new_weather():
     # check - weather was rolled from the documented option pool
     mockChoice.assert_called_once_with(WEATHER_OPTIONS)
     assert timeService.weather == "stormy"
+
+
+def test_dayReportLines_carries_the_fleet_report_and_the_eviction_notice():
+    # Both halves of increaseDay()'s contract, in the order the player reads
+    # them: what the fleet did, then what went wrong at home.
+    lines = dayReportLines(
+        {"evicted": True, "report": ["The Marauder landed 12 fish.", "Bess quit."]}
+    )
+
+    assert lines == [
+        "The Marauder landed 12 fish.",
+        "Bess quit.",
+        housing.EVICTION_MESSAGE,
+    ]
+
+
+def test_dayReportLines_is_empty_on_an_hour_that_does_not_roll_a_day():
+    # increaseTime() returns this shape 23 hours out of 24, so every caller can
+    # pass its return value straight in without checking first.
+    assert dayReportLines({"evicted": False, "report": []}) == []
+
+
+def test_dayReportLines_tolerates_a_summary_with_no_report_key():
+    # Callers that only ever produced an eviction flag (and tests that mock
+    # increaseTime with just {"evicted": ...}) must not raise here.
+    assert dayReportLines({"evicted": False}) == []
+    assert dayReportLines({"evicted": True}) == [housing.EVICTION_MESSAGE]
+
+
+def test_appendDayReport_appends_nothing_when_no_day_passed():
+    prompt = Prompt("You caught 3 cod.")
+
+    appendDayReport(prompt, {"evicted": False, "report": []})
+
+    assert prompt.text == "You caught 3 cod."
+
+
+def test_appendDayReport_separator_defaults_to_one_space():
+    prompt = Prompt("You sleep until the next morning.")
+
+    appendDayReport(prompt, {"evicted": False, "report": ["The fleet landed 4 fish."]})
+
+    assert prompt.text == ("You sleep until the next morning. The fleet landed 4 fish.")
+
+
+def test_appendDayReport_honours_a_wider_separator():
+    # FishE's game loop passes two spaces, because there the day's news is
+    # appended to text a different subsystem already wrote.
+    prompt = Prompt("You bought a rod.")
+
+    appendDayReport(
+        prompt, {"evicted": False, "report": ["The fleet landed 4 fish."]}, "  "
+    )
+
+    assert prompt.text == "You bought a rod.  The fleet landed 4 fish."


### PR DESCRIPTION
## Summary

`TimeService.increaseDay()` returns `{"evicted": bool, "report": [str]}`, and its own docstring states the contract: *"a pirate crew can come home a man short, the player has to be told rather than left to notice their roster changed."* `README.md:75` makes the same promise. Three of the six places a day rolls over honoured it; three read only `evicted` and dropped `report`.

**Fixed — the three that dropped it:**

- **A captained voyage leg** (`docks.py`) bound *nothing* from `increaseDay()`. Each leg runs wages, rent, crew walkouts and possible eviction, so a player could sail a five-day voyage and come home homeless without a single line of text saying so.
- **A fishing trip long enough to cross 8am** read only `evicted`, so a crew member who didn't come back went unmentioned until the player happened to open Manage Fleet.
- **`FishE`'s hourly tick** — the one place guaranteed to run whatever the player did — read only `evicted`.

## What changed

The three sites that *did* work were three hand-rolled copies of the same loop (`home.py` and `tavern.py` were character-identical to `Docks._reportTheDay`'s body). All six now go through two functions added next to the producer in `timeService.py`:

- `dayReportLines(summary)` — the display lines: the fleet's takings, then the eviction notice. Lives beside `increaseDay` so reading one half of the contract and dropping the other stops being the easy thing to write. Tolerates a summary with no `report` key, so callers (and existing tests) that only ever produced an eviction flag don't raise.
- `appendDayReport(prompt, summary, separator=" ")` — appends those lines to a prompt.

`Docks._reportTheDay` — a fourth copy, then a one-line passthrough — is gone; its single call site calls the shared helper directly.

Two call sites needed more than a swap:

- **The voyage leg** now rolls the day *before* building its dialogue, so the news lands on the same screen as the leg that caused it rather than a screen later. The `"\n".join([outcome] + notes) if notes else outcome` conditional was redundant (joining a one-item list returns the item) and collapsed into the unconditional join.
- **The fishing trip** collects its lines across the hour loop and folds them into the trip report, because that report is written *after* the loop and would otherwise overwrite anything put on the prompt during it. A trip is 1–10 hours, so it crosses at most one 8am boundary and the lines can't stack up.

`separator` exists because `FishE`'s loop deliberately uses a wider gap — there the day's news is appended to text a *different* subsystem already wrote, which isn't true of the location sites. This also resolves the spacing inconsistency the issue flagged, by making it an explicit parameter with a stated reason rather than an accident.

## Verification

The existing 791 tests all passed **before** this fix, which is why the bug survived — no test covered the reporting at any of the six sites except the eviction flag. So the new tests were checked against a simulated regression: with `dayReportLines` stubbed to drop the report, exactly these fail, and nothing else does.

```
test_fish_reports_what_the_fleet_did_while_the_player_was_on_the_water
test_a_voyage_leg_reports_what_happened_back_home
test_sleep_reports_what_the_fleet_did_overnight
test_getDrunk_reports_what_the_fleet_did_overnight
test_play_appends_the_overnight_fleet_report
test_play_appends_the_fleet_report_and_the_eviction_together
test_dayReportLines_carries_the_fleet_report_and_the_eviction_notice
test_appendDayReport_separator_defaults_to_one_space
test_appendDayReport_honours_a_wider_separator
```

All six sites are now guarded: the export site's existing eviction test was extended to assert the fleet report too, so a future per-site drift fails the build instead of going quiet.

## Test plan

- [x] `python3 -m compileall -q src tests`
- [x] `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python3 -m pytest --verbose -vv --cov=src --cov-report=term-missing --cov-report=xml:cov.xml` — **803 passed**, 97% total coverage
- [x] Confirmed the new tests fail against a simulated re-introduction of the bug (above), so they test the fix rather than the code
- [x] **Front-end parity:** no front-end code touched. The day report reaches the player as prompt text or, on a voyage leg, inside an existing `showDialogue` call — both already front-end agnostic, so console, pygame, web and Pyodide all get it through the same path with no per-UI work.
- [x] **Schemas:** no `Player`/`Stats`/`TimeService` field added, renamed or retyped, so no `schemas/*.json` change applies.
- [x] **Docs:** `README.md:75` already promised this overnight report — the fix makes that promise true at all six sites instead of three, so no wording change was needed. `PLANNING.md` unaffected.
- [x] `black`/`autoflake` per `format.sh`; `housing` became an unused import in `docks.py`, `tavern.py` and `fishE.py` and was removed. Only the ten files in this diff are touched.

Closes #151

---

_drafted by Claude on behalf of Daniel Stephenson_