### PR TITLE
Announce the web app's URL only once its server is bound

### DIFF
--- a/examples/web_app.py
+++ b/examples/web_app.py
@@ -14,10 +14,11 @@ Run it and open the printed URL:
     python3 examples/web_app.py
 
 The whole game (save-file manager, fishing, shop, bank, tavern, dialogue) then
-plays in the browser. The server binds 127.0.0.1:8000 by default; set
-FISHE_WEB_HOST/FISHE_WEB_PORT (read by UserInterfaceFactory's WEB branch) to
-change that — e.g. FISHE_WEB_HOST=0.0.0.0 so it's reachable from outside its
-own host, such as from inside a container.
+plays in the browser. The server binds 127.0.0.1:8000 by default (the default
+and the two variables that move it live in WebUserInterface); set
+FISHE_WEB_HOST/FISHE_WEB_PORT to change that — e.g. FISHE_WEB_HOST=0.0.0.0 so
+it's reachable from outside its own host, such as from inside a container. The
+URL is printed once the server is bound, so what it names is always served.
 """
 
 import os
@@ -31,12 +32,12 @@ from fishE import FishE  # noqa: E402
 
 
 def main():
-    host = os.environ.get("FISHE_WEB_HOST", "127.0.0.1")
-    port = os.environ.get("FISHE_WEB_PORT", "8000")
-    print(f"FishE web app is starting at http://{host}:{port}")
-    print("Open that URL in your browser to play. Press Ctrl+C here to stop.")
     # Building FishE starts the web server and then waits (in the save-file
     # manager) for the browser to interact, so play happens entirely in-browser.
+    # The URL is announced by the front-end once that server is bound, rather
+    # than from here beforehand: control never comes back to this function to
+    # say what was bound, and a port that is misspelled or already taken would
+    # otherwise be preceded by an address that will never answer.
     game = FishE(interfaceType=UIType.WEB)
     game.play()
 

--- a/src/ui/userInterfaceFactory.py
+++ b/src/ui/userInterfaceFactory.py
@@ -1,5 +1,3 @@
-import os
-
 from ui.enum.uiType import UIType
 from ui.consoleUserInterface import ConsoleUserInterface
 from prompt.prompt import Prompt
@@ -33,21 +31,16 @@ class UserInterfaceFactory:
             return PygameUserInterface(currentPrompt, timeService, player)
         elif ui_type == UIType.WEB:
             # Imported lazily so other modes don't start the HTTP machinery.
-            from ui.webUserInterface import WebUserInterface
+            from ui.webUserInterface import (
+                WebUserInterface,
+                resolveAddressFromEnvironment,
+            )
 
-            # WebUserInterface itself defaults to 127.0.0.1:8000 (unreachable
-            # from outside its own host/container). Let FISHE_WEB_HOST/
-            # FISHE_WEB_PORT override that — e.g. FISHE_WEB_HOST=0.0.0.0 so a
-            # container's port mapping/reverse proxy can actually reach it —
-            # while leaving the default unchanged for anyone not setting them.
-            host = os.environ.get("FISHE_WEB_HOST", "127.0.0.1")
-            port_str = os.environ.get("FISHE_WEB_PORT", "8000")
-            try:
-                port = int(port_str)
-            except ValueError:
-                raise ValueError(
-                    f"FISHE_WEB_PORT must be an integer, got: {port_str!r}"
-                )
+            # The default (127.0.0.1:8000, unreachable from outside its own
+            # host/container) and the FISHE_WEB_HOST/FISHE_WEB_PORT overrides
+            # that move it both live beside the server, so this branch does not
+            # keep a second copy of either.
+            host, port = resolveAddressFromEnvironment()
             return WebUserInterface(
                 currentPrompt, timeService, player, host=host, port=port
             )

--- a/src/ui/webUserInterface.py
+++ b/src/ui/webUserInterface.py
@@ -145,6 +145,32 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+# The address this front-end serves on when nothing says otherwise. Stated
+# here, beside the server that binds it, so the factory branch that reads the
+# environment and the constructor below share one copy of the default rather
+# than each carrying their own - a copy elsewhere would keep announcing the old
+# value if this one ever moved, with nothing failing to say so. (web/serve.py
+# deliberately keeps a different default of its own; see the comment there.)
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
+
+def resolveAddressFromEnvironment():
+    """The (host, port) to serve on, or a ValueError naming the variable that is
+    wrong.
+
+    FISHE_WEB_HOST/FISHE_WEB_PORT are how a player moves the game off the
+    default loopback address - e.g. FISHE_WEB_HOST=0.0.0.0 so a container's
+    port mapping or reverse proxy can reach it."""
+    host = os.environ.get("FISHE_WEB_HOST", DEFAULT_HOST)
+    portText = os.environ.get("FISHE_WEB_PORT", str(DEFAULT_PORT))
+    try:
+        port = int(portText)
+    except ValueError:
+        raise ValueError(f"FISHE_WEB_PORT must be an integer, got: {portText!r}")
+    return host, port
+
+
 def _bindServer(host, port, handler):
     """Start the game's HTTP server, turning a refused address into a sentence.
 
@@ -227,8 +253,8 @@ class WebUserInterface(BaseUserInterface):
         currentPrompt: Prompt,
         timeService: TimeService,
         player: Player,
-        host="127.0.0.1",
-        port=8000,
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
         start_server=True,
         endedScreenTimeoutSeconds=ENDED_SCREEN_DELIVERY_TIMEOUT_SECONDS,
     ):
@@ -247,11 +273,26 @@ class WebUserInterface(BaseUserInterface):
             self._server = _bindServer(host, port, _makeRequestHandler(self))
             self._server.daemon_threads = True
             threading.Thread(target=self._server.serve_forever, daemon=True).start()
+            self._announceAddress()
 
     @property
     def address(self):
         """The (host, port) the server is bound to, or None if not started."""
         return self._server.server_address if self._server else None
+
+    def _announceAddress(self):
+        """Say where the game can be played, once it is actually being served.
+
+        Said from here rather than from the entry point that started the game
+        (examples/web_app.py) because building FishE starts this server and
+        then blocks in the save-file manager, so nothing gets control back
+        there to announce a bound address - and announcing one beforehand names
+        an address that a misspelled or already-taken port means will never
+        answer. The address named is the socket's own, so a caller that asked
+        for port 0 is told the port it actually got."""
+        boundHost, boundPort = self._server.server_address[:2]
+        print(f"FishE is being served at http://{boundHost}:{boundPort}/")
+        print("Open that URL in your browser to play. Press Ctrl+C here to stop.")
 
     # --- web rendezvous ---------------------------------------------------
     def get_state(self):

--- a/tests/examples/test_web_app.py
+++ b/tests/examples/test_web_app.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, patch
+
+from examples import web_app
+
+
+def test_entry_point_builds_the_web_front_end():
+    # check - the example's whole job is to run the ordinary game behind the
+    # server-backed front-end, then hand control to it
+    game = MagicMock()
+    with patch.object(web_app, "FishE", return_value=game) as fishE:
+        web_app.main()
+
+    assert fishE.call_args.kwargs["interfaceType"] == web_app.UIType.WEB
+    game.play.assert_called_once_with()
+
+
+def test_entry_point_announces_no_address_of_its_own(capsys):
+    # check - the URL is said by the front-end once its server is bound, so a
+    # port that is misspelled or already taken is never preceded here by an
+    # address that will never answer
+    with patch.object(web_app, "FishE", return_value=MagicMock()):
+        web_app.main()
+
+    assert capsys.readouterr().out == ""

--- a/tests/ui/test_webUserInterface.py
+++ b/tests/ui/test_webUserInterface.py
@@ -412,3 +412,76 @@ def test_taken_port_is_explained_rather_than_traced():
     assert "FISHE_WEB_PORT" in message
     assert "already listening" in message
     assert str(port) in message
+
+
+def test_bound_address_is_announced_once_the_server_is_listening(capsys):
+    # The entry point cannot say this: building FishE starts the server and
+    # then blocks in the save-file manager, so the announcement has to come
+    # from here - and it has to name the port the socket actually got, which
+    # a caller that asked for an ephemeral one could not have known.
+    ui = makeWebUI(start_server=True)
+    try:
+        boundPort = ui.address[1]
+    finally:
+        ui.cleanup()
+
+    printed = capsys.readouterr().out
+    assert f"http://127.0.0.1:{boundPort}/" in printed
+    assert "Open that URL in your browser to play" in printed
+
+
+def test_nothing_is_announced_when_no_server_was_started(capsys):
+    # check - the Pyodide front-end subclasses this one with start_server=False
+    # and has no address to announce; a URL there would name nothing at all
+    makeWebUI(start_server=False)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_nothing_is_announced_when_the_port_is_already_taken(capsys):
+    # check - a bind that fails is not preceded by an address that will never
+    # answer, which is what announcing before binding used to produce
+    running = makeWebUI(start_server=True)
+    port = running.address[1]
+    capsys.readouterr()  # discard the running server's own announcement
+    try:
+        with pytest.raises(OSError):
+            makeWebUI(start_server=True, port=port)
+    finally:
+        running.cleanup()
+
+    assert "http://" not in capsys.readouterr().out
+
+
+def test_address_defaults_to_loopback_and_the_documented_port(monkeypatch):
+    # check - with neither variable set, the resolver hands back the one
+    # default that the constructor and the factory branch both use
+    monkeypatch.delenv("FISHE_WEB_HOST", raising=False)
+    monkeypatch.delenv("FISHE_WEB_PORT", raising=False)
+
+    assert webUserInterface.resolveAddressFromEnvironment() == (
+        webUserInterface.DEFAULT_HOST,
+        webUserInterface.DEFAULT_PORT,
+    )
+    assert (webUserInterface.DEFAULT_HOST, webUserInterface.DEFAULT_PORT) == (
+        "127.0.0.1",
+        8000,
+    )
+
+
+def test_address_is_taken_from_the_environment_when_set(monkeypatch):
+    # check - FISHE_WEB_HOST=0.0.0.0 is how the game is reached from outside
+    # its own container, and the port arrives as an int ready to bind
+    monkeypatch.setenv("FISHE_WEB_HOST", "0.0.0.0")
+    monkeypatch.setenv("FISHE_WEB_PORT", "9123")
+
+    assert webUserInterface.resolveAddressFromEnvironment() == ("0.0.0.0", 9123)
+
+
+def test_misspelled_port_names_the_variable_it_came_from(monkeypatch):
+    # check - the value is converted before anything is printed or bound, and
+    # the complaint names what the player would have to change
+    monkeypatch.setenv("FISHE_WEB_PORT", "80801x")
+
+    with pytest.raises(ValueError, match="FISHE_WEB_PORT"):
+        webUserInterface.resolveAddressFromEnvironment()


### PR DESCRIPTION
## Summary

- `examples/web_app.py` printed `http://{host}:{port}` before anything was listening on it, from its own copy of `FISHE_WEB_HOST`/`FISHE_WEB_PORT`. Both ordinary startup failures — a misspelled port and a busy one — were therefore preceded by a confident sentence naming an address that would never answer, since neither the conversion (`UserInterfaceFactory`'s WEB branch) nor the bind (`WebUserInterface._bindServer`) happens until after that print. `web/serve.py` was given the opposite ordering in #177, so the two web entry points disagreed about it.
- The ordering could not simply be swapped in the example: `FishE.__init__` builds the front-end and then blocks in `_selectSaveFile()`, so control never returns to `main()` to say what was bound. The announcement is instead made by `WebUserInterface` immediately after `_bindServer` returns, and names the socket's own address — so a caller that asked for an ephemeral port is told the port it actually got. The entry point now announces nothing of its own, and a failed bind is no longer preceded by a URL.
- The `"8000"` default and the two variables that move it are now stated once, in `webUserInterface` (`DEFAULT_HOST`/`DEFAULT_PORT` and `resolveAddressFromEnvironment()`), and shared by the factory branch and the constructor; the example no longer reads the environment at all. `web/serve.py` keeps its own `8080` default deliberately, as the comment there already explains.
- No behaviour was changed for the Pyodide front-end: it subclasses `WebUserInterface` with `start_server=False`, so it has no address and announces nothing.

## Test plan

- [x] `python3 -m pytest` (with `SDL_VIDEODRIVER`/`SDL_AUDIODRIVER=dummy`) — 829 passed
- [x] New: the bound address is announced with the port the socket actually got
- [x] New: nothing is announced when no server was started, or when the port was already taken
- [x] New: `resolveAddressFromEnvironment()` covers the default, the override, and the misspelled-port `ValueError`
- [x] New `tests/examples/test_web_app.py`: the entry point builds the WEB front-end and prints no address of its own
- [x] `black --check` on the changed files

## Deferred this cycle

No other issue was open at triage time, so nothing was deferred.

Closes #178

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_