### PR TITLE
Name FISHE_WEB_PORT when a web port is busy or misspelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ python3 web/serve.py
 # then open http://127.0.0.1:8080
 ```
 
+Set `FISHE_WEB_PORT` to serve on a different port (and `FISHE_WEB_HOST`, e.g. `0.0.0.0`, to be reachable from outside the machine); both entry points name that variable if the port they were given is misspelled or already taken.
+
 `web/serve.py` only serves files — it never runs the game. It does have to send the `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers it sets, though: without them the page is not cross-origin isolated, `SharedArrayBuffer` is unavailable, and the browser cannot deliver your input to the game. Any proxy placed in front of it must preserve those headers.
 
 **On a server (`UIType.WEB`)** — the game runs in the Python process and the browser is a terminal for it, with save files on the server's disk under `data/`. Handy for playing over a terminal-less machine on your own network, but everyone who opens the page shares one game and one set of saves:

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import queue
@@ -144,6 +145,30 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def _bindServer(host, port, handler):
+    """Start the game's HTTP server, turning a refused address into a sentence.
+
+    The front-end does not exist yet at this point, so there is no showDialogue
+    to say it through: a port that is already listening - a second copy of the
+    game, most often - would otherwise reach the player as an errno raised from
+    inside http.server, naming neither FishE nor FISHE_WEB_PORT, which is what
+    they would have to change."""
+    try:
+        return ThreadingHTTPServer((host, port), handler)
+    except OSError as e:
+        if e.errno == errno.EADDRINUSE:
+            reason = "something else is already listening there"
+        elif e.errno == errno.EACCES:
+            reason = "this process is not allowed to use that port"
+        else:
+            reason = str(e)
+        raise OSError(
+            f"FishE's web front-end could not be served at http://{host}:{port}/: "
+            f"{reason}. Set FISHE_WEB_PORT to a free port (or FISHE_WEB_HOST to "
+            f"an address this machine can bind) and start the game again."
+        ) from e
+
+
 def _makeRequestHandler(ui):
     """Build a request handler bound to a specific WebUserInterface instance."""
 
@@ -219,7 +244,7 @@ class WebUserInterface(BaseUserInterface):
         self._inputQueue = queue.Queue()
         self._server = None
         if start_server:
-            self._server = ThreadingHTTPServer((host, port), _makeRequestHandler(self))
+            self._server = _bindServer(host, port, _makeRequestHandler(self))
             self._server.daemon_threads = True
             threading.Thread(target=self._server.serve_forever, daemon=True).start()
 

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -6,6 +6,8 @@ import threading
 import urllib.error
 import urllib.request
 
+import pytest
+
 # Use the bare `ui.*`/`player.*` import style (matching production) so class
 # identities line up with the runtime MRO; pytest.ini exposes both `.` and `src`.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
@@ -392,3 +394,21 @@ def test_client_stops_polling_once_the_game_has_ended():
     page = webUserInterface.htmlPage()
 
     assert 'state.screen.type === "ended"' in page
+
+
+def test_taken_port_is_explained_rather_than_traced():
+    # The front-end does not exist yet when the bind fails, so there is no
+    # showDialogue to say it through - a second copy of the game would
+    # otherwise reach the player as an errno raised from inside http.server.
+    running = makeWebUI(start_server=True)
+    port = running.address[1]
+    try:
+        with pytest.raises(OSError) as raised:
+            makeWebUI(start_server=True, port=port)
+    finally:
+        running.cleanup()
+
+    message = str(raised.value)
+    assert "FISHE_WEB_PORT" in message
+    assert "already listening" in message
+    assert str(port) in message

--- a/tests/web/test_serve.py
+++ b/tests/web/test_serve.py
@@ -2,7 +2,9 @@ import threading
 import urllib.error
 import urllib.request
 
-from web.serve import _Handler, _Server
+import pytest
+
+from web.serve import _bindServer, _Handler, _resolvePort, _Server
 
 
 def startServer():
@@ -82,3 +84,47 @@ def test_does_not_serve_the_rest_of_the_repository():
 
     assert not served
     assert status == 404
+
+
+def test_port_defaults_to_the_one_the_dockerfile_sets(monkeypatch):
+    monkeypatch.delenv("FISHE_WEB_PORT", raising=False)
+
+    assert _resolvePort() == 8080
+
+
+def test_port_is_read_from_the_environment(monkeypatch):
+    monkeypatch.setenv("FISHE_WEB_PORT", "9001")
+
+    assert _resolvePort() == 9001
+
+
+def test_misspelled_port_names_the_variable(monkeypatch):
+    # This entry point is the one the Dockerfile runs, so its port is the one
+    # most likely to arrive from outside - and a bare int() conversion error
+    # names neither the variable nor what it should hold.
+    monkeypatch.setenv("FISHE_WEB_PORT", "80801x")
+
+    with pytest.raises(ValueError, match="FISHE_WEB_PORT"):
+        _resolvePort()
+
+    with pytest.raises(ValueError, match="80801x"):
+        _resolvePort()
+
+
+def test_taken_port_is_explained_rather_than_traced():
+    # "It is already running in another terminal" is the ordinary failure, and
+    # allow_reuse_address does not cover it: that only reopens a socket left in
+    # TIME_WAIT, while a live listener still refuses the bind.
+    server, _ = startServer()
+    host, port = server.server_address[0], server.server_address[1]
+    try:
+        with pytest.raises(OSError) as raised:
+            _bindServer(host, port)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    message = str(raised.value)
+    assert "FISHE_WEB_PORT" in message
+    assert "already listening" in message
+    assert str(port) in message

--- a/tests/web/test_serve.py
+++ b/tests/web/test_serve.py
@@ -111,6 +111,17 @@ def test_misspelled_port_names_the_variable(monkeypatch):
         _resolvePort()
 
 
+def test_free_port_is_bound_and_handed_back():
+    server = _bindServer("127.0.0.1", 0)
+    try:
+        boundHost, boundPort = server.server_address[0], server.server_address[1]
+    finally:
+        server.server_close()
+
+    assert boundHost == "127.0.0.1"
+    assert boundPort != 0
+
+
 def test_taken_port_is_explained_rather_than_traced():
     # "It is already running in another terminal" is the ordinary failure, and
     # allow_reuse_address does not cover it: that only reopens a socket left in

--- a/web/serve.py
+++ b/web/serve.py
@@ -21,6 +21,7 @@ missing, which is the usual symptom of a proxy in front of this server dropping
 them.
 """
 
+import errno
 import http.server
 import os
 from urllib.parse import unquote, urlparse
@@ -29,6 +30,14 @@ REPOSITORY_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..")
 WEB_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 INDEX_PATHS = ("/", "/play", "/play/", "/index.html")
+
+# FISHE_WEB_PORT is read here and by UserInterfaceFactory's WEB branch, with a
+# different default in each: 8080 for this server (what the Dockerfile sets),
+# 8000 for the server-backed front-end behind examples/web_app.py. They are
+# separate programs that can be run at the same time, so the defaults are
+# deliberately not shared - the check on the value is, so a misspelled port
+# names itself whichever one the player started.
+DEFAULT_PORT = "8080"
 
 
 class _Handler(http.server.SimpleHTTPRequestHandler):
@@ -82,12 +91,46 @@ class _Server(http.server.ThreadingHTTPServer):
     daemon_threads = True
 
 
+def _resolvePort():
+    """The port to serve on, or a ValueError naming the variable that is wrong."""
+    portText = os.environ.get("FISHE_WEB_PORT", DEFAULT_PORT)
+    try:
+        return int(portText)
+    except ValueError:
+        raise ValueError(f"FISHE_WEB_PORT must be an integer, got: {portText!r}")
+
+
+def _bindServer(host, port):
+    """Bind the server, turning a refused address into a sentence.
+
+    A port that is already listening - a second copy of the game, most often -
+    otherwise surfaces as an errno raised from inside http.server, naming
+    neither FishE nor the variable the player would have to change."""
+    try:
+        return _Server((host, port), _Handler)
+    except OSError as e:
+        if e.errno == errno.EADDRINUSE:
+            reason = "something else is already listening there"
+        elif e.errno == errno.EACCES:
+            reason = "this process is not allowed to use that port"
+        else:
+            reason = str(e)
+        raise OSError(
+            f"FishE could not be served at http://{host}:{port}/: {reason}. "
+            f"Set FISHE_WEB_PORT to a free port (or FISHE_WEB_HOST to an "
+            f"address this machine can bind) and start it again."
+        ) from e
+
+
 def main():
     host = os.environ.get("FISHE_WEB_HOST", "127.0.0.1")
-    port = int(os.environ.get("FISHE_WEB_PORT", "8080"))
+    port = _resolvePort()
+    # Bound before the URL is announced, so a failure is never preceded by an
+    # address that was never served.
+    server = _bindServer(host, port)
     print(f"FishE is being served at http://{host}:{port}/")
     print("Open that URL to play. Press Ctrl+C here to stop.")
-    _Server((host, port), _Handler).serve_forever()
+    server.serve_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `web/serve.py` — the entry point the `Dockerfile` runs, and therefore the one most likely to be handed a value from outside — converted `FISHE_WEB_PORT` with a bare `int()`. A typo was reported as `ValueError: invalid literal for int() with base 10: '80801x'`, which names neither the variable nor what it should hold. The integer check `UserInterfaceFactory`'s WEB branch already had has been given to it as well.
- Neither web entry point handled a port that is simply taken. Both bound inside a constructor with nothing around it, so a second copy of the game — or anything else already on 8000/8080 — was surfaced as `OSError: [Errno 98] Address already in use` traced through `http.server`. `allow_reuse_address` does not cover this; only a socket left in `TIME_WAIT` is reopened by it, while a live listener still refuses the bind. A refused bind is now turned into a sentence naming the address, the reason (already listening / not permitted), and `FISHE_WEB_PORT`.
- Both failures happen before the front-end exists, so no `showDialogue` is available to say them through — they are raised, the way the factory already does.
- `web/serve.py` now binds before the URL is announced, so a failure is no longer preceded by an address that was never served.
- The two defaults are kept apart (8080 for the static server, 8000 for the server-backed front-end behind `examples/web_app.py`), since those are separate programs that can be run at the same time; a comment now records why. Only the check on the value is shared in spirit.
- `README.md` now mentions `FISHE_WEB_PORT`/`FISHE_WEB_HOST`, which the new messages instruct the player to set.

## Front-ends touched

Only the two web entry points bind a socket, so this failure path has no console, pygame, or Pyodide equivalent: the console and pygame front-ends open no server, and the Pyodide front-end runs inside the browser tab. No `BaseUserInterface` primitive was changed, so front-end parity is unaffected.

## Test plan

- [x] `python3 -m compileall -q src tests web`
- [x] `python3 -m pytest` — 820 passed, including four new tests in `tests/web/test_serve.py` (default port, port from the environment, a misspelled port naming the variable, a taken port explained rather than traced) and one in `tests/ui/test_webUserInterface.py` (a taken port explained rather than traced)
- [x] `black` run over the changed files
- [x] No `Player`/`Stats`/`TimeService` field changed, so `schemas/*.json` and the `*JsonReaderWriter` classes are untouched

Closes #176

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).